### PR TITLE
docs: add Phase 2 command documentation

### DIFF
--- a/docs/commands/flow.md
+++ b/docs/commands/flow.md
@@ -1,0 +1,225 @@
+# flow
+
+> Unified CLI dispatcher for all flow-cli commands
+
+The `flow` command is the main entry point for the flow-cli plugin. It provides access to all subcommands through a unified namespace.
+
+---
+
+## Usage
+
+```bash
+flow <command> [args]
+```
+
+## Getting Help
+
+```bash
+flow help              # Show all commands
+flow help <command>    # Help for specific command
+flow help --list       # List all commands
+flow help --search <term>  # Search commands
+```
+
+---
+
+## Command Categories
+
+### Core Workflow
+
+| Command                | Description                    |
+| ---------------------- | ------------------------------ |
+| `flow work <project>`  | Start focused work session     |
+| `flow pick [category]` | Interactive project picker     |
+| `flow dash [scope]`    | Project dashboard              |
+| `flow finish [note]`   | End session, optionally commit |
+| `flow hop <project>`   | Quick switch (tmux)            |
+| `flow why`             | Show current context           |
+
+### ADHD Helpers
+
+| Command             | Description                |
+| ------------------- | -------------------------- |
+| `flow start`, `js`  | Just start (picks for you) |
+| `flow stuck`        | Get unstuck when blocked   |
+| `flow focus <text>` | Set current focus          |
+| `flow next`         | What to work on next       |
+| `flow break [min]`  | Take a proper break        |
+
+### Capture & Track
+
+| Command             | Description              |
+| ------------------- | ------------------------ |
+| `flow catch <idea>` | Quick capture to inbox   |
+| `flow crumb <note>` | Leave breadcrumb         |
+| `flow inbox`        | View inbox               |
+| `flow win <text>`   | Log a win                |
+| `flow goal [set n]` | Daily win goal tracking  |
+| `flow status`       | View/update .STATUS file |
+
+### Context-Aware Actions
+
+| Command        | Description                   |
+| -------------- | ----------------------------- |
+| `flow test`    | Run tests (auto-detects type) |
+| `flow build`   | Build project                 |
+| `flow preview` | Preview output                |
+| `flow sync`    | Smart git sync                |
+| `flow check`   | Health check (lint, types)    |
+| `flow plan`    | Sprint/project planning       |
+| `flow log`     | Activity log                  |
+
+### Timer & Routine
+
+| Command            | Description             |
+| ------------------ | ----------------------- |
+| `flow timer [min]` | Start focus timer       |
+| `flow morning`     | Morning startup routine |
+
+### Setup & Diagnostics
+
+| Command        | Description                 |
+| -------------- | --------------------------- |
+| `flow doctor`  | Check dependencies & health |
+| `flow setup`   | Interactive setup wizard    |
+| `flow install` | Install tools               |
+| `flow upgrade` | Update flow-cli             |
+| `flow learn`   | Interactive tutorial        |
+
+### AI-Powered
+
+| Command             | Description               |
+| ------------------- | ------------------------- |
+| `flow ai <query>`   | Ask AI anything           |
+| `flow do "request"` | Natural language commands |
+
+### Configuration
+
+| Command            | Description        |
+| ------------------ | ------------------ |
+| `flow config show` | Show settings      |
+| `flow config set`  | Set a config value |
+| `flow plugin`      | Manage plugins     |
+
+---
+
+## Direct Command Access
+
+Most commands work directly without the `flow` prefix:
+
+```bash
+# These are equivalent:
+flow work my-project
+work my-project
+
+# Direct access commands:
+work, pick, dash, finish, hop, why
+catch, crumb, inbox, win
+timer, morning
+doctor, status
+```
+
+---
+
+## Examples
+
+### Starting Your Day
+
+```bash
+# Morning routine
+flow morning
+
+# Or quick version
+am
+
+# Start working
+flow work my-project
+# or just
+work my-project
+```
+
+### During Work
+
+```bash
+# Log wins as you go
+flow win "Fixed the auth bug"
+
+# Check progress
+flow status
+
+# Take a break
+flow break 5
+```
+
+### Context-Aware Actions
+
+```bash
+# Run tests (auto-detects R/Node/Python)
+flow test
+
+# Build project (auto-detects Quarto/npm/R CMD)
+flow build
+
+# Preview output
+flow preview
+```
+
+### Getting Help
+
+```bash
+# Search for git-related commands
+flow help --search git
+
+# Get help on sync
+flow help sync
+
+# List all available commands
+flow help --list
+```
+
+---
+
+## Dispatchers
+
+Flow-cli includes domain-specific dispatchers that are separate from the `flow` command:
+
+| Dispatcher | Domain            | Example              |
+| ---------- | ----------------- | -------------------- |
+| `g`        | Git workflows     | `g push`, `g status` |
+| `r`        | R package dev     | `r test`, `r check`  |
+| `qu`       | Quarto publishing | `qu preview`         |
+| `mcp`      | MCP servers       | `mcp status`         |
+| `obs`      | Obsidian notes    | `obs daily`          |
+| `cc`       | Claude Code       | `cc`, `cc pick`      |
+
+Get help for any dispatcher with `<dispatcher> help`.
+
+---
+
+## Version
+
+```bash
+flow version
+# flow-cli v4.0.1
+```
+
+---
+
+## Tips
+
+!!! tip "Use Direct Commands"
+For common commands like `work`, `dash`, `pick`, skip the `flow` prefix for speed.
+
+!!! tip "Search When Unsure"
+Use `flow help --search <term>` to find commands you don't remember.
+
+!!! tip "Tab Completion"
+If you have completions installed, `flow <Tab>` shows available commands.
+
+---
+
+## Related
+
+- [Command Quick Reference](../reference/COMMAND-QUICK-REFERENCE.md)
+- [Dispatcher Reference](../reference/DISPATCHER-REFERENCE.md)
+- [Getting Started](../getting-started/quick-start.md)

