### PR TITLE
fix(readme): use static badge for private repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/github/v/tag/Data-Wise/flow-cli?label=version&color=blue)](https://github.com/Data-Wise/flow-cli/releases/latest)
+[![Version](https://img.shields.io/badge/version-3.6.2-blue.svg)](https://github.com/Data-Wise/flow-cli/releases/tag/v3.6.2)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 


### PR DESCRIPTION
Dynamic GitHub badges require public repos. This reverts to static badge showing v3.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)