### PR TITLE
style: switch to adhd-calm theme preset

### DIFF
--- a/docs/stylesheets/adhd-colors.css
+++ b/docs/stylesheets/adhd-colors.css
@@ -1,10 +1,12 @@
 /*
- * ADHD-Optimized Color Palette for MkDocs Material Theme
+ * ADHD-Calm Color Palette for MkDocs Material Theme
  *
- * Based on research showing cyan/purple provides maximum dopamine response
- * while maintaining professional credibility and accessibility compliance.
+ * Warm earth tones designed to reduce anxiety and create a cozy reading
+ * experience. Browns and oranges provide grounding comfort while
+ * maintaining focus without overstimulation.
  *
- * Date: 2025-12-20
+ * Date: 2025-12-27
+ * Preset: adhd-calm
  * WCAG AAA compliant for normal text
  */
 
@@ -13,37 +15,37 @@
    ============================================ */
 
 :root {
-  /* Primary - Cyan (dopamine-friendly, energizing + calming) */
-  --md-primary-fg-color: #00bcd4;
-  --md-primary-fg-color--light: #62efff;
-  --md-primary-fg-color--dark: #008ba3;
+  /* Primary - Warm Brown (grounding, cozy, reduces anxiety) */
+  --md-primary-fg-color: #795548;
+  --md-primary-fg-color--light: #a98274;
+  --md-primary-fg-color--dark: #5d4037;
 
-  /* Accent - Purple (creative focus, high novelty) */
-  --md-accent-fg-color: #9c27b0;
-  --md-accent-fg-color--light: #d05ce3;
-  --md-accent-fg-color--dark: #6a0080;
+  /* Accent - Deep Orange (warm energy without overstimulation) */
+  --md-accent-fg-color: #ff5722;
+  --md-accent-fg-color--light: #ff8a50;
+  --md-accent-fg-color--dark: #c41c00;
 
-  /* Semantic ADHD colors */
-  --adhd-success: #00e676;        /* Bright green - dopamine reward */
-  --adhd-warning: #ffc107;        /* Amber - attention grabber */
-  --adhd-danger: #f44336;         /* Red - stop signal */
-  --adhd-info: #00bcd4;           /* Cyan - same as primary */
-  --adhd-example: #9c27b0;        /* Purple - code/examples */
+  /* Semantic ADHD colors - warmer palette */
+  --adhd-success: #8bc34a;        /* Warm green - natural, calming */
+  --adhd-warning: #ffb300;        /* Warm amber - gentle attention */
+  --adhd-danger: #e64a19;         /* Deep orange-red - noticeable but not harsh */
+  --adhd-info: #795548;           /* Brown - same as primary */
+  --adhd-example: #ff5722;        /* Deep orange - code/examples */
 
   /* Gradient accents (for hover effects and visual interest) */
-  --adhd-gradient-primary: linear-gradient(135deg, #00bcd4, #9c27b0);
-  --adhd-gradient-success: linear-gradient(135deg, #00e676, #00c853);
-  --adhd-gradient-warning: linear-gradient(135deg, #ffc107, #ffa000);
-  --adhd-gradient-danger: linear-gradient(135deg, #f44336, #d32f2f);
+  --adhd-gradient-primary: linear-gradient(135deg, #795548, #ff5722);
+  --adhd-gradient-success: linear-gradient(135deg, #8bc34a, #689f38);
+  --adhd-gradient-warning: linear-gradient(135deg, #ffb300, #ff8f00);
+  --adhd-gradient-danger: linear-gradient(135deg, #e64a19, #bf360c);
 }
 
-/* Dark mode adjustments - lighter colors for better contrast */
+/* Dark mode adjustments - warmer, lighter colors for cozy dark reading */
 [data-md-color-scheme="slate"] {
-  --md-primary-fg-color: #4dd0e1;      /* Lighter cyan */
-  --md-accent-fg-color: #ba68c8;       /* Lighter purple */
-  --adhd-success: #69f0ae;             /* Lighter green */
+  --md-primary-fg-color: #a1887f;      /* Lighter warm brown */
+  --md-accent-fg-color: #ff8a65;       /* Lighter deep orange */
+  --adhd-success: #aed581;             /* Lighter warm green */
   --adhd-warning: #ffd54f;             /* Lighter amber */
-  --adhd-danger: #ff5252;              /* Lighter red */
+  --adhd-danger: #ff7043;              /* Lighter orange-red */
 }
 
 /* ============================================
@@ -127,29 +129,29 @@
    NAVIGATION ENHANCEMENTS
    ============================================ */
 
-/* High-energy hover effects with gradient */
+/* Warm hover effects with gradient */
 .md-nav__link:hover {
   background: linear-gradient(90deg,
-    rgba(0, 188, 212, 0.12) 0%,
-    rgba(156, 39, 176, 0.06) 100%);
+    rgba(121, 85, 72, 0.12) 0%,
+    rgba(255, 87, 34, 0.06) 100%);
   transform: translateX(4px);
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* Active navigation item with stronger accent */
+/* Active navigation item with cozy accent */
 .md-nav__link--active {
   background: linear-gradient(90deg,
-    rgba(0, 188, 212, 0.15) 0%,
-    rgba(156, 39, 176, 0.08) 100%);
+    rgba(121, 85, 72, 0.15) 0%,
+    rgba(255, 87, 34, 0.08) 100%);
   border-left: 3px solid var(--md-primary-fg-color);
   font-weight: 600;
 }
 
-/* Dark mode needs stronger background for visibility */
+/* Dark mode needs warmer background for cozy feel */
 [data-md-color-scheme="slate"] .md-nav__link--active {
   background: linear-gradient(90deg,
-    rgba(77, 208, 225, 0.25) 0%,     /* Higher opacity for dark bg */
-    rgba(186, 104, 200, 0.15) 100%);
+    rgba(161, 136, 127, 0.25) 0%,     /* Warm brown for dark bg */
+    rgba(255, 138, 101, 0.15) 100%);
   border-left: 3px solid var(--md-primary-fg-color);
 }
 
@@ -166,7 +168,7 @@
 
 .md-button--primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 16px rgba(0, 188, 212, 0.3);
+  box-shadow: 0 8px 16px rgba(121, 85, 72, 0.3);
 }
 
 /* Copy code button enhancement */
@@ -240,26 +242,26 @@
    TABLES
    ============================================ */
 
-/* Table headers with gradient accent */
+/* Table headers with warm gradient accent */
 .md-typeset table thead {
   background: linear-gradient(90deg,
-    rgba(0, 188, 212, 0.1) 0%,
-    rgba(156, 39, 176, 0.05) 100%);
+    rgba(121, 85, 72, 0.1) 0%,
+    rgba(255, 87, 34, 0.05) 100%);
 }
 
-/* Table row hover with subtle highlight */
+/* Table row hover with cozy highlight */
 .md-typeset table tbody tr:hover {
   background: linear-gradient(90deg,
-    rgba(0, 188, 212, 0.05) 0%,
+    rgba(121, 85, 72, 0.05) 0%,
     transparent 100%);
   transition: background 0.2s ease;
 }
 
-/* Dark mode needs higher opacity for visibility */
+/* Dark mode with warm tones for cozy reading */
 [data-md-color-scheme="slate"] .md-typeset table tbody tr:hover {
   background: linear-gradient(90deg,
-    rgba(77, 208, 225, 0.15) 0%,     /* 3x opacity for visibility */
-    rgba(77, 208, 225, 0.05) 50%,
+    rgba(161, 136, 127, 0.15) 0%,     /* Warm brown for visibility */
+    rgba(161, 136, 127, 0.05) 50%,
     transparent 100%);
 }
 
@@ -282,16 +284,16 @@
    SEARCH
    ============================================ */
 
-/* Search highlight with bright color */
+/* Search highlight with warm color */
 .md-search-result__item--selected {
-  background-color: rgba(0, 188, 212, 0.1);
+  background-color: rgba(121, 85, 72, 0.1);
   border-left: 3px solid var(--md-primary-fg-color);
 }
 
 /* Search result hover */
 .md-search-result__link:hover {
   background: linear-gradient(90deg,
-    rgba(0, 188, 212, 0.08) 0%,
+    rgba(121, 85, 72, 0.08) 0%,
     transparent 100%);
 }
 
@@ -299,16 +301,16 @@
    ANIMATIONS & FEEDBACK
    ============================================ */
 
-/* Success pulse animation for positive feedback */
+/* Success pulse animation for positive feedback - warm green */
 @keyframes successPulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(0, 230, 118, 0.7);
+    box-shadow: 0 0 0 0 rgba(139, 195, 74, 0.7);
   }
   70% {
-    box-shadow: 0 0 0 10px rgba(0, 230, 118, 0);
+    box-shadow: 0 0 0 10px rgba(139, 195, 74, 0);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(0, 230, 118, 0);
+    box-shadow: 0 0 0 0 rgba(139, 195, 74, 0);
   }
 }
 
@@ -356,15 +358,15 @@
   background: var(--md-accent-fg-color);
 }
 
-/* Dark mode scrollbar adjustments */
+/* Dark mode scrollbar adjustments - warm tones */
 [data-md-color-scheme="slate"] ::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.05);  /* Lighter track for dark bg */
 }
 
 [data-md-color-scheme="slate"] ::-webkit-scrollbar-thumb {
   background: linear-gradient(180deg,
-    rgba(77, 208, 225, 0.6),      /* Lighter cyan */
-    rgba(186, 104, 200, 0.6));    /* Lighter purple */
+    rgba(161, 136, 127, 0.6),      /* Warm brown */
+    rgba(255, 138, 101, 0.6));     /* Warm orange */
 }
 
 [data-md-color-scheme="slate"] ::-webkit-scrollbar-thumb:hover {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -73,13 +73,13 @@ html {
   transform: translateY(0) !important;
 }
 
-/* Dark mode button shadows - lighter glow for ADHD feedback */
+/* Dark mode button shadows - warm glow for cozy feedback */
 [data-md-color-scheme="slate"] .md-button:hover {
-  box-shadow: 0 4px 12px rgba(77, 208, 225, 0.3) !important;
+  box-shadow: 0 4px 12px rgba(161, 136, 127, 0.3) !important;
 }
 
 [data-md-color-scheme="slate"] .md-button--primary:hover {
-  box-shadow: 0 8px 16px rgba(77, 208, 225, 0.4) !important;
+  box-shadow: 0 8px 16px rgba(255, 138, 101, 0.4) !important;
 }
 
 /* Softer dividers */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,19 +13,19 @@ edit_uri: edit/main/docs/
 theme:
   name: material
   palette:
-    # Light mode - ADHD-optimized cyan/purple
+    # Light mode - ADHD-calm warm earth tones
     - media: '(prefers-color-scheme: light)'
       scheme: default
-      primary: cyan
-      accent: purple
+      primary: brown
+      accent: deep orange
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    # Dark mode - ADHD-optimized cyan/purple
+    # Dark mode - ADHD-calm warm earth tones
     - media: '(prefers-color-scheme: dark)'
       scheme: slate
-      primary: cyan
-      accent: purple
+      primary: brown
+      accent: deep orange
       toggle:
         icon: material/brightness-4
         name: Switch to light mode


### PR DESCRIPTION
## Summary
- Switch documentation theme from cyan/purple to warm brown/deep orange
- ADHD-calm preset designed for reduced anxiety and cozy reading experience
- Earth tones provide grounding comfort without overstimulation

## Changes
- Primary: cyan (#00bcd4) → brown (#795548)
- Accent: purple (#9c27b0) → deep orange (#ff5722)
- Updated all gradient references, hover effects, and dark mode variants

## Test plan
- [ ] Preview locally with `mkdocs serve`
- [ ] Verify light mode appearance
- [ ] Verify dark mode toggle works
- [ ] Check navigation hover effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)