--- a/docs/commands/hop.md
+++ b/docs/commands/hop.md
@@ -1,0 +1,137 @@
+# hop
+
+> Quick project switch with tmux session management
+
+The `hop` command provides fast project switching, especially powerful when using tmux. It creates or switches to project-specific tmux sessions.
+
+---
+
+## Usage
+
+```bash
+hop [project]
+```
+
+## Arguments
+
+| Argument  | Description               | Default                  |
+| --------- | ------------------------- | ------------------------ |
+| `project` | Project name to switch to | Interactive picker (fzf) |
+
+---
+
+## What It Does
+
+1. **Without tmux** - Simple `cd` to project directory
+2. **With tmux** - Creates or switches to a named tmux session for the project
+
+### Tmux Behavior
+
+When running inside tmux:
+
+- **Session exists** - Switches to the existing session
+- **Session doesn't exist** - Creates new session in project directory
+- **Session naming** - Uses sanitized project name (replaces special chars with `_`)
+
+---
+
+## Examples
+
+### Basic Switch
+
+```bash
+# Switch to a project
+hop flow-cli
+
+# Interactive picker (if no project specified)
+hop
+```
+
+### With Tmux
+
+```bash
+# Creates/switches to 'flow_cli' tmux session
+hop flow-cli
+
+# View all tmux sessions
+tmux list-sessions
+```
+
+### Without Tmux
+
+```bash
+# Simply changes to project directory
+hop my-project
+# Changed to: my-project (start tmux for session management)
+```
+
+---
+
+## Output
+
+With tmux:
+
+```
+✓ Hopped to: flow-cli
+```
+
+Without tmux:
+
+```
+ℹ Changed to: my-project (start tmux for session management)
+```
+
+---
+
+## hop vs work
+
+| Feature          | `hop`                   | `work`                  |
+| ---------------- | ----------------------- | ----------------------- |
+| Session tracking | No                      | Yes (atlas)             |
+| Editor launch    | No                      | Yes                     |
+| Context display  | No                      | Yes (.STATUS shown)     |
+| Tmux integration | Full (creates sessions) | No                      |
+| Speed            | Instant                 | Slightly slower (setup) |
+| Use case         | Quick context switches  | Starting focused work   |
+
+**Rule of thumb:**
+
+- Use `work` when starting a focused work block
+- Use `hop` when quickly checking something in another project
+
+---
+
+## Tmux Tips
+
+!!! tip "View All Sessions"
+```bash # List all tmux sessions
+tmux ls
+
+    # Kill a specific session
+    tmux kill-session -t session_name
+    ```
+
+!!! tip "Detach and Return"
+`bash
+    # Detach from current session: Ctrl-b d
+    # Then hop to another project
+    hop other-project
+    `
+
+---
+
+## Related Commands
+
+| Command           | Description                         |
+| ----------------- | ----------------------------------- |
+| [`work`](work.md) | Start focused session (with editor) |
+| [`pick`](pick.md) | Interactive project picker          |
+| [`dash`](dash.md) | View all projects dashboard         |
+
+---
+
+## See Also
+
+- [`work`](work.md) - Start a full work session
+- [`pick`](pick.md) - Interactive project picker
+- [Workflow Quick Reference](../reference/WORKFLOW-QUICK-REFERENCE.md)

