### PR TITLE
docs: sync version refs to 4.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v4.0.0)
+- **Status:** Production ready (v4.0.1)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -366,16 +366,17 @@ export FLOW_DEBUG=1
 
 ## Current Status (2025-12-27)
 
-### ✅ v4.0.0 Released
+### ✅ v4.0.1 Released
 
+- [x] Unified sync command (`flow sync all`)
 - [x] Dopamine features (win tracking, streaks, goals)
 - [x] Win categories with auto-detection
 - [x] Daily goal tracking (global + per-project)
 - [x] Extended .STATUS format (wins, streak, last_active, tags)
 - [x] Dashboard TUI enhancements (Ctrl-E/S/W shortcuts)
 - [x] Watch mode (`dash --watch`)
-- [x] Documentation fully updated
-- [x] GitHub release tagged and published
+- [x] ADHD-calm theme for documentation site
+- [x] CI improvements and test suite enhancements
 
 ### ✅ CC Dispatcher (2025-12-27)
 
@@ -387,18 +388,18 @@ export FLOW_DEBUG=1
 
 ### 🎯 Production Ready
 
-- **Version:** 3.6.0
+- **Version:** 4.0.1
 - **Released:** 2025-12-27
 - **Status:** Production use phase
 - **Performance:** Sub-10ms for core commands
 - **Documentation:** https://Data-Wise.github.io/flow-cli/
 - **Tests:** Interactive dog feeding test (gamified)
 
-### 📋 Next: v4.0.0 Planning
+### 📋 Next: v4.1.0 Planning
 
-- [ ] Cross-tool orchestration (`flow sync all`)
 - [ ] Remote state sync (optional cloud backup)
 - [ ] Team features (shared templates)
+- [ ] Multi-device sync
 
 ---
 
@@ -459,10 +460,10 @@ git diff
 
 # Commit and tag
 git add -A && git commit -m "chore: bump version to 3.7.0"
-git tag -a v4.0.0 -m "v4.0.0"
+git tag -a v4.0.1 -m "v4.0.1"
 
 # Push (requires PR for protected branch)
-git push origin main && git push origin v4.0.0
+git push origin main && git push origin v4.0.1
 ```
 
 **Files updated by release script:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.0.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases/tag/v4.0.0)
+[![Version](https://img.shields.io/badge/version-4.0.1-blue.svg)](https://github.com/Data-Wise/flow-cli/releases/tag/v4.0.1)
 [![CI Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)


### PR DESCRIPTION
## Summary
- Update README badge to v4.0.1
- Update CLAUDE.md version references
- Add sync command and adhd-calm theme to status section
- Update next planning section to v4.1.0

## Test plan
- [x] Version refs consistent across files

🤖 Generated with [Claude Code](https://claude.com/claude-code)