### PR TITLE
docs: sync version to 3.5.0 and fix broken links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v3.0.0)
+- **Status:** Production ready (v3.5.0)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -347,7 +347,7 @@ export FLOW_DEBUG=1
 
 ### 🎯 Production Ready
 
-- **Version:** 2.0+
+- **Version:** 3.5.0
 - **Status:** Production use phase
 - **Performance:** Sub-10ms for core commands
 - **Documentation:** https://Data-Wise.github.io/flow-cli/

--- a/docs/contributing/DOCUMENTATION-STYLE-GUIDE.md
+++ b/docs/contributing/DOCUMENTATION-STYLE-GUIDE.md
@@ -545,7 +545,7 @@ graph LR
 
 ```markdown
 !!! warning "Deprecated"
-This feature was removed in v2.0.0. Use [new feature](link) instead.
+This feature was removed in v2.0.0. Use [new feature](#) instead.
 ```
 
 ---
@@ -669,8 +669,8 @@ This feature was removed in v2.0.0. Use [new feature](link) instead.
 
 **See also:**
 
-- [Related doc 1](link)
-- [Related doc 2](link)
+- [Related doc 1](#)
+- [Related doc 2](#)
 
 ````
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "2.0.0-beta.1",
+  "version": "3.5.0",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

- Synced package.json version from 2.0.0-beta.1 to 3.5.0
- Updated CLAUDE.md version references to 3.5.0
- Fixed placeholder `(link)` references in DOCUMENTATION-STYLE-GUIDE.md

## Changes

- `package.json` - version bump to 3.5.0
- `CLAUDE.md` - version reference updates
- `docs/contributing/DOCUMENTATION-STYLE-GUIDE.md` - fixed broken links

## Test plan

- [x] `mkdocs build --strict` passes
- [x] Documentation deployed successfully to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)