--- a/docs/commands/morning.md
+++ b/docs/commands/morning.md
@@ -1,0 +1,215 @@
+# morning
+
+> ADHD-friendly daily startup routine
+
+The `morning` command provides a structured startup routine to reduce decision fatigue and get you working faster. It shows your inbox, active projects, yesterday's wins, and suggests what to work on.
+
+---
+
+## Usage
+
+```bash
+morning [options]
+```
+
+## Options
+
+| Flag      | Short | Description        |
+| --------- | ----- | ------------------ |
+| `--quick` | `-q`  | Quick summary only |
+
+---
+
+## What It Shows
+
+The full `morning` command displays:
+
+1. **Inbox count** - Captured ideas awaiting review
+2. **Active projects** - Top 5 with progress and focus
+3. **Yesterday's wins** - Recent accomplishments
+4. **Suggestion** - What to work on next
+
+---
+
+## Examples
+
+### Full Morning Routine
+
+```bash
+morning
+```
+
+Output:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ☀️  GOOD MORNING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  📥 3 items in inbox
+
+  Active Projects:
+     🔧 flow-cli        [ 85%] → Documentation enhancement
+     📦 rmediation      [ 60%] → CRAN submission prep
+     🎓 stat-440        [ 40%] → Week 12 materials
+
+  Yesterday's wins:
+     💻 Implemented dark mode toggle
+     🔧 Fixed session tracking bug
+
+  💡 Suggestion:
+     Work on flow-cli
+     Run: work flow-cli
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Ready to start? Try: js (just-start) or work <project>
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Quick Mode
+
+```bash
+morning -q
+# or
+am
+```
+
+Output:
+
+```
+  📥 3 inbox  │  📂 5 active projects
+
+  → js to start working
+```
+
+---
+
+## Related Commands
+
+### today
+
+Quick daily status showing current session and today's wins:
+
+```bash
+today
+```
+
+Output:
+
+```
+📅 TODAY Friday, December 27
+
+  🎯 Working on: flow-cli (2h 15m)
+
+  Today's wins:
+     💻 Added hop command documentation
+     📝 Updated Quick Start guide
+
+  Active Projects:
+     🔧 flow-cli        [ 85%] → Documentation enhancement
+```
+
+### week
+
+Weekly review helper showing session stats and wins:
+
+```bash
+week
+```
+
+Output:
+
+```
+📊 WEEKLY REVIEW
+Week of December 27, 2025
+
+  Sessions this week:
+    Mon: flow-cli (3h), rmediation (1h)
+    Tue: stat-440 (2h)
+    Wed: flow-cli (4h)
+    ...
+
+  Wins this week:
+     🚀 Deployed v4.0.1
+     💻 Added win categories
+     📝 Updated documentation
+     ...
+
+  Take a moment to celebrate progress! 🎉
+```
+
+---
+
+## Aliases
+
+| Alias | Command      |
+| ----- | ------------ |
+| `am`  | `morning -q` |
+
+---
+
+## How Suggestions Work
+
+The `morning` command suggests projects based on:
+
+1. **Priority** - P1/P0 projects are suggested first
+2. **Status** - Active projects only
+3. **Recency** - Recently worked projects get priority
+
+---
+
+## Tips
+
+!!! tip "Make It a Habit"
+Run `morning` as the first command when you open your terminal. It sets the context for your day.
+
+!!! tip "Quick Mode for Busy Days"
+Use `morning -q` (or just `am`) when you're in a rush but still want to see the essentials.
+
+!!! tip "Follow the Suggestion"
+If you're not sure what to work on, just follow the suggestion. Reducing decision fatigue is the goal.
+
+!!! tip "Use with js"
+After `morning`, run `js` (just-start) to let the system pick and open a project for you automatically.
+
+---
+
+## Workflow Example
+
+```bash
+# Start your day
+morning
+
+# Follow the suggestion or pick your own
+work flow-cli     # Explicit choice
+# or
+js                # Let system decide
+
+# ... do your work ...
+
+# Check progress later
+today
+
+# End of week
+week              # Review accomplishments
+```
+
+---
+
+## Related Commands
+
+| Command                 | Description                     |
+| ----------------------- | ------------------------------- |
+| [`work`](work.md)       | Start focused work session      |
+| [`dash`](dash.md)       | Project dashboard               |
+| `js`                    | Just start (auto-picks project) |
+| [`timer`](timer.md)     | Focus timer                     |
+| [`capture`](capture.md) | View inbox with `inbox`         |
+
+---
+
+## See Also
+
+- [First Session Tutorial](../tutorials/01-first-session.md)
+- [Dopamine Features Guide](../guides/DOPAMINE-FEATURES-GUIDE.md)
+- [Workflow Quick Reference](../reference/WORKFLOW-QUICK-REFERENCE.md)

