### PR TITLE
chore: bump version to 3.6.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v3.6.2)
+- **Status:** Production ready (v3.6.3)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -38,7 +38,7 @@ flow doctor       # Health check (verify dependencies)
 flow doctor --fix # Interactive install missing tools
 ```
 
-### Dopamine Features (v3.5.0)
+### Dopamine Features (v3.6.3)
 
 ```bash
 win <text>        # Log accomplishment (auto-categorized)
@@ -366,7 +366,7 @@ export FLOW_DEBUG=1
 
 ## Current Status (2025-12-27)
 
-### ✅ v3.5.0 Released
+### ✅ v3.6.3 Released
 
 - [x] Dopamine features (win tracking, streaks, goals)
 - [x] Win categories with auto-detection
@@ -394,7 +394,7 @@ export FLOW_DEBUG=1
 - **Documentation:** https://Data-Wise.github.io/flow-cli/
 - **Tests:** Interactive dog feeding test (gamified)
 
-### 📋 Next: v4.0.0 Planning
+### 📋 Next: v3.6.3 Planning
 
 - [ ] Cross-tool orchestration (`flow sync all`)
 - [ ] Remote state sync (optional cloud backup)
@@ -459,10 +459,10 @@ git diff
 
 # Commit and tag
 git add -A && git commit -m "chore: bump version to 3.7.0"
-git tag -a v3.7.0 -m "v3.7.0"
+git tag -a v3.6.3 -m "v3.6.3"
 
 # Push (requires PR for protected branch)
-git push origin main && git push origin v3.7.0
+git push origin main && git push origin v3.6.3
 ```
 
 **Files updated by release script:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-3.6.2-blue.svg)](https://github.com/Data-Wise/flow-cli/releases/tag/v3.6.2)
+[![Version](https://img.shields.io/badge/version-3.6.3-blue.svg)](https://github.com/Data-Wise/flow-cli/releases/tag/v3.6.3)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Maintenance release v3.6.3 with code quality improvements.

## Changes in v3.6.3

- **Testing:** Added 12 unit tests for `_flow_status_get/set_field` functions
- **Refactoring:** Moved `zmodload zsh/datetime` to module initialization
- **Documentation:** Added TODO for future `atlas --type=win` support

## Files Updated

- `package.json` - Version bump
- `README.md` - Badge update
- `CLAUDE.md` - Version reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)