### PR TITLE
chore: update .STATUS with v3.6.3 release session

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -4,11 +4,11 @@
 ## Project: flow-cli
 ## Type: zsh-plugin
 ## Status: active
-## Phase: v3.6.2 Released → v4.0.0 Planning
+## Phase: v3.6.3 Released → v4.0.0 Planning
 ## Priority: 1
 ## Progress: 100
 
-## Focus: v3.6.2 RELEASED - CC pick variants fix + release automation
+## Focus: v3.6.3 RELEASED - Unit tests, docs cleanup, maintenance
 
 ## Quick Context
 Pure ZSH workflow plugin with optional atlas integration for state management.
@@ -307,6 +307,9 @@ FLOW_QUIET=1               # Disable welcome message
   - [ ] Team dashboards
 
 ## Session Log
+- 2025-12-27: DOCS - Deployed v3.6.3 documentation to GitHub Pages
+- 2025-12-27: DOCS - Fixed 11 orphan pages, 2 broken links in mkdocs (PR #26)
+- 2025-12-27: v3.6.3 - Version bump, maintenance release (PR #25)
 - 2025-12-27: TEST - Added unit tests for _flow_status_get/set_field (12 tests) (PR #23)
 - 2025-12-27: REFACTOR - Moved zmodload to module initialization in capture.zsh (PR #23)
 - 2025-12-27: DOCS - Added TODO for atlas --type=win support (PR #23)
@@ -378,6 +381,6 @@ FLOW_QUIET=1               # Disable welcome message
 - 2025-12-25: Legacy 140KB functions archived
 - 2025-12-25: Symlink-only external integrations
 
-## wins: Code review improvements PR #23 (2025-12-27)
+## wins: v3.6.3 released + docs deployed (2025-12-27)
 ## streak: 2
-## last_active: 2025-12-27 13:45
+## last_active: 2025-12-27 14:15


### PR DESCRIPTION
## Summary

Updates .STATUS to reflect v3.6.3 release and docs deployment session.

## Changes

- Updated Phase: v3.6.3 Released → v4.0.0 Planning
- Updated Focus: v3.6.3 maintenance release
- Added session log entries:
  - v3.6.3 version bump (PR #25)
  - Fixed 11 orphan pages, 2 broken links (PR #26)
  - Deployed v3.6.3 docs to GitHub Pages
- Updated wins and last_active timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)