### PR TITLE
chore: sync version to 4.2.0 and update nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.1.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.2.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,8 @@ nav:
       - ADR-002 Clean Architecture: decisions/ADR-002-adopt-clean-architecture.md
       - ADR-003 Bridge Pattern: decisions/ADR-003-bridge-pattern.md
       - ADR-004 Module API: decisions/ADR-004-module-api-not-rest.md
+  - Planning:
+      - v4.3.0+ Roadmap: planning/V4.3-ROADMAP.md
   # Project Status files removed - they're root-level project tracking docs
   # with internal links that break in mkdocs context
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Version sync and nav update from `/craft:docs:update`

## Changes

- `package.json`: Bump version to 4.2.0
- `README.md`: Update version badge to 4.2.0
- `mkdocs.yml`: Add Planning section with V4.3-ROADMAP.md

## Test plan

- [x] mkdocs build passes
- [x] All links valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)