### PR TITLE
docs: fix orphan pages and broken links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -130,7 +130,7 @@ glo      # git log --oneline
 - **[Testing Guide](testing/TESTING.md)** - Validate your installation 🐕
 - **[Alias Reference Card](reference/ALIAS-REFERENCE-CARD.md)** - All 28 aliases + migration guide
 - **[Workflow Quick Reference](reference/WORKFLOW-QUICK-REFERENCE.md)** - Daily workflows
-- **[Reference Index](reference/INDEX.md)** - All reference docs
+- **[Command Quick Reference](reference/COMMAND-QUICK-REFERENCE.md)** - All commands at a glance
 
 ### Testing Your Installation
 
@@ -317,7 +317,7 @@ Before adding new aliases, ensure they meet ALL criteria:
 
 ## 📖 Additional Resources
 
-- **[Reference Index](reference/INDEX.md)** - All reference docs
+- **[Command Quick Reference](reference/COMMAND-QUICK-REFERENCE.md)** - All commands at a glance
 - **[ZSH Development Guidelines](ZSH-DEVELOPMENT-GUIDELINES.md)** - Coding standards
 - **[OMZ Git Plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git)** - Git aliases reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,16 @@ plugins:
         - guides/MONOREPO-COMMANDS-TUTORIAL.md
         - guides/PROJECT-SCOPE.md
         - reference/ALIAS-CONFLICT-REVIEW.md
+        - reference/DEVOPS-PHASE2.md
+        - reference/DEVOPS-SETUP.md
+        - reference/FILE-REORGANIZATION-VISUAL.md
+        - reference/INDEX.md
+        - reference/SYNC-SETUP.md
+        - architecture/API-DESIGN-QUICK-REFERENCE.md
+        - architecture/VENDOR-INTEGRATION-QUICK-REFERENCE.md
+        - architecture/integration/*
+        - guides/CLI-INSTALLATION.md
+        - guides/hop/*
         - proposals/*
         - LINK-CHECK-*.md
         - PLAN-*.md
@@ -110,7 +120,6 @@ nav:
       - Workflow Tutorial: guides/WORKFLOW-TUTORIAL.md
       - Enhanced Help Quick Start: guides/ENHANCED-HELP-QUICK-START.md
       - Migration v1 to v2: guides/MIGRATION-v1-to-v2.md
-      - HOP Setup: guides/hop/README.md
   - Reference:
       - Command Explorer: reference/COMMAND-EXPLORER.md
       - Dispatcher Reference: reference/DISPATCHER-REFERENCE.md


### PR DESCRIPTION
## Summary

Fixes documentation build warnings by excluding orphan pages and fixing broken links.

## Changes

- Added 11 orphan pages to `mkdocs.yml` exclude list
- Removed "HOP Setup" from nav (page is excluded)
- Fixed 2 broken `reference/INDEX.md` links in `docs/index.md`

## Build Result

```
INFO - Documentation built in 3.11 seconds
```

No errors, no warnings (strict mode passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)