### PR TITLE
ci: make link check blocking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,6 @@ jobs:
   link-check:
     name: Documentation Link Check
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout code
@@ -202,7 +201,7 @@ jobs:
             --exclude '127.0.0.1'
             --no-progress
             'docs/**/*.md'
-          fail: false
+          fail: true
 
       - name: Link Check Summary
         if: always()


### PR DESCRIPTION
Makes the documentation link check a required CI check.

## Changes
- Removed `continue-on-error: true`
- Set `fail: true` in lychee action

PRs with broken documentation links will now fail CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)