--- a/docs/commands/pick.md
+++ b/docs/commands/pick.md
@@ -1,0 +1,179 @@
+# pick
+
+> Interactive project picker with fzf
+
+The `pick` command provides an interactive, ADHD-friendly way to select and navigate to projects. It supports category filtering, fuzzy matching, and smart session resume.
+
+---
+
+## Usage
+
+```bash
+pick [options] [category|project-name]
+```
+
+## Arguments
+
+| Argument       | Description                          |
+| -------------- | ------------------------------------ |
+| `category`     | Filter by category (r, dev, q, etc.) |
+| `project-name` | Fuzzy match for direct jump          |
+
+## Options
+
+| Flag        | Description                             |
+| ----------- | --------------------------------------- |
+| `--fast`    | Skip git status checks (faster loading) |
+| `-a, --all` | Force full picker (skip direct jump)    |
+
+---
+
+## Categories
+
+| Shortcut            | Category          | Icon |
+| ------------------- | ----------------- | ---- |
+| `r`, `R`, `rpkg`    | R packages        | 📦   |
+| `dev`, `DEV`        | Development tools | 🔧   |
+| `q`, `qu`, `quarto` | Quarto projects   | 📝   |
+| `teach`, `teaching` | Teaching courses  | 🎓   |
+| `rs`, `research`    | Research projects | 🔬   |
+| `app`, `apps`       | Applications      | 📱   |
+
+---
+
+## Examples
+
+### Interactive Picker
+
+```bash
+# Show all projects
+pick
+
+# Filter by category
+pick dev         # Development tools only
+pick r           # R packages only
+pick teach       # Teaching courses only
+```
+
+### Direct Jump
+
+```bash
+# Jump directly to matching project
+pick flow        # → cd to flow-cli (if unique match)
+pick med         # → cd to mediationverse
+
+# If multiple matches, shows filtered picker
+pick stat        # Shows all projects containing "stat"
+```
+
+### Category Aliases
+
+```bash
+pickr            # pick r
+pickdev          # pick dev
+pickq            # pick q
+```
+
+---
+
+## Smart Resume
+
+When you run `pick` without arguments and have a recent session (< 24 hours), you'll see:
+
+```
+╔════════════════════════════════════════════════════════════╗
+║  🔍 PROJECT PICKER                                          ║
+╚════════════════════════════════════════════════════════════╝
+
+  💡 Last: flow-cli (2h ago)
+  [Enter] Resume  │  [Space] Browse all  │  Type to search...
+```
+
+| Key   | Action                          |
+| ----- | ------------------------------- |
+| Enter | Resume last project             |
+| Space | Bypass resume, show full picker |
+| Type  | Search/filter projects          |
+
+---
+
+## Interactive Keys
+
+While in the fzf picker:
+
+| Key    | Action                  |
+| ------ | ----------------------- |
+| Enter  | Go to project directory |
+| Ctrl-S | View .STATUS file       |
+| Ctrl-L | View git log            |
+| Ctrl-C | Exit without action     |
+
+---
+
+## Output
+
+When selecting a project:
+
+```
+  📂 /Users/dt/projects/dev-tools/flow-cli
+```
+
+When viewing .STATUS (Ctrl-S):
+
+```
+  📊 .STATUS file for: flow-cli
+
+  ## Status: Active
+  ## Phase: v4.0.1 Released
+  ## Focus: Documentation enhancement
+```
+
+---
+
+## Configuration
+
+Projects are discovered from `$FLOW_PROJECTS_ROOT` (default: `~/projects`). Categories are defined in:
+
+```bash
+PROJ_CATEGORIES=(
+    "r-packages/active:r:📦"
+    "r-packages/stable:r:📦"
+    "dev-tools:dev:🔧"
+    "teaching:teach:🎓"
+    "research:rs:🔬"
+    "quarto/manuscripts:q:📝"
+    "quarto/presentations:q:📊"
+    "apps:app:📱"
+)
+```
+
+---
+
+## Tips
+
+!!! tip "Direct Jump for Speed"
+If you know your project name, use direct jump: `pick flow` is faster than browsing the full picker.
+
+!!! tip "Category Filtering"
+When you have many projects, filter by category first: `pick dev` shows only dev tools.
+
+!!! tip "Resume Your Session"
+Just press Enter when the resume hint appears to continue where you left off.
+
+---
+
+## Related Commands
+
+| Command           | Description                   |
+| ----------------- | ----------------------------- |
+| [`work`](work.md) | Start session (includes pick) |
+| [`hop`](hop.md)   | Quick switch (tmux)           |
+| [`dash`](dash.md) | View all projects dashboard   |
+
+---
+
+## See Also
+
+- [`work`](work.md) - Start a full work session
+- [`hop`](hop.md) - Quick project switch with tmux
+- [Workflow Quick Reference](../reference/WORKFLOW-QUICK-REFERENCE.md)

--- a/docs/commands/timer.md
+++ b/docs/commands/timer.md
@@ -1,0 +1,205 @@
+# timer
+
+> Focus and break timer for ADHD-friendly time management
+
+The `timer` command provides Pomodoro-style focus timers with visual countdown, break reminders, and macOS notifications.
+
+---
+
+## Usage
+
+```bash
+timer [command] [options]
+```
+
+## Commands
+
+| Command     | Alias | Description                     |
+| ----------- | ----- | ------------------------------- |
+| `[minutes]` | -     | Start focus timer (default: 25) |
+| `focus`     | -     | Start focus session             |
+| `break`     | `brk` | Start break timer (default: 5)  |
+| `pomodoro`  | `pom` | Run pomodoro cycles             |
+| `stop`      | -     | Cancel active timer             |
+| `status`    | `st`  | Show remaining time             |
+| `help`      | `-h`  | Show help                       |
+
+---
+
+## Examples
+
+### Quick Start
+
+```bash
+# Default 25-minute focus timer
+timer
+
+# Custom duration
+timer 45           # 45 minutes
+
+# 5-minute break
+timer break
+```
+
+### Focus Sessions
+
+```bash
+# Start focus session with label
+timer focus 30 "Finish documentation"
+
+# Check remaining time
+timer status
+# ⏱️ focus: 23:45 remaining
+#    Finish documentation
+```
+
+### Pomodoro Cycles
+
+```bash
+# Run 4 pomodoro cycles (default)
+timer pomodoro
+
+# Custom: 6 cycles, 30-min focus, 5-min break, 20-min long break
+timer pomodoro 6 30 5 20
+
+# Shortcut alias
+pom                # Same as: timer pomodoro
+```
+
+---
+
+## Visual Output
+
+### Focus Timer
+
+```
+🎯 FOCUS MODE
+Focus session - 25 minutes
+
+  ⏱️  23:45 [████████████░░░░░░░░]
+```
+
+### Break Timer
+
+```
+☕ BREAK TIME
+5 minutes - stretch, hydrate, move
+
+  ☕ 4:23 remaining
+```
+
+### Pomodoro
+
+```
+🍅 POMODORO
+4 cycles: 25m focus, 5m break
+
+━━━ Cycle 1 of 4 ━━━
+```
+
+---
+
+## Notifications
+
+On macOS, `timer` sends system notifications when timers complete:
+
+- **Focus complete:** Glass sound
+- **Break over:** Ping sound
+
+---
+
+## Timer State
+
+Timers save state to `$FLOW_DATA_DIR/timer.state`, allowing you to:
+
+- Check status from any terminal
+- Cancel from any terminal
+- Resume awareness after terminal switch
+
+```bash
+# From any terminal
+timer status
+timer stop
+```
+
+---
+
+## Integration with Work Sessions
+
+The `timer` command integrates with the work flow:
+
+```bash
+# Start working
+work my-project
+
+# Start a focus block
+timer 45 "Complete feature X"
+
+# Timer leaves a breadcrumb
+# 🍞 Started 45 min focus: Complete feature X
+
+# When done
+finish "Completed feature X"
+```
+
+---
+
+## Pomodoro Options
+
+```bash
+timer pomodoro [cycles] [focus] [break] [long-break]
+```
+
+| Parameter    | Default | Description                    |
+| ------------ | ------- | ------------------------------ |
+| `cycles`     | 4       | Number of pomodoro cycles      |
+| `focus`      | 25      | Focus duration (minutes)       |
+| `break`      | 5       | Short break duration (minutes) |
+| `long-break` | 15      | Long break after all cycles    |
+
+**Long break logic:**
+
+- After every 4th cycle: long break
+- After final cycle: long break
+
+---
+
+## Tips
+
+!!! tip "Start Small"
+If 25 minutes feels too long, start with `timer 15`. Build up gradually.
+
+!!! tip "Respect the Break"
+When the break timer starts, actually step away. The short break is essential for ADHD focus management.
+
+!!! tip "Use Labels"
+`timer 25 "Fix the auth bug"` helps you remember what you were doing when you return.
+
+!!! tip "Interrupt = Stop"
+Press `Ctrl+C` to interrupt any timer. Your session state is preserved.
+
+---
+
+## Aliases
+
+| Alias | Command          |
+| ----- | ---------------- |
+| `pom` | `timer pomodoro` |
+
+---
+
+## Related Commands
+
+| Command                 | Description                |
+| ----------------------- | -------------------------- |
+| [`work`](work.md)       | Start focused work session |
+| [`finish`](finish.md)   | End session                |
+| [`morning`](morning.md) | Morning startup routine    |
+| `flow break`            | Take a proper break        |
+
+---
+
+## See Also
+
+- [Dopamine Features Guide](../guides/DOPAMINE-FEATURES-GUIDE.md)
+- [Workflow Quick Reference](../reference/WORKFLOW-QUICK-REFERENCE.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,9 +137,14 @@ nav:
       - Existing System Summary: reference/EXISTING-SYSTEM-SUMMARY.md
       - ZSH Clean Workflow: reference/ZSH-CLEAN-WORKFLOW.md
   - Commands:
+      - flow (main): commands/flow.md
       - work: commands/work.md
       - finish: commands/finish.md
+      - hop: commands/hop.md
+      - pick: commands/pick.md
       - capture (win/yay/catch): commands/capture.md
+      - timer: commands/timer.md
+      - morning: commands/morning.md
       - dash: commands/dash.md
       - status: commands/status.md
       - sync: commands/sync.md


### PR DESCRIPTION
## Summary
- Add 5 missing command documentation files (Phase 2 of docs enhancement plan)
- Update mkdocs.yml navigation to include new commands

## New Documentation
| Command | Purpose |
|---------|---------|
| `flow` | Main CLI dispatcher with all subcommands |
| `hop` | Quick project switch with tmux session management |
| `pick` | Interactive project picker with fzf |
| `timer` | Focus and break timers (pomodoro) |
| `morning` | ADHD-friendly daily startup routine |

## Related
- Continues work from PR #40 (Phase 1)
- Addresses remaining gaps identified in `docs/planning/DOCS-ENHANCEMENT-PLAN.md`

## Test plan
- [x] `mkdocs build` completes without errors
- [x] New command docs render correctly in navigation
- [ ] Verify links work on live site after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)