### PR TITLE
chore: bump version to 4.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v4.0.1)
+- **Status:** Production ready (v4.1.0)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -38,7 +38,7 @@ flow doctor       # Health check (verify dependencies)
 flow doctor --fix # Interactive install missing tools
 ```
 
-### Dopamine Features (v4.0.0)
+### Dopamine Features (v4.1.0)
 
 ```bash
 win <text>        # Log accomplishment (auto-categorized)
@@ -366,7 +366,7 @@ export FLOW_DEBUG=1
 
 ## Current Status (2025-12-27)
 
-### ✅ v4.0.1 Released
+### ✅ v4.1.0 Released
 
 - [x] Unified sync command (`flow sync all`)
 - [x] Dopamine features (win tracking, streaks, goals)
@@ -460,10 +460,10 @@ git diff
 
 # Commit and tag
 git add -A && git commit -m "chore: bump version to 3.7.0"
-git tag -a v4.0.1 -m "v4.0.1"
+git tag -a v4.1.0 -m "v4.1.0"
 
 # Push (requires PR for protected branch)
-git push origin main && git push origin v4.0.1
+git push origin main && git push origin v4.1.0
 ```
 
 **Files updated by release script:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.0.1-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.1.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump version to 4.1.0 in package.json, README.md, CLAUDE.md

## Release Notes (v4.1.0)

### New Features
- `g feature` commands (start, sync, list, finish)
- `g promote` - Create PR: feature → dev
- `g release` - Create PR: dev → main
- Workflow guard for protected branches (main, dev)
- `wt` dispatcher for git worktree management

### Tests
- 33 new tests (16 for g feature, 17 for wt dispatcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)