### PR TITLE
chore: bump version to 3.6.0

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -4,11 +4,11 @@
 ## Project: flow-cli
 ## Type: zsh-plugin
 ## Status: active
-## Phase: v3.5.0 Complete → v4.0.0 Planning
+## Phase: v3.6.0 Released → v4.0.0 Planning
 ## Priority: 1
 ## Progress: 100
 
-## Focus: v3.5.0 COMPLETE - Dopamine features, goal tracking, extended .STATUS
+## Focus: v3.6.0 RELEASED - CC dispatcher with current-dir default
 
 ## Quick Context
 Pure ZSH workflow plugin with optional atlas integration for state management.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v3.5.0)
+- **Status:** Production ready (v3.6.0)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -387,8 +387,8 @@ export FLOW_DEBUG=1
 
 ### 🎯 Production Ready
 
-- **Version:** 3.5.0
-- **Released:** 2025-12-26
+- **Version:** 3.6.0
+- **Released:** 2025-12-27
 - **Status:** Production use phase
 - **Performance:** Sub-10ms for core commands
 - **Documentation:** https://Data-Wise.github.io/flow-cli/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-3.5.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases/tag/v3.5.0)
+[![Version](https://img.shields.io/badge/version-3.6.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases/tag/v3.6.0)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -120,7 +120,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="3.5.0"
+export FLOW_VERSION="3.6.0"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Version 3.6.0

### Features
- CC dispatcher for Claude Code workflows
- Default launches Claude in current directory
- `cc pick` subcommand for project selection
- Consistent pattern across all modes

### Files Updated
- package.json
- flow.plugin.zsh
- CLAUDE.md
- README.md
- .STATUS

🤖 Generated with [Claude Code](https://claude.com/claude-code)