### PR TITLE
fix: use pure ZSH in win command and status functions

### DIFF
--- a/commands/capture.zsh
+++ b/commands/capture.zsh
@@ -189,13 +189,11 @@ win() {
 
   local cat_icon="${FLOW_WIN_CATEGORIES[$category]:-✨}"
 
-  # Log the win with category
-  if _flow_has_atlas; then
-    _flow_atlas catch "$text" --type=win --category="$category" ${project:+--project="$project"}
-  else
-    local wins="${FLOW_DATA_DIR}/wins.md"
-    echo "- $cat_icon $text${project:+ (@$project)} #$category [$(date '+%Y-%m-%d %H:%M')]" >> "$wins"
-  fi
+  # Log the win to local file (atlas doesn't support win type yet)
+  local wins="${FLOW_DATA_DIR}/wins.md"
+  zmodload -F zsh/datetime b:strftime
+  local timestamp=$(strftime "%Y-%m-%d %H:%M" $EPOCHSECONDS)
+  echo "- $cat_icon $text${project:+ (@$project)} #$category [$timestamp]" >> "$wins"
 
   # Also update project .STATUS if in a project (v3.5.0)
   if _flow_in_project; then

--- a/commands/status.zsh
+++ b/commands/status.zsh
@@ -365,39 +365,56 @@ setprogress() {
 # EXTENDED .STATUS FIELDS (v3.5.0)
 # ============================================================================
 
-# Read a field from .STATUS file
+# Read a field from .STATUS file (pure ZSH - no external commands)
 _flow_status_get_field() {
   local status_file="$1"
   local field="$2"
+  local value="" line
 
   [[ ! -f "$status_file" ]] && return 1
 
-  # Match ## Field: value format
-  grep -i "^## ${field}:" "$status_file" 2>/dev/null | head -1 | sed 's/^## [^:]*: *//'
+  # Read file and find matching line (case-insensitive)
+  while IFS= read -r line; do
+    # Match ## Field: value format
+    if [[ "${line:l}" == "## ${field:l}:"* ]]; then
+      value="${line#*: }"  # Remove everything up to ": "
+      value="${value#"${value%%[![:space:]]*}"}"  # Trim leading whitespace
+      echo "$value"
+      return 0
+    fi
+  done < "$status_file"
+
+  return 1
 }
 
-# Set a field in .STATUS file (create if missing)
+# Set a field in .STATUS file (pure ZSH - no external commands)
 _flow_status_set_field() {
   local status_file="$1"
   local field="$2"
   local value="$3"
+  local found=0
+  local -a new_lines=()
+  local line
 
   [[ ! -f "$status_file" ]] && return 1
 
-  # Check if field exists
-  if grep -qi "^## ${field}:" "$status_file" 2>/dev/null; then
-    # Update existing field
-    sed -i '' "s/^## ${field}:.*$/## ${field}: ${value}/i" "$status_file"
-  else
-    # Add new field after Progress line (or at end if not found)
-    if grep -q "^## Progress:" "$status_file"; then
-      sed -i '' "/^## Progress:.*/a\\
-## ${field}: ${value}
-" "$status_file"
+  # Read all lines and update matching field
+  while IFS= read -r line; do
+    if [[ "${line:l}" == "## ${field:l}:"* ]]; then
+      new_lines+=("## ${field}: ${value}")
+      found=1
     else
-      echo "## ${field}: ${value}" >> "$status_file"
+      new_lines+=("$line")
     fi
+  done < "$status_file"
+
+  # If field not found, append it
+  if (( ! found )); then
+    new_lines+=("## ${field}: ${value}")
   fi
+
+  # Write back to file
+  printf '%s\n' "${new_lines[@]}" > "$status_file"
 }
 
 # Update last_active timestamp


### PR DESCRIPTION
## Summary
Bug fixes for dash not capturing today's progress:

- `win` command now writes to local file (atlas doesn't support `--type=win`)
- `_flow_status_get_field` uses ZSH builtins instead of `grep/head/sed`
- `_flow_status_set_field` uses ZSH builtins instead of `grep/sed`

## Root Cause
- The `win` command was calling `atlas catch --type=win --category=X` but atlas only supports `--type=idea|task|bug|note`
- The `_flow_status_*` functions were using external commands that may not be in PATH

## Testing
```zsh
# Test win command works
source flow.plugin.zsh
win "Test win" -c fix

# Verify wins.md has entry with correct format
cat ~/.local/share/flow/wins.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)