### PR TITLE
chore: add v4.2.0 roadmap (#67)

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -319,7 +319,21 @@ FLOW_QUIET=1               # Disable welcome message
 - [x] Documentation updated (DISPATCHER-REFERENCE.md)
 - [x] See: docs/decisions/PROPOSAL-GIT-FEATURE-WORKFLOW.md
 
-### v4.2.0 - Team & Remote (Future)
+### v4.2.0 - Git Workflow Enhancements (Future)
+- [ ] Hotfix workflow
+  - [ ] `g hotfix start <name>` - Create hotfix from main
+  - [ ] `g hotfix finish` - Merge to main AND dev
+  - [ ] Cherry-pick support for urgent fixes
+- [ ] Branch cleanup
+  - [ ] Auto-delete feature branches after merge
+  - [ ] `g feature prune` - Clean merged feature branches
+  - [ ] Integration with `wt clean` for worktrees
+- [ ] Worktree + Claude integration
+  - [ ] `cc wt <branch>` - Launch Claude in worktree
+  - [ ] Worktree-aware project detection
+  - [ ] Session isolation per worktree
+
+### v4.3.0 - Team & Remote (Future)
 - [ ] Remote state sync
   - [ ] Optional cloud backup
   - [ ] Multi-device support
@@ -414,6 +428,8 @@ FLOW_QUIET=1               # Disable welcome message
 ## last_active: 2025-12-29 12:45
 
 ## Session Log (continued)
+- 2025-12-29: PLAN - Added v4.2.0 roadmap (hotfix, branch cleanup, worktree+claude)
+- 2025-12-29: DOCS - Site updated for v4.1.0 (PR #66), deployed to GitHub Pages
 - 2025-12-29: v4.1.0 RELEASE - Git Feature Branch Workflow
 - 2025-12-29: FEAT - Added `g feature` commands (start, sync, list, finish)
 - 2025-12-29: FEAT - Added `g promote` (PR: feature → dev) and `g release` (PR: dev → main)

--- a/docs/index.md
+++ b/docs/index.md
@@ -201,4 +201,4 @@ Commands that adapt to your project:
 
 ---
 
-**v4.0.1** · Pure ZSH · MIT License
+**v4.1.0** · Pure ZSH · MIT License

--- a/docs/reference/COMMAND-QUICK-REFERENCE.md
+++ b/docs/reference/COMMAND-QUICK-REFERENCE.md
@@ -29,7 +29,7 @@ g                   # Status (short)
 g status            # Full status
 g add .             # Stage all
 g commit "msg"      # Commit with message
-g push              # Push to remote
+g push              # Push to remote (with workflow guard)
 g pull              # Pull from remote
 g log               # Pretty log (20 lines)
 g branch            # List branches
@@ -38,6 +38,29 @@ g stash             # Stash changes
 g stash pop         # Pop stash
 g undo              # Undo last commit (keep changes)
 g help              # Show all commands
+```
+
+**Feature Workflow (v4.1.0):**
+
+```bash
+g feature start <n> # Create feature/<n> from dev
+g feature sync      # Rebase feature onto dev
+g feature list      # List feature/hotfix branches
+g feature finish    # Push + create PR to dev
+g promote           # Create PR: feature → dev
+g release           # Create PR: dev → main
+```
+
+### Git Worktrees: `wt`
+
+```bash
+wt                  # Navigate to worktrees folder
+wt list             # List all worktrees
+wt create <branch>  # Create worktree for branch
+wt move             # Move current branch to worktree
+wt remove <path>    # Remove a worktree
+wt clean            # Prune stale worktrees
+wt help             # Show all commands
 ```
 
 ### Quarto Publishing: `qu`


### PR DESCRIPTION
* docs: update site for v4.1.0 release (#66)

- Update version badge: 4.0.1 → 4.1.0
- Add g feature workflow commands to quick reference
- Add wt dispatcher to quick reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>

* chore: add v4.2.0 roadmap with future enhancements

- Hotfix workflow (g hotfix start/finish)
- Branch cleanup (auto-delete, g feature prune)
- Worktree + Claude integration (cc wt <branch>)
- Bumped Team & Remote to v4.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>