### PR TITLE
fix: resolve broken relative links in docs

### DIFF
--- a/docs/api/API-REFERENCE.md
+++ b/docs/api/API-REFERENCE.md
@@ -1357,7 +1357,7 @@ describe('Session Entity', () => {
 - [Architecture Overview](../architecture/README.md)
 - [ADR-002: Clean Architecture](../decisions/ADR-002-adopt-clean-architecture.md)
 - [Getting Started Guide](../getting-started/quick-start.md)
-- [CLI Commands Reference](../commands/)
+- [CLI Commands Reference](../reference/COMMAND-QUICK-REFERENCE.md)
 - [Testing Guide](../testing/TESTING.md)
 
 ---

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -369,7 +369,7 @@ The `doctor` command follows these principles:
 ## See Also
 
 - [Setup Guide](../getting-started/quick-start.md) - First-time setup
-- [Brewfile](../../setup/Brewfile) - All recommended tools
+- [Brewfile](https://github.com/Data-Wise/flow-cli/blob/main/setup/Brewfile) - All recommended tools
 - [DISPATCHER-REFERENCE.md](../reference/DISPATCHER-REFERENCE.md) - Command reference
 
 ---


### PR DESCRIPTION
Fixes mkdocs build warnings about unrecognized relative links.

## Changes
- `API-REFERENCE.md`: Changed `../commands/` → `../reference/COMMAND-QUICK-REFERENCE.md`
- `doctor.md`: Changed `../../setup/Brewfile` → GitHub source URL

## Why
MkDocs can't resolve directory links or links outside the docs folder. These now point to valid targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)