### PR TITLE
docs: add collapsible demo to front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,34 @@ finish             # Done
 ```
 
 !!! success "That's the whole workflow"
-Everything else is optional enhancement.
+    Everything else is optional enhancement.
+
+??? example "📺 See it in action"
+    ```
+    $ work my-project
+    🚀 Starting session: my-project
+       📍 ~/projects/my-project
+
+    $ win "Fixed the login bug"
+    🔧 fix: Fixed the login bug
+       ✨ Win #1 today!
+
+    $ win "Added unit tests"
+    🧪 test: Added unit tests
+       ✨ Win #2 today!
+
+    $ yay
+    ╭──────────────────────────────────────╮
+    │ 🏆 Today's Wins (2)                 │
+    ├──────────────────────────────────────┤
+    │ 🔧 Fixed the login bug              │
+    │ 🧪 Added unit tests                 │
+    ╰──────────────────────────────────────╯
+       🔥 2-day streak!
+
+    $ finish
+    ✅ Session complete (47 min, 2 wins)
+    ```
 
 ---
 


### PR DESCRIPTION
Adds the same **📺 See it in action** demo to docs/index.md.

Uses MkDocs `???` admonition for native collapsible styling that matches the site theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)