### PR TITLE
feat(sync): add shell completions and scheduled sync

### DIFF
--- a/completions/_flow
+++ b/completions/_flow
@@ -166,12 +166,59 @@ _flow() {
           _describe -t periods 'period' log_periods
           ;;
         sync)
-          local -a sync_opts
-          sync_opts=(
-            '--force:Force push'
-            '--dry-run:Show what would happen'
-          )
-          _describe -t options 'option' sync_opts
+          # Check if we're completing the first arg (target) or subsequent args (options)
+          if [[ ${#line[@]} -eq 2 ]]; then
+            local -a sync_targets
+            sync_targets=(
+              'all:Sync everything (session → status → wins → goals → git)'
+              'session:Persist current session to worklog'
+              'status:Update .STATUS timestamps and streaks'
+              'wins:Aggregate project wins to global wins.md'
+              'goals:Recalculate daily goal progress'
+              'git:Smart git push/pull with stash handling'
+              'schedule:Manage automated sync schedule'
+              'help:Show sync help'
+            )
+            local -a sync_opts
+            sync_opts=(
+              '--status:Show sync dashboard'
+              '--dry-run:Preview changes without executing'
+              '-n:Dry run (short)'
+              '--verbose:Show detailed output'
+              '-v:Verbose (short)'
+              '--quiet:Minimal output for scripts'
+              '-q:Quiet (short)'
+              '--skip-git:Skip git sync for quick local sync'
+              '--help:Show help'
+              '-h:Help (short)'
+            )
+            _describe -t targets 'sync target' sync_targets
+            _describe -t options 'option' sync_opts
+          elif [[ "${line[2]}" == "schedule" ]]; then
+            # Schedule subcommands
+            local -a schedule_cmds
+            schedule_cmds=(
+              'status:Show schedule status'
+              'enable:Enable scheduled sync (default: 30 min)'
+              'disable:Disable scheduled sync'
+              'logs:View sync schedule logs'
+              'help:Show schedule help'
+            )
+            _describe -t commands 'schedule command' schedule_cmds
+          else
+            # Completing options after target
+            local -a sync_opts
+            sync_opts=(
+              '--dry-run:Preview changes'
+              '-n:Dry run (short)'
+              '--verbose:Detailed output'
+              '-v:Verbose (short)'
+              '--quiet:Minimal output'
+              '-q:Quiet (short)'
+              '--skip-git:Skip git sync'
+            )
+            _describe -t options 'option' sync_opts
+          fi
           ;;
         help)
           # Complete command names for help

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -303,11 +303,28 @@ flow sync all --quiet || exit 1
 
 ---
 
+## Scheduled Sync
+
+Enable automatic background sync using macOS launchd:
+
+```bash
+flow sync schedule                 # Show status
+flow sync schedule enable          # Every 30 minutes
+flow sync schedule enable 15       # Every 15 minutes
+flow sync schedule disable         # Stop scheduled sync
+flow sync schedule logs            # View logs
+```
+
+**What runs:** session, status, wins, goals (git is skipped - requires user interaction)
+
+---
+
 ## Version History
 
-| Version | Changes                             |
-| ------- | ----------------------------------- |
-| v4.0.0  | Initial release with 5 sync targets |
+| Version | Changes                                        |
+| ------- | ---------------------------------------------- |
+| v4.0.0  | Initial release with 5 sync targets            |
+| v4.0.1  | Added `schedule` for automated background sync |
 
 ---
 


### PR DESCRIPTION
## Summary

Enhancements to the `flow sync` command:

### 1. Shell Completions
- All 6 sync targets with descriptions (all, session, status, wins, goals, git, schedule)
- All options (--dry-run, --verbose, --quiet, --skip-git, --status)
- Schedule subcommands (enable, disable, logs, status)

### 2. Scheduled Sync (`flow sync schedule`)
Enable automated background sync using macOS launchd:

```bash
flow sync schedule                 # Show status
flow sync schedule enable [min]    # Enable (default: 30 min)
flow sync schedule disable         # Disable
flow sync schedule logs            # View logs
```

**What runs:** session, status, wins, goals (git is skipped - requires user interaction)

### Files Changed
- `commands/sync.zsh` - Added schedule dispatcher and 5 schedule functions (~225 lines)
- `completions/_flow` - Enhanced sync completions with schedule subcommands
- `docs/commands/sync.md` - Added Scheduled Sync section

## Test Plan
- [x] `flow sync schedule help` displays help
- [x] `flow sync schedule status` shows "Not configured"
- [x] All 40 sync tests pass
- [x] Tab completions work for sync targets and schedule subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)