### PR TITLE
docs: add critical command docs and update Quick Start

### DIFF
--- a/docs/commands/capture.md
+++ b/docs/commands/capture.md
@@ -1,0 +1,287 @@
+# capture
+
+> Frictionless idea and accomplishment capture for ADHD workflows
+
+The capture commands provide instant, low-friction ways to log ideas, breadcrumbs, and accomplishments. They're designed for ADHD minds that need to capture thoughts before they disappear.
+
+---
+
+## Commands Overview
+
+| Command | Purpose                 | Shortcut |
+| ------- | ----------------------- | -------- |
+| `catch` | Quick idea/task capture | `c`      |
+| `win`   | Log an accomplishment   | -        |
+| `yay`   | Show recent wins        | -        |
+| `crumb` | Leave a breadcrumb      | `b`      |
+| `trail` | Show breadcrumb trail   | `t`      |
+| `inbox` | View captured items     | `i`      |
+
+---
+
+## win
+
+> Log an accomplishment and get a dopamine boost! 🎉
+
+### Usage
+
+```bash
+win [options] <text>
+```
+
+### Options
+
+| Flag       | Short | Category            |
+| ---------- | ----- | ------------------- |
+| `--code`   | `-c`  | 💻 Code work        |
+| `--docs`   | `-d`  | 📝 Documentation    |
+| `--review` | `-r`  | 👀 Code review      |
+| `--ship`   | `-s`  | 🚀 Shipped/deployed |
+| `--fix`    | `-f`  | 🔧 Bug fix          |
+| `--test`   | `-t`  | 🧪 Testing          |
+
+### Examples
+
+```bash
+# Basic win (auto-detects category)
+win "Implemented user authentication"
+
+# With explicit category
+win --ship "Deployed v2.0 to production"
+win -f "Fixed login bug"
+
+# Interactive mode
+win
+# 🎉 What's your win? _
+```
+
+### Auto-Detection
+
+If you don't specify a category, `win` automatically detects it from keywords:
+
+| Keywords                              | Category  |
+| ------------------------------------- | --------- |
+| deploy, release, ship, publish, merge | 🚀 ship   |
+| review, pr, feedback, approve         | 👀 review |
+| test, spec, coverage, passing         | 🧪 test   |
+| fix, bug, issue, resolve, patch       | 🔧 fix    |
+| doc, readme, guide, tutorial          | 📝 docs   |
+| implement, add, create, build         | 💻 code   |
+
+### Output
+
+```
+  🎉 WIN LOGGED! #code
+  Implemented user authentication
+
+  Keep it up! 🚀
+```
+
+---
+
+## yay
+
+> Celebrate your wins and view your streak
+
+### Usage
+
+```bash
+yay [--week|-w]
+```
+
+### Show Recent Wins
+
+```bash
+# Show last 5 wins
+yay
+```
+
+Output:
+
+```
+  🎉 Recent Wins
+
+  💻 Implemented dark mode
+  🔧 Fixed memory leak in worker
+  📝 Updated API documentation
+  🚀 Deployed to staging
+
+  Total: 4 wins today | 🔥 3-day streak
+```
+
+### Weekly Summary
+
+```bash
+# Show this week's wins with stats
+yay --week
+```
+
+Output:
+
+```
+  📊 This Week's Wins
+
+  🚀 Deployed v2.0 to production
+  💻 Implemented OAuth login
+  🧪 Added integration tests
+  🔧 Fixed race condition
+  📝 Updated installation docs
+
+  ─────────────────────────────────────
+  🚀2 💻3 🔧1 📝1 = 7 wins this week
+
+  Mon Tue Wed Thu Fri Sat Sun
+   ▁   ▃   ██  ▅   ▂
+       Activity Graph
+```
+
+---
+
+## catch
+
+> Capture an idea or task instantly before it escapes
+
+### Usage
+
+```bash
+catch <text>
+# or
+c <text>
+```
+
+### Examples
+
+```bash
+# Quick capture
+catch "Add dark mode toggle to settings"
+c "Research better caching strategy"
+
+# Interactive mode
+catch
+# 💡 Quick capture: _
+```
+
+### Where It Goes
+
+- **With atlas:** Saved to atlas inbox
+- **Without atlas:** Saved to `~/.local/share/flow/inbox.md`
+
+---
+
+## crumb
+
+> Leave a breadcrumb to trace your thinking
+
+Breadcrumbs help you remember what you were doing and why. Perfect for ADHD when you get interrupted.
+
+### Usage
+
+```bash
+crumb <text>
+# or
+b <text>
+```
+
+### Examples
+
+```bash
+# Leave a breadcrumb
+crumb "Started refactoring auth module"
+b "Switching to fix urgent bug, will return"
+
+# Interactive mode
+crumb
+# 🍞 Breadcrumb: _
+```
+
+---
+
+## trail
+
+> View your breadcrumb trail
+
+### Usage
+
+```bash
+trail [project] [limit]
+# or
+t [project] [limit]
+```
+
+### Examples
+
+```bash
+# Show last 20 breadcrumbs
+trail
+
+# Show breadcrumbs for a specific project
+trail flow-cli
+
+# Limit results
+trail flow-cli 10
+```
+
+---
+
+## inbox
+
+> View your captured ideas and tasks
+
+### Usage
+
+```bash
+inbox
+# or
+i
+```
+
+---
+
+## Daily Goals
+
+Combine wins with daily goals for maximum motivation:
+
+```bash
+# Set a daily win goal
+flow goal set 3
+
+# Check progress
+flow goal
+# Today: ██░░░░░░░░ 2/3 wins
+
+# Log a win
+win "Completed API endpoint"
+# 🎉 WIN LOGGED! #code
+# 🎯 Goal: 3/3 - You did it! 🏆
+```
+
+---
+
+## Tips
+
+!!! tip "Log Wins Immediately"
+Don't wait until the end of the day. Log wins as they happen for maximum dopamine and accurate tracking.
+
+!!! tip "Use Categories"
+Categories help you see patterns in your work. Are you shipping a lot but not writing docs? The weekly summary reveals it.
+
+!!! tip "Breadcrumbs for Interruptions"
+When you get interrupted, drop a quick `crumb` so you can pick up where you left off.
+
+---
+
+## Related Commands
+
+| Command                                             | Description             |
+| --------------------------------------------------- | ----------------------- |
+| [`work`](work.md)                                   | Start a session         |
+| [`finish`](finish.md)                               | End session with commit |
+| [`dash`](dash.md)                                   | View wins in dashboard  |
+| [`flow goal`](../guides/DOPAMINE-FEATURES-GUIDE.md) | Daily goal tracking     |
+
+---
+
+## See Also
+
+- [Dopamine Features Guide](../guides/DOPAMINE-FEATURES-GUIDE.md)
+- [Workflow Quick Reference](../reference/WORKFLOW-QUICK-REFERENCE.md)

--- a/docs/commands/finish.md
+++ b/docs/commands/finish.md
@@ -1,0 +1,147 @@
+# finish
+
+> End your current work session with an optional commit
+
+The `finish` command cleanly ends your work session and optionally commits your changes.
+
+---
+
+## Usage
+
+```bash
+finish [note]
+```
+
+## Arguments
+
+| Argument | Description                   | Default                  |
+| -------- | ----------------------------- | ------------------------ |
+| `note`   | Session note / commit message | "Work session completed" |
+
+---
+
+## What It Does
+
+1. **Ends the session** - Records session end time in atlas
+2. **Detects git changes** - Counts uncommitted changes
+3. **Prompts for commit** - Asks if you want to commit (if changes exist)
+4. **Creates commit** - Uses your note as the commit message
+
+---
+
+## Examples
+
+### Basic Finish
+
+```bash
+# End session with a note
+finish "Completed feature implementation"
+
+# End session without note
+finish
+```
+
+### With Commit
+
+```bash
+$ finish "Fixed authentication bug"
+
+# Output:
+# ✓ Session ended
+# Commit 3 change(s)? [y/N] y
+# ✓ Changes committed: Fixed authentication bug
+```
+
+### Skip Commit
+
+```bash
+$ finish "WIP - will continue tomorrow"
+
+# Output:
+# ✓ Session ended
+# Commit 5 change(s)? [y/N] n
+```
+
+---
+
+## Session Tracking
+
+When you `finish`, your session metrics are recorded:
+
+- **Duration** - How long you worked
+- **Project** - Which project you were on
+- **Note** - What you accomplished
+
+View your session history:
+
+```bash
+# See today's sessions
+flow status -v
+
+# See session stats in dashboard
+dash
+```
+
+---
+
+## Git Integration
+
+The `finish` command has smart git integration:
+
+| Scenario      | Behavior                        |
+| ------------- | ------------------------------- |
+| No git repo   | Skips commit prompt             |
+| No changes    | Skips commit prompt             |
+| Has changes   | Prompts to commit               |
+| User confirms | Runs `git add -A && git commit` |
+
+!!! warning "Stages All Changes"
+`finish` uses `git add -A` which stages **all** changes including new files. Review your changes before confirming the commit.
+
+---
+
+## Related Commands
+
+| Command                 | Description                            |
+| ----------------------- | -------------------------------------- |
+| [`work`](work.md)       | Start a new session                    |
+| [`hop`](hop.md)         | Switch projects without ending session |
+| [`win`](capture.md#win) | Log an accomplishment before finishing |
+
+---
+
+## Workflow Example
+
+A typical work session:
+
+```bash
+# Start
+work my-project
+
+# ... do your work ...
+
+# Log accomplishments
+win "Implemented user auth"
+win "Added tests"
+
+# End session
+finish "Auth feature complete"
+```
+
+---
+
+## Tips
+
+!!! tip "Log Wins Before Finishing"
+Use `win` to log your accomplishments before running `finish`. This builds your streak and gives you a dopamine boost!
+
+!!! tip "Meaningful Notes"
+Use descriptive notes - they become your commit messages and help you remember what you did.
+
+---
+
+## See Also
+
+- [`work`](work.md) - Start a session
+- [`capture`](capture.md) - Log wins and ideas
+- [Workflow Quick Reference](../reference/WORKFLOW-QUICK-REFERENCE.md)

--- a/docs/commands/work.md
+++ b/docs/commands/work.md
@@ -1,0 +1,155 @@
+# work
+
+> Start a focused work session on a project
+
+The `work` command is the **primary entry point** for flow-cli. It sets up your entire development context in one command.
+
+---
+
+## Usage
+
+```bash
+work [project] [editor]
+```
+
+## Arguments
+
+| Argument  | Description          | Default                                          |
+| --------- | -------------------- | ------------------------------------------------ |
+| `project` | Project name or path | Interactive picker (if fzf) or current directory |
+| `editor`  | Editor to open       | `$EDITOR` or `code`                              |
+
+---
+
+## What It Does
+
+1. **Checks for existing session** - Prompts to switch if another project is active
+2. **Locates the project** - Uses atlas registry or scans `$FLOW_PROJECTS_ROOT`
+3. **Changes to project directory** - `cd` to the project root
+4. **Starts a session** - Records session start time in atlas
+5. **Shows context** - Displays project type, status, and focus
+6. **Opens your editor** - Launches VS Code, Cursor, Vim, Emacs, etc.
+
+---
+
+## Examples
+
+### Start Working on a Project
+
+```bash
+# Start working on flow-cli
+work flow-cli
+
+# With a specific editor
+work flow-cli cursor
+
+# Use vim
+work my-project vim
+```
+
+### Interactive Selection
+
+```bash
+# Opens fzf picker if no project specified
+work
+```
+
+### Use Current Directory
+
+```bash
+# If you're already in a project directory
+cd ~/projects/my-app
+work
+```
+
+---
+
+## Output
+
+When you run `work`, you'll see:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🔧 flow-cli (zsh-plugin)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🟢 Status: active
+📍 Phase: v4.0.1 Released
+🎯 Focus: Documentation enhancement
+```
+
+---
+
+## Session Management
+
+`work` automatically manages your session state:
+
+- **Single active session** - Only one project can be "active" at a time
+- **Conflict detection** - Prompts before switching projects
+- **Duration tracking** - Session time is recorded for productivity stats
+
+### Check Current Session
+
+```bash
+# See what you're working on
+flow status
+
+# Or use the quick status
+st
+```
+
+---
+
+## Editor Support
+
+The `work` command supports these editors out of the box:
+
+| Editor     | Command                | Notes                         |
+| ---------- | ---------------------- | ----------------------------- |
+| VS Code    | `code`                 | Default if `$EDITOR` not set  |
+| Cursor     | `cursor`               | AI-powered VS Code fork       |
+| Vim/Neovim | `vim`, `nvim`          | Opens in terminal             |
+| Emacs      | `emacs`, `emacsclient` | Uses emacsclient if available |
+| Positron   | `positron`             | RStudio-based IDE (macOS)     |
+
+### Custom Editor
+
+```bash
+# Set default editor in .zshrc
+export EDITOR="nvim"
+
+# Or specify per-session
+work my-project "code-insiders"
+```
+
+---
+
+## Related Commands
+
+| Command               | Description                          |
+| --------------------- | ------------------------------------ |
+| [`finish`](finish.md) | End the current session              |
+| [`hop`](hop.md)       | Quick switch between projects (tmux) |
+| [`dash`](dash.md)     | View all projects dashboard          |
+| [`pick`](pick.md)     | Interactive project picker           |
+
+---
+
+## Tips
+
+!!! tip "ADHD-Friendly Workflow"
+The `work` command is designed to minimize friction:
+
+    - **One command** to set up everything
+    - **Smart defaults** so you rarely need arguments
+    - **Visual feedback** confirms what's happening
+
+!!! note "Project Detection"
+flow-cli automatically detects your project type (R package, Node.js, Python, ZSH, etc.) and shows the appropriate icon and context.
+
+---
+
+## See Also
+
+- [First Session Tutorial](../tutorials/01-first-session.md)
+- [Multiple Projects Tutorial](../tutorials/02-multiple-projects.md)
+- [Workflow Quick Reference](../reference/WORKFLOW-QUICK-REFERENCE.md)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -4,187 +4,242 @@ Get up and running with Flow CLI in 5 minutes.
 
 ---
 
-## 💡 Two Command Systems
+## The Core Workflow
 
-This workflow system provides **two complementary sets of commands**:
-
-| Type               | Commands                           | Speed  | Use For                           |
-| ------------------ | ---------------------------------- | ------ | --------------------------------- |
-| **⚡ Fast (ZSH)**  | `work`, `finish`, `dash`, `status` | < 10ms | Daily workflow, context switching |
-| **🎨 Rich (flow)** | `flow status`, `flow dashboard`    | ~100ms | Detailed views, monitoring        |
-
-**Mental model:** ZSH for doing, `flow` for viewing.
-
-**Example:**
+Flow CLI is built around a simple, ADHD-friendly workflow:
 
 ```bash
-work my-project          # Start session (instant, ZSH)
-flow dashboard           # Monitor all projects (rich TUI, Node.js)
-finish "Completed work"  # End session (instant, ZSH)
+work my-project     # 1. Start a focused session
+# ... do your work ...
+win "Did the thing"  # 2. Log your wins
+finish "Done!"       # 3. End and optionally commit
 ```
+
+**That's it!** Everything else builds on this foundation.
 
 ---
 
-## Step 1: Check Your Setup
+## Step 1: Verify Installation
 
-The configuration files are already installed in `~/.config/zsh/`. Verify:
+Check that flow-cli is loaded:
 
 ```bash
-ls ~/.config/zsh/.zshrc
-ls ~/.config/zsh/functions/
-
-# Test the new CLI commands
+# Should show version
 flow --version
-flow status
+
+# Should show help
+flow help
+```
+
+If commands aren't found, ensure the plugin is sourced in your `.zshrc`:
+
+```bash
+# Via antidote
+antidote load data-wise/flow-cli
+
+# Or manual source
+source /path/to/flow-cli/flow.plugin.zsh
 ```
 
 ---
 
-## Step 2: Try the Enhanced Status Command
-
-Flow CLI now includes beautiful ASCII visualizations:
+## Step 2: Start Your First Session
 
 ```bash
-flow status          # Basic status with progress bars
-flow status -v       # Verbose mode with productivity metrics
-flow dashboard       # Interactive real-time TUI (press 'q' to quit)
+# Start working on a project
+work my-project
+
+# Or use the interactive picker
+work
 ```
 
-**What you'll see:**
+You'll see:
 
-- Active session status with duration
-- Today's productivity stats
-- Recent sessions with sparkline trends
-- Quick action menu
-- Flow state indicators 🔥
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📦 my-project (node)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🟢 Status: active
+🎯 Focus: Implement new feature
+```
+
+**What happened:**
+
+- Changed to project directory
+- Started session tracking
+- Opened your editor
+- Showed project context
 
 ---
 
-## Step 3: Learn the 6 Core Aliases
+## Step 3: Log Your Wins
 
-These are your daily drivers for R package development:
+As you accomplish things, log them:
 
 ```bash
-rload    # Load package code         (50x/day)
-rtest    # Run tests                 (30x/day)
-rdoc     # Generate documentation    (20x/day)
-rcheck   # R CMD check              (10x/day)
-rbuild   # Build tar.gz             (5x/day)
-rinstall # Install package          (5x/day)
+win "Implemented user login"
+win "Fixed that annoying bug"
+win --ship "Deployed to production"
 ```
 
-**Try it now:**
+Output:
+
+```
+🎉 WIN LOGGED! #code
+Implemented user login
+
+Keep it up! 🚀
+```
+
+### Win Categories
+
+Wins are auto-categorized, or you can specify:
+
+| Flag       | Category      | Icon |
+| ---------- | ------------- | ---- |
+| `--code`   | Code work     | 💻   |
+| `--docs`   | Documentation | 📝   |
+| `--fix`    | Bug fix       | 🔧   |
+| `--ship`   | Deployed      | 🚀   |
+| `--test`   | Testing       | 🧪   |
+| `--review` | Code review   | 👀   |
+
+---
+
+## Step 4: Check Your Progress
 
 ```bash
-cd ~/projects/r-packages/active/your-package
-rload
-rtest
+# Quick dashboard
+dash
+
+# Show recent wins
+yay
+
+# Weekly summary with graph
+yay --week
 ```
 
 ---
 
-## Step 4: Use Smart Dispatchers
-
-Instead of navigating manually, use context-aware functions:
-
-### Project Picker
+## Step 5: End Your Session
 
 ```bash
-pick     # Fuzzy-find and navigate to any project (10x faster with caching!)
-```
+# End session with a note
+finish "Completed auth feature"
 
-**Performance:** First scan ~3ms, cached scans <1ms for 60 projects.
-
-**Note:** The `pp` alias was removed (2025-12-25) to avoid conflicts with system `/usr/bin/pp`. Use `pick` directly.
-
-### Claude Code
-
-```bash
-ccy      # Project picker → Claude Code (function in ~/.config/zsh/.zshrc)
-ccp      # Claude print mode (non-interactive)
-ccr      # Resume last session
-```
-
-**Note:** The `cc` dispatcher was replaced (2025-12-25) with the `ccy` function for better project integration.
-
-### File Viewer
-
-```bash
-peek README.md       # Smart syntax highlighting
-peek *.R             # View R files
+# You'll be prompted to commit if there are changes
+# Commit 3 change(s)? [y/N] y
+# ✓ Changes committed
 ```
 
 ---
 
-## Step 5: Set Up Focus Timers
+## Daily Goals (Optional)
 
-Stay productive with Pomodoro timers:
+Set and track daily win goals:
 
 ```bash
-f25      # 25-minute focused session
-f50      # 50-minute deep work session
+# Set a goal of 3 wins per day
+flow goal set 3
+
+# Check progress
+flow goal
+# Today: ██████░░░░ 2/3 wins
 ```
-
-During a timer:
-
-- Terminal shows countdown
-- Notification when time's up
-- Helps combat time blindness
 
 ---
 
-## Step 6: Learn Git Plugin Aliases
+## Essential Commands
 
-Standard OMZ git plugin (226+ aliases) is enabled:
+### Workflow
+
+| Command          | Description                    |
+| ---------------- | ------------------------------ |
+| `work [project]` | Start a focused session        |
+| `finish [note]`  | End session, optionally commit |
+| `hop <project>`  | Quick switch (tmux)            |
+| `dash`           | Project dashboard              |
+
+### Capture & Celebrate
+
+| Command        | Description           |
+| -------------- | --------------------- |
+| `win <text>`   | Log an accomplishment |
+| `yay`          | Show recent wins      |
+| `catch <text>` | Quick idea capture    |
+| `crumb <text>` | Leave a breadcrumb    |
+
+### Navigation
+
+| Command   | Description                |
+| --------- | -------------------------- |
+| `pick`    | Interactive project picker |
+| `cc`      | Launch Claude Code         |
+| `cc pick` | Pick project → Claude Code |
+
+---
+
+## Smart Dispatchers
+
+Flow CLI includes 6 domain-specific dispatchers:
+
+| Dispatcher | Domain      | Example                    |
+| ---------- | ----------- | -------------------------- |
+| `g`        | Git         | `g status`, `g push`       |
+| `r`        | R packages  | `r test`, `r check`        |
+| `qu`       | Quarto      | `qu preview`, `qu render`  |
+| `mcp`      | MCP servers | `mcp status`, `mcp logs`   |
+| `obs`      | Obsidian    | `obs daily`, `obs search`  |
+| `cc`       | Claude Code | `cc`, `cc pick`, `cc yolo` |
+
+Get help for any dispatcher:
 
 ```bash
-gst      # git status
-ga       # git add
-gaa      # git add --all
-gcmsg    # git commit -m "message"
-gp       # git push
-glo      # git log --oneline
-```
-
-**Try it:**
-
-```bash
-gst                          # Check status
-ga README.md                 # Stage file
-gcmsg "Update documentation" # Commit
-gp                           # Push
+g help
+r help
+cc help
 ```
 
 ---
 
 ## What's Next?
 
-### Learn Through Tutorials
+### Tutorials (Recommended)
 
-1. [Tutorial 1: Your First Session](../tutorials/01-first-session.md) - Start tracking work
-2. [Tutorial 2: Multiple Projects](../tutorials/02-multiple-projects.md) - Manage many projects
-3. [Tutorial 3: Status Visualizations](../tutorials/03-status-visualizations.md) - Master ASCII visuals
-4. [Tutorial 4: Web Dashboard](../tutorials/04-web-dashboard.md) - Interactive TUI
+1. [Your First Session](../tutorials/01-first-session.md) - Deep dive into `work`
+2. [Multiple Projects](../tutorials/02-multiple-projects.md) - Managing many projects
+3. [AI-Powered Commands](../tutorials/05-ai-commands.md) - Using `flow ai`
 
-### Master the Commands
+### Reference
 
-1. [flow status Command](../commands/status.md) - Complete reference
-2. [flow dashboard Command](../commands/dashboard.md) - TUI guide
-3. [Alias Reference Card](../reference/ALIAS-REFERENCE-CARD.md) - All 28 aliases
-4. [Workflow Quick Reference](../reference/WORKFLOW-QUICK-REFERENCE.md) - Daily workflows
-
-### Customize Your Workflow
-
-- Add aliases if used 10+ times/day
-- Create custom dispatcher functions
-- Configure focus timer defaults
+- [Command Quick Reference](../reference/COMMAND-QUICK-REFERENCE.md)
+- [Dispatcher Reference](../reference/DISPATCHER-REFERENCE.md)
+- [Dopamine Features Guide](../guides/DOPAMINE-FEATURES-GUIDE.md)
 
 ### Get Help
 
-- All docs: [Documentation Site](https://Data-Wise.github.io/flow-cli/)
-- Testing guide: [TESTING.md](../testing/TESTING.md)
-- Coding standards: [Development Guidelines](../ZSH-DEVELOPMENT-GUIDELINES.md)
-- Git plugin: [OMZ Git Plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git)
+```bash
+# Built-in help
+flow help
+dash --help
+work --help
+
+# Health check
+flow doctor
+```
+
+---
+
+## ADHD Tips
+
+!!! tip "One Command to Start"
+Just type `work` and let the picker guide you. No need to remember project paths.
+
+!!! tip "Log Wins Immediately"
+Don't wait - log wins as they happen. Each `win` gives you a dopamine boost!
+
+!!! tip "Use Breadcrumbs"
+Before switching contexts, run `crumb "was working on X"` so you can pick up later.
 
 ---
 

--- a/docs/planning/DOCS-ENHANCEMENT-PLAN.md
+++ b/docs/planning/DOCS-ENHANCEMENT-PLAN.md
@@ -1,0 +1,310 @@
+# Documentation Enhancement Plan
+
+**Created:** 2025-12-27
+**Status:** Planning
+**Priority:** High
+
+---
+
+## Executive Summary
+
+The flow-cli documentation site has 166 markdown files but suffers from:
+
+1. **Missing core command docs** - `work`, `finish`, `hop` not documented
+2. **Outdated content** - Still references Node.js CLI, old paths
+3. **No v4.0 tutorials** - Dopamine features, sync command undocumented
+4. **Cluttered reference section** - 15+ docs, hard to navigate
+5. **No FAQ or Troubleshooting hub**
+
+---
+
+## Quick Wins (< 30 min each)
+
+### 1. ⚡ Add Missing Core Command Docs
+
+**Priority:** Critical - these are the most-used commands!
+
+| Command   | File to Create             | Content                          |
+| --------- | -------------------------- | -------------------------------- |
+| `work`    | `docs/commands/work.md`    | Start session, project detection |
+| `finish`  | `docs/commands/finish.md`  | End session, auto-commit         |
+| `hop`     | `docs/commands/hop.md`     | Quick project switch (tmux)      |
+| `capture` | `docs/commands/capture.md` | catch, crumb, win, yay           |
+| `timer`   | `docs/commands/timer.md`   | Focus timer, pomodoro            |
+| `morning` | `docs/commands/morning.md` | Daily routine commands           |
+| `pick`    | `docs/commands/pick.md`    | Project picker                   |
+| `flow`    | `docs/commands/flow.md`    | Main dispatcher                  |
+
+**Template:**
+
+```markdown
+# command-name
+
+> Brief description
+
+## Usage
+
+\`\`\`bash
+command [options] [args]
+\`\`\`
+
+## Options
+
+| Flag | Description |
+| ---- | ----------- |
+
+## Examples
+
+\`\`\`bash
+
+# Example 1
+
+command arg
+
+# Example 2
+
+command --option
+\`\`\`
+
+## See Also
+
+- Related command
+```
+
+### 2. ⚡ Update Quick Start for v4.0
+
+**File:** `docs/getting-started/quick-start.md`
+
+**Issues:**
+
+- References Node.js CLI (removed in v3.0)
+- Mentions `~/.config/zsh/functions/` (legacy)
+- Missing dopamine features
+- Missing dispatchers
+
+**Changes:**
+
+- Remove Node.js references
+- Add `work → finish` flow
+- Add `win` command mention
+- Update installation paths
+
+### 3. ⚡ Fix Outdated Version References
+
+Search and replace across docs:
+
+- "v3.2.0" → "v4.0.1" where appropriate
+- Remove "Node.js" references
+- Update architecture descriptions
+
+---
+
+## Medium Effort (1-2 hours)
+
+### 4. 🔧 New Tutorial: Dopamine Features
+
+**File:** `docs/tutorials/06-dopamine-features.md`
+
+**Content:**
+
+1. Introduction to win tracking
+2. Setting daily goals
+3. Viewing streaks
+4. Win categories
+5. Weekly summaries
+
+**Why:** v4.0's flagship feature is undocumented in tutorials!
+
+### 5. 🔧 New Tutorial: Sync Command
+
+**File:** `docs/tutorials/07-sync-command.md`
+
+**Content:**
+
+1. What sync does
+2. Sync targets (session, status, wins, goals, git)
+3. Smart sync vs full sync
+4. Scheduled sync setup
+
+### 6. 🔧 Reorganize Reference Section
+
+**Current:** 15 docs, overwhelming
+
+**Proposed Structure:**
+
+```
+Reference:
+  - Quick References:
+      - Command Quick Ref
+      - Alias Reference Card
+      - Workflow Quick Ref
+  - Dispatchers:
+      - Dispatcher Overview
+      - CC Dispatcher
+  - Deep Dives:
+      - Project Detection
+      - ADHD Helpers Map
+```
+
+### 7. 🔧 Create FAQ Page
+
+**File:** `docs/getting-started/faq.md`
+
+**Sections:**
+
+- Installation issues
+- "Command not found" fixes
+- Atlas integration questions
+- Performance concerns
+- ADHD-specific tips
+
+---
+
+## Larger Improvements (2+ hours)
+
+### 8. 🏗️ Interactive Command Explorer
+
+Enhance `docs/reference/COMMAND-EXPLORER.md`:
+
+- Add search/filter functionality
+- Group by category (workflow, capture, time, etc.)
+- Include all 28 aliases
+- Add "copy to clipboard" for commands
+
+### 9. 🏗️ Video/GIF Tutorials
+
+Create visual guides:
+
+- `work → dash → finish` workflow
+- Dashboard TUI navigation
+- Win tracking in action
+
+### 10. 🏗️ Changelog Page
+
+**File:** `docs/CHANGELOG.md`
+
+Auto-generated from git tags or manually maintained.
+Current "Recent Updates" section on homepage is good but limited.
+
+---
+
+## Content Audit Results
+
+### ✅ Well-Documented
+
+- Dashboard (`dash.md`, 16KB)
+- Status (`status.md`, 10KB)
+- Doctor (`doctor.md`, 10KB)
+- Sync (`sync.md`, 8KB)
+- Dopamine Guide (guide exists)
+
+### ⚠️ Needs Update
+
+- Quick Start (references old architecture)
+- AI Tutorial (v3.2.0 reference)
+- Installation (may have outdated paths)
+
+### ❌ Missing Entirely
+
+- `work` command (THE core command!)
+- `finish` command
+- `hop` command
+- `capture` commands (win, catch, yay)
+- `timer` command
+- `pick` command
+
+### 🗑️ Consider Removing/Archiving
+
+- `docs/active/` - Internal planning docs
+- `docs/planning/` - Internal planning docs
+- `docs/ideas/` - Internal brainstorming
+- `docs/standards/` - Internal standards
+
+These are excluded from nav but still in repo.
+
+---
+
+## Navigation Improvements
+
+### Current Nav (11 sections)
+
+```
+Home | Getting Started | Tutorials | Guides | Reference |
+Commands | Architecture | API | Testing | Development | Decisions
+```
+
+### Proposed Nav (Simplified)
+
+```
+Home
+Getting Started (4 pages)
+Tutorials (7 pages) ← Add 2 new
+Guides (6 pages)
+Commands (18 pages) ← Add 8 new
+Reference (reorganized into 3 subsections)
+For Developers:
+  - Architecture
+  - API
+  - Testing
+  - Contributing
+  - Decisions (ADRs)
+```
+
+---
+
+## Priority Order
+
+| #   | Task                         | Effort | Impact      |
+| --- | ---------------------------- | ------ | ----------- |
+| 1   | Add `work` command doc       | 20 min | 🔥 Critical |
+| 2   | Add `finish` command doc     | 15 min | 🔥 Critical |
+| 3   | Add `capture` commands doc   | 25 min | 🔥 High     |
+| 4   | Update Quick Start           | 30 min | 🔥 High     |
+| 5   | Add Dopamine tutorial        | 45 min | High        |
+| 6   | Add remaining command docs   | 1 hr   | Medium      |
+| 7   | Create FAQ                   | 30 min | Medium      |
+| 8   | Reorganize Reference section | 1 hr   | Medium      |
+| 9   | Add Sync tutorial            | 30 min | Medium      |
+| 10  | Fix version references       | 20 min | Low         |
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Critical Gaps (Today)
+
+- [ ] Create `docs/commands/work.md`
+- [ ] Create `docs/commands/finish.md`
+- [ ] Create `docs/commands/capture.md`
+- [ ] Update `docs/getting-started/quick-start.md`
+
+### Phase 2: Complete Commands (This Week)
+
+- [ ] Create `docs/commands/hop.md`
+- [ ] Create `docs/commands/timer.md`
+- [ ] Create `docs/commands/morning.md`
+- [ ] Create `docs/commands/pick.md`
+- [ ] Create `docs/commands/flow.md`
+- [ ] Update `mkdocs.yml` navigation
+
+### Phase 3: New Tutorials (Next)
+
+- [ ] Create `docs/tutorials/06-dopamine-features.md`
+- [ ] Create `docs/tutorials/07-sync-command.md`
+- [ ] Create `docs/getting-started/faq.md`
+
+### Phase 4: Polish (Future)
+
+- [ ] Reorganize Reference section
+- [ ] Add video/GIF content
+- [ ] Create CHANGELOG page
+- [ ] Archive internal planning docs
+
+---
+
+## Notes
+
+- Keep ADHD-friendly: short sections, clear headers, lots of examples
+- Every command doc should have copy-pasteable examples
+- Use admonitions (tip, warning, note) for visual breaks
+- Link related commands together

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,9 +137,12 @@ nav:
       - Existing System Summary: reference/EXISTING-SYSTEM-SUMMARY.md
       - ZSH Clean Workflow: reference/ZSH-CLEAN-WORKFLOW.md
   - Commands:
-      - status: commands/status.md
-      - dashboard: commands/dashboard.md
+      - work: commands/work.md
+      - finish: commands/finish.md
+      - capture (win/yay/catch): commands/capture.md
       - dash: commands/dash.md
+      - status: commands/status.md
+      - sync: commands/sync.md
       - doctor: commands/doctor.md
       - config: commands/config.md
       - plugin: commands/plugin.md
@@ -147,7 +150,7 @@ nav:
       - do: commands/do.md
       - install: commands/install.md
       - upgrade: commands/upgrade.md
-      - sync: commands/sync.md
+      - dashboard: commands/dashboard.md
   - Architecture:
       - Overview: architecture/README.md
       - Architecture Diagrams: architecture/ARCHITECTURE-DIAGRAM.md


### PR DESCRIPTION
## Summary

Phase 1 of documentation enhancement addressing critical gaps:

### New Command Docs
- **work.md** - Core session start command (was completely missing!)
- **finish.md** - Session end command with git integration
- **capture.md** - Complete guide to win/yay/catch/crumb commands

### Updated Content
- **Quick Start** - Complete rewrite for v4.0 pure ZSH architecture
  - Removed outdated Node.js references
  - Added work → win → finish workflow
  - Added dopamine features
  - Updated dispatcher list

### Navigation
- Reordered Commands section to put core commands first
- Added new command docs to navigation

### Planning
- Added DOCS-ENHANCEMENT-PLAN.md for tracking future improvements

## Impact

These are the **most-used commands** that were completely undocumented:
- `work` - Used to start every session
- `finish` - Used to end every session  
- `win`/`yay` - v4.0 flagship dopamine features

## Test plan
- [ ] Build docs locally: `mkdocs build`
- [ ] Verify new pages render correctly
- [ ] Check internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)