### PR TITLE
fix(cc): pass project args to pick instead of claude

### DIFF
--- a/lib/dispatchers/cc-dispatcher.zsh
+++ b/lib/dispatchers/cc-dispatcher.zsh
@@ -41,7 +41,8 @@ cc() {
         pick)
             shift
             if (( $+functions[pick] )); then
-                pick && claude --permission-mode acceptEdits "$@"
+                # Pass remaining args to pick (for filtering), not claude
+                pick "$@" && claude --permission-mode acceptEdits
             else
                 echo "❌ pick function not available" >&2
                 return 1
@@ -55,7 +56,8 @@ cc() {
             if [[ "$1" == "pick" ]]; then
                 shift
                 if (( $+functions[pick] )); then
-                    pick && claude --dangerously-skip-permissions "$@"
+                    # Pass remaining args to pick (for filtering), not claude
+                    pick "$@" && claude --dangerously-skip-permissions
                 else
                     echo "❌ pick function not available" >&2
                     return 1
@@ -81,7 +83,8 @@ cc() {
             if [[ "$1" == "pick" ]]; then
                 shift
                 if (( $+functions[pick] )); then
-                    pick && claude --permission-mode plan "$@"
+                    # Pass remaining args to pick (for filtering), not claude
+                    pick "$@" && claude --permission-mode plan
                 else
                     echo "❌ pick function not available" >&2
                     return 1
@@ -182,7 +185,8 @@ cc() {
             if [[ "$1" == "pick" ]]; then
                 shift
                 if (( $+functions[pick] )); then
-                    pick && claude --model opus --permission-mode acceptEdits "$@"
+                    # Pass remaining args to pick (for filtering), not claude
+                    pick "$@" && claude --model opus --permission-mode acceptEdits
                 else
                     echo "❌ pick function not available" >&2
                     return 1
@@ -208,7 +212,8 @@ cc() {
             if [[ "$1" == "pick" ]]; then
                 shift
                 if (( $+functions[pick] )); then
-                    pick && claude --model haiku --permission-mode acceptEdits "$@"
+                    # Pass remaining args to pick (for filtering), not claude
+                    pick "$@" && claude --model haiku --permission-mode acceptEdits
                 else
                     echo "❌ pick function not available" >&2
                     return 1


### PR DESCRIPTION
## Summary
- Fixed bug where `cc <mode> pick <project>` variants showed interactive picker instead of direct jumping
- The issue was that remaining args after `shift` were passed to `claude` instead of `pick`
- All 5 pick variants now correctly pass project names to pick: pick, yolo pick, plan pick, opus pick, haiku pick

## Test plan
- [x] All 24 cc dispatcher tests pass
- [x] Manual testing with mock claude confirms all variants work
- [x] `cc pick flow-cli` → direct jump ✓
- [x] `cc yolo pick flow-cli` → direct jump ✓
- [x] `cc plan pick flow-cli` → direct jump ✓  
- [x] `cc opus pick flow-cli` → direct jump ✓
- [x] `cc haiku pick flow-cli` → direct jump ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)