### PR TITLE
feat(scripts): add release.sh for automated version bumping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,6 +448,30 @@ mkdocs gh-deploy --force
 open https://Data-Wise.github.io/flow-cli/
 ```
 
+### Create Release
+
+```bash
+# Use the release script to bump all version files
+./scripts/release.sh 3.7.0
+
+# Review changes
+git diff
+
+# Commit and tag
+git add -A && git commit -m "chore: bump version to 3.7.0"
+git tag -a v3.7.0 -m "v3.7.0"
+
+# Push (requires PR for protected branch)
+git push origin main && git push origin v3.7.0
+```
+
+**Files updated by release script:**
+
+- `package.json` - version field
+- `README.md` - badge version
+- `CLAUDE.md` - version references
+- `docs/reference/CC-DISPATCHER-REFERENCE.md` - version
+
 ---
 
 ## Support

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# release.sh - Automate version bumping and release
+# Usage: ./scripts/release.sh <version>
+# Example: ./scripts/release.sh 3.6.3
+
+set -e
+
+VERSION="$1"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: ./scripts/release.sh <version>"
+    echo "Example: ./scripts/release.sh 3.6.3"
+    exit 1
+fi
+
+# Validate version format
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must be in format X.Y.Z (e.g., 3.6.3)"
+    exit 1
+fi
+
+echo "🚀 Releasing v$VERSION"
+echo ""
+
+# 1. Update package.json
+echo "📦 Updating package.json..."
+sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" package.json
+
+# 2. Update README badge
+echo "🏷️  Updating README badge..."
+sed -i '' "s/version-[0-9]*\.[0-9]*\.[0-9]*/version-$VERSION/" README.md
+sed -i '' "s/releases\/tag\/v[0-9]*\.[0-9]*\.[0-9]*/releases\/tag\/v$VERSION/" README.md
+
+# 3. Update CLAUDE.md
+echo "📝 Updating CLAUDE.md..."
+sed -i '' "s/v[0-9]*\.[0-9]*\.[0-9]*/v$VERSION/g" CLAUDE.md
+
+# 4. Update CC-DISPATCHER-REFERENCE.md
+echo "📖 Updating CC-DISPATCHER-REFERENCE.md..."
+sed -i '' "s/Version: v[0-9]*\.[0-9]*\.[0-9]*/Version: v$VERSION/" docs/reference/CC-DISPATCHER-REFERENCE.md
+
+# Show changes
+echo ""
+echo "📋 Changes made:"
+git diff --stat
+
+echo ""
+echo "✅ Version files updated to v$VERSION"
+echo ""
+echo "Next steps:"
+echo "  1. Review changes: git diff"
+echo "  2. Commit: git add -A && git commit -m 'chore: bump version to $VERSION'"
+echo "  3. Tag: git tag -a v$VERSION -m 'v$VERSION'"
+echo "  4. Push: git push origin main && git push origin v$VERSION"


### PR DESCRIPTION
## Summary
- Add `scripts/release.sh` for automated version bumping
- Updates all version files: package.json, README badge, CLAUDE.md, docs
- Add release instructions to CLAUDE.md

## Usage
```bash
./scripts/release.sh 3.7.0
```

## Test plan
- [x] Script syntax validated
- [x] Help message works
- [x] Documentation added

🤖 Generated with [Claude Code](https://claude.com/claude-code)