### PR TITLE
chore: ignore docs markdown in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,6 @@ package-lock.json
 cli/node_modules
 cli/coverage
 docs/archive/2025-12-20-app-removal
+
+# MkDocs markdown - prettier breaks admonition formatting
+docs/**/*.md


### PR DESCRIPTION
Prevents prettier from breaking MkDocs admonition formatting.

## Problem
MkDocs admonitions (`???` collapsible blocks, `!!!` callouts) require specific 4-space indentation. Prettier reformats these, breaking the rendering.

## Solution
Add `docs/**/*.md` to `.prettierignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)