### PR TITLE
chore: simplify v4.2.0 roadmap - remove hotfix workflow (#71)

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -319,17 +319,14 @@ FLOW_QUIET=1               # Disable welcome message
 - [x] Documentation updated (DISPATCHER-REFERENCE.md)
 - [x] See: docs/decisions/PROPOSAL-GIT-FEATURE-WORKFLOW.md
 
-### v4.2.0 - Git Workflow Enhancements (Future)
-- [ ] Hotfix workflow
-  - [ ] `g hotfix start <name>` - Create hotfix from main
-  - [ ] `g hotfix finish` - Merge to main AND dev
-  - [ ] Cherry-pick support for urgent fixes
+### v4.2.0 - Workflow Polish (Future)
 - [ ] Branch cleanup
-  - [ ] Auto-delete feature branches after merge
-  - [ ] `g feature prune` - Clean merged feature branches
+  - [ ] `g feature prune` - Delete merged feature branches
+  - [ ] `g feature prune --all` - Also clean remote tracking branches
   - [ ] Integration with `wt clean` for worktrees
+  - [ ] Note: Rich interactive cleanup → aiterm (`ait feature cleanup`)
 - [ ] Worktree + Claude integration
-  - [ ] `cc wt <branch>` - Launch Claude in worktree
+  - [ ] `cc wt <branch>` - Launch Claude in worktree (creates if needed)
   - [ ] Worktree-aware project detection
   - [ ] Session isolation per worktree
 

--- a/docs/decisions/PROPOSAL-GIT-FEATURE-WORKFLOW.md
+++ b/docs/decisions/PROPOSAL-GIT-FEATURE-WORKFLOW.md
@@ -734,15 +734,15 @@ Full documentation for the wt dispatcher.
 
 | Task | Priority | Status |
 |------|----------|--------|
-| Add `_g_hotfix()` to g-dispatcher.zsh | P0 | 🔲 |
-| Add `_g_hotfix_finish()` with dual-merge | P0 | 🔲 |
-| Update workflow guard for hotfix branches | P0 | 🔲 |
-| Add `g feature prune` for branch cleanup | P1 | 🔲 |
+| Add `g feature prune` for branch cleanup | P0 | 🔲 |
+| Add `g feature prune --all` for remote cleanup | P0 | 🔲 |
 | Integrate prune with `wt clean` | P1 | 🔲 |
 | Add `cc wt <branch>` to cc-dispatcher.zsh | P1 | 🔲 |
 | Update project-detector for worktree paths | P2 | 🔲 |
-| Create `tests/test-g-hotfix.zsh` | P2 | 🔲 |
+| Create `tests/test-g-feature-prune.zsh` | P2 | 🔲 |
 | Update DISPATCHER-REFERENCE.md | P2 | 🔲 |
+
+*Note: Hotfix workflow removed - see "Why No Hotfix Workflow?" section*
 
 ---
 
@@ -779,25 +779,9 @@ Full documentation for the wt dispatcher.
 
 ## Future Enhancements (v4.2.0 Roadmap)
 
-Building on v4.1.0's foundation, the following enhancements are planned:
+Building on v4.1.0's foundation, these enhancements are planned:
 
-### 1. Hotfix Workflow 🚨
-
-**Why it fits:** The current workflow handles features well (`feature/* → dev → main`), but urgent production fixes need a faster path. Hotfixes should go directly to main AND be merged back to dev.
-
-```bash
-g hotfix start <name>   # Create hotfix/* from main
-g hotfix finish         # Merge to main AND cherry-pick to dev
-```
-
-**Flow diagram:**
-```
-main ◄─── hotfix/urgent ───► dev (cherry-pick)
-  │                            │
-  └──────── normal flow ───────┘
-```
-
-### 2. Branch Cleanup 🧹
+### 1. Branch Cleanup 🧹
 
 **Why it fits:** After PRs merge, stale branches accumulate. This automates cleanup.
 
@@ -810,8 +794,9 @@ g feature prune --all   # Also delete remote tracking branches
 - Coordinates with `wt clean` for worktree cleanup
 - Respects protected branches (main, dev)
 - Safe by default (only merged branches)
+- Note: Rich interactive cleanup → aiterm (`ait feature cleanup`)
 
-### 3. Worktree + Claude Integration 🤖
+### 2. Worktree + Claude Integration 🤖
 
 **Why it fits:** You use worktrees for parallel development and Claude for coding. Combining them enables seamless context switching.
 
@@ -831,11 +816,16 @@ cc wt auth              # → Opens Claude in ~/.git-worktrees/project/feature-a
 
 | v4.1.0 Foundation | v4.2.0 Enhancement |
 |-------------------|---------------------|
-| `g feature start` | `g hotfix start` (same pattern, different base) |
-| `g feature finish` → dev | `g hotfix finish` → main + dev |
 | `wt create` | `cc wt` (Claude integration) |
 | `wt clean` | `g feature prune` (branch cleanup) |
-| Workflow guards | Extended for hotfix branches |
+
+### Why No Hotfix Workflow?
+
+Hotfix workflows (`g hotfix start/finish`) were considered but **removed** because:
+- flow-cli is a personal dev tool, not production software
+- No urgent production pressure requiring faster paths
+- Normal feature workflow is already fast (~2 minutes end-to-end)
+- Adds complexity without clear benefit for solo development
 
 **Design principle:** v4.2.0 fills gaps in the workflow without changing the core patterns.
 


### PR DESCRIPTION
Removed g hotfix commands from v4.2.0 roadmap:
- flow-cli is personal dev tool, not production software
- Normal feature workflow is fast enough (~2 min)
- Adds complexity without clear benefit

Remaining v4.2.0 scope:
- g feature prune (branch cleanup)
- cc wt <branch> (worktree + Claude integration)

Added note about aiterm split:
- flow-cli: quick cleanup (g feature prune)
- aiterm: rich interactive cleanup (ait feature cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>