### PR TITLE
docs: add tutorials for git feature workflow and worktrees

### DIFF
--- a/docs/guides/WORKFLOWS-QUICK-WINS.md
+++ b/docs/guides/WORKFLOWS-QUICK-WINS.md
@@ -21,6 +21,8 @@
 | 8   | [Focus Mode](#8-focus-mode-deep-work)                      | setup  | 🟢   | Need concentration     |
 | 9   | [Start Feature](#9-start-new-feature)                      | 2 min  | 🟢   | Beginning new work     |
 | 10  | [Emergency Recovery](#what-did-i-break-emergency-recovery) | varies | 🔴   | Something broke        |
+| 11  | [Git Feature Workflow](#11-git-feature-branch-workflow-v410) | 2 min  | 🟢 | Feature branches       |
+| 12  | [Worktrees](#12-parallel-development-with-worktrees-v410)    | 1 min  | 🟢 | Parallel development   |
 
 **Cognitive Load:** 🟢 Easy | 🟡 Medium | 🔴 Hard
 
@@ -793,16 +795,148 @@ rtest → git commit -m "wip: progress on X" → Update .STATUS for tomorrow
 
 ---
 
+## 1️⃣1️⃣ Git Feature Branch Workflow (v4.1.0+)
+
+**When:** Working on new features, hotfixes, or any code changes
+**Time:** ~2 minutes | **Load:** 🟢 Easy | **Safety:** 🟢 Safe
+
+### Commands
+
+```bash
+# Start a feature
+g feature start auth-improvements
+
+# Work on your feature...
+g add . && g commit "Add OAuth2 support"
+
+# Stay synced with dev
+g feature sync
+
+# Finish: push + create PR
+g feature finish
+```
+
+### Visual Flow
+
+```
+Start → feature start → code → commit → sync → finish → PR → merge
+```
+
+### Quick Reference
+
+| Command                    | What It Does                    |
+|----------------------------|---------------------------------|
+| `g feature start <name>`   | Create feature branch from dev  |
+| `g feature sync`           | Rebase feature onto dev         |
+| `g feature list`           | List feature/hotfix branches    |
+| `g feature finish`         | Push + create PR to dev         |
+| `g promote`                | Create PR: feature → dev        |
+| `g release`                | Create PR: dev → main           |
+| `g feature prune`          | Delete merged branches          |
+
+### Workflow Guard
+
+The workflow guard blocks direct pushes to protected branches:
+
+```bash
+# Blocked ❌
+git checkout main && g push   # Direct push to main blocked
+
+# Allowed ✅
+g feature start my-fix        # Create feature branch
+g push                        # Push feature branch OK
+g promote                     # Create PR instead
+```
+
+### Pro Tips
+
+💡 Run `g feature sync` daily to avoid merge conflicts
+💡 Use `g feature finish` to push + create PR in one step
+💡 Clean up with `g feature prune` weekly
+
+---
+
+## 1️⃣2️⃣ Parallel Development with Worktrees (v4.1.0+)
+
+**When:** Need to work on multiple features simultaneously
+**Time:** ~1 minute | **Load:** 🟢 Easy | **Safety:** 🟢 Safe
+
+### Commands
+
+```bash
+# Create worktree for a branch
+wt create feature/auth
+
+# List all worktrees
+wt list
+
+# Navigate to worktrees folder
+wt
+
+# Clean up stale worktrees
+wt clean
+```
+
+### Visual Flow
+
+```
+Main work → wt create feature/b → Parallel work → wt clean
+```
+
+### Claude Code + Worktrees
+
+Launch Claude in a dedicated worktree:
+
+```bash
+# Launch Claude in worktree (creates if needed)
+cc wt feature/auth
+
+# Pick from existing worktrees
+cc wt pick
+
+# Worktree + YOLO mode
+cc wt yolo feature/risky
+
+# Worktree + Plan mode
+cc wt plan feature/complex
+```
+
+### Aliases
+
+| Alias  | Expands To     | Description           |
+|--------|----------------|-----------------------|
+| `ccw`  | `cc wt`        | Worktree + Claude     |
+| `ccwy` | `cc wt yolo`   | Worktree + YOLO mode  |
+| `ccwp` | `cc wt pick`   | Worktree picker       |
+
+### When to Use Worktrees
+
+- 🔀 **Parallel features** - Work on feature-a while feature-b runs tests
+- 👀 **Code review** - Review PR in isolated directory
+- 🧪 **Experiments** - Try risky changes without affecting main work
+- ⚡ **Quick fixes** - Hotfix while feature work continues
+
+### Pro Tips
+
+💡 Each worktree is completely isolated - no stashing needed
+💡 Worktrees persist after Claude exits
+💡 Use `wt clean` regularly to remove stale worktrees
+
+---
+
 ## 📖 Related Documentation
 
-- **ALIAS-REFERENCE-CARD.md** - All 28 core aliases
+- **[Git Feature Workflow Tutorial](../tutorials/08-git-feature-workflow.md)** - Full tutorial
+- **[Worktrees Tutorial](../tutorials/09-worktrees.md)** - Parallel development guide
+- **[Dispatcher Reference](../reference/DISPATCHER-REFERENCE.md)** - All dispatchers
+- **ALIAS-REFERENCE-CARD.md** - All core aliases
 - **WORKFLOW-TUTORIAL.md** - Complete tutorial
 - **PROJECT-HUB.md** - Strategic overview
 
 ---
 
-**Last Updated:** 2025-12-21
-**Version:** 2.0 (Updated for 28-alias system)
+**Last Updated:** 2025-12-30
+**Version:** 2.1 (Added Git Feature Workflow and Worktrees)
 **Time to Master:** Practice each workflow 3-5 times
 
 💡 **Pro Tip:** Bookmark this guide for quick reference!

--- a/docs/tutorials/08-git-feature-workflow.md
+++ b/docs/tutorials/08-git-feature-workflow.md
@@ -1,0 +1,349 @@
+# Tutorial: Git Feature Branch Workflow
+
+> **What you'll learn:** Use the feature branch workflow to safely develop and merge changes
+>
+> **Time:** ~15 minutes | **Level:** Intermediate
+> **Version:** v4.1.0+
+
+---
+
+## Prerequisites
+
+Before starting, you should:
+
+- [ ] Completed: [Tutorial 1: Your First Flow Session](01-first-session.md)
+- [ ] Have a git repository with `main` and `dev` branches
+- [ ] Understand basic git concepts (branches, commits, PRs)
+
+**Verify your setup:**
+
+```bash
+# Check g dispatcher is available
+g help
+
+# Check you have main and dev branches
+git branch -a | grep -E "main|dev"
+```
+
+---
+
+## What You'll Learn
+
+By the end of this tutorial, you will:
+
+1. Create feature branches from dev
+2. Keep features synced with dev
+3. Create PRs using the proper workflow
+4. Clean up merged branches
+
+---
+
+## The Workflow Pattern
+
+```
+feature/* ──► dev ──► main
+    │          │        │
+    └── PR ────┘        │
+               └── PR ──┘
+```
+
+**Key Rules:**
+
+- Never push directly to `main` or `dev`
+- All work happens on `feature/*`, `hotfix/*`, or `bugfix/*` branches
+- Use PRs to merge changes up the chain
+
+---
+
+## Part 1: Starting a Feature
+
+### Step 1.1: Create a Feature Branch
+
+```bash
+# Start a new feature from dev
+g feature start auth-improvements
+```
+
+**What happened:**
+
+```
+✅ Created feature/auth-improvements from dev
+📍 Now on: feature/auth-improvements
+```
+
+This:
+
+- Fetches latest `dev`
+- Creates `feature/auth-improvements` from `dev`
+- Switches to the new branch
+
+### Step 1.2: Verify Your Branch
+
+```bash
+# Check current branch
+g
+```
+
+**Output:**
+
+```
+On branch feature/auth-improvements
+nothing to commit, working tree clean
+```
+
+---
+
+## Part 2: Working on Your Feature
+
+### Step 2.1: Make Changes and Commit
+
+```bash
+# Make your changes...
+# Then commit
+g add .
+g commit "Add OAuth2 support"
+```
+
+### Step 2.2: Keep in Sync with Dev
+
+While you work, `dev` may have new changes. Stay synced:
+
+```bash
+# Rebase your feature onto latest dev
+g feature sync
+```
+
+**What happened:**
+
+```
+✅ Rebased feature/auth-improvements onto dev
+📊 Your branch is 3 commits ahead of dev
+```
+
+**Tip:** Run `g feature sync` daily to avoid big merge conflicts!
+
+### Step 2.3: Push Your Feature
+
+```bash
+# Push to remote
+g push
+```
+
+The workflow guard will let this through because you're on a feature branch.
+
+---
+
+## Part 3: Creating Pull Requests
+
+### Step 3.1: PR to Dev (Promote)
+
+When your feature is ready:
+
+```bash
+# Create PR: feature → dev
+g promote
+```
+
+**What happened:**
+
+```
+Creating PR: feature/auth-improvements → dev
+
+✅ PR #42 created
+   https://github.com/user/repo/pull/42
+```
+
+### Step 3.2: PR to Main (Release)
+
+Once changes are tested in dev:
+
+```bash
+# First, switch to dev
+git checkout dev
+
+# Create PR: dev → main
+g release
+```
+
+**What happened:**
+
+```
+Creating PR: dev → main
+
+✅ PR #43 created
+   https://github.com/user/repo/pull/43
+```
+
+---
+
+## Part 4: Finishing and Cleanup
+
+### Step 4.1: Finish a Feature
+
+Push and create PR in one command:
+
+```bash
+# Push + create PR to dev
+g feature finish
+```
+
+**What happened:**
+
+```
+📤 Pushing feature/auth-improvements...
+✅ Created PR #42: feature/auth-improvements → dev
+```
+
+### Step 4.2: Clean Up Merged Branches
+
+After your PRs are merged:
+
+```bash
+# See what would be deleted
+g feature prune -n
+
+# Actually delete merged branches
+g feature prune
+
+# Also clean remote tracking branches
+g feature prune --all
+```
+
+**Output:**
+
+```
+🧹 Cleaning merged feature branches...
+
+Will delete:
+  feature/auth-improvements (merged to dev)
+  feature/old-feature (merged to dev)
+
+Delete 2 branches? [y/N] y
+
+✅ Deleted 2 merged branches
+```
+
+---
+
+## Part 5: The Workflow Guard
+
+### What It Does
+
+The workflow guard protects `main` and `dev` from direct pushes:
+
+```bash
+# Try to push to main (blocked)
+git checkout main
+g push
+```
+
+**Output:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⛔ Direct push to 'main' blocked
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Workflow: feature/* → dev → main
+
+Commands:
+  g promote    Create PR: feature → dev
+  g release    Create PR: dev → main
+
+Override: GIT_WORKFLOW_SKIP=1 git push
+```
+
+### Override When Needed
+
+For emergencies only:
+
+```bash
+# Skip the guard (use sparingly!)
+GIT_WORKFLOW_SKIP=1 git push
+```
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `g feature start <name>` | Create feature branch from dev |
+| `g feature sync` | Rebase feature onto dev |
+| `g feature list` | List feature/hotfix branches |
+| `g feature finish` | Push + create PR to dev |
+| `g feature prune` | Delete merged branches |
+| `g promote` | Create PR: feature → dev |
+| `g release` | Create PR: dev → main |
+
+---
+
+## Common Scenarios
+
+### Scenario 1: Starting New Work
+
+```bash
+g feature start new-feature    # Create branch
+# ... make changes ...
+g add . && g commit "message"  # Commit
+g feature finish               # Push + PR
+```
+
+### Scenario 2: Hotfix Needed
+
+```bash
+g feature start hotfix/urgent-fix  # Use hotfix/ prefix
+# ... fix the issue ...
+g promote                          # PR to dev
+g release                          # PR to main (after dev merge)
+```
+
+### Scenario 3: Weekly Cleanup
+
+```bash
+g feature list                 # See all feature branches
+g feature prune --all          # Clean merged + remote
+```
+
+---
+
+## Troubleshooting
+
+### "Branch already exists"
+
+```bash
+# Delete old branch first
+git branch -d feature/old-name
+g feature start new-name
+```
+
+### "Rebase conflicts"
+
+```bash
+# During g feature sync, if conflicts:
+# 1. Fix conflicts in files
+# 2. git add <fixed-files>
+# 3. git rebase --continue
+```
+
+### "PR creation failed"
+
+```bash
+# Check gh is authenticated
+gh auth status
+
+# Re-authenticate if needed
+gh auth login
+```
+
+---
+
+## What's Next?
+
+- **[Tutorial 9: Worktrees](09-worktrees.md)** - Parallel development with worktrees
+- **[Git Dispatcher Reference](../reference/DISPATCHER-REFERENCE.md#1-g-git-workflows)** - All g commands
+- **[V4.3 Roadmap](../planning/V4.3-ROADMAP.md)** - Upcoming features
+
+---
+
+**Tip:** Start with `g feature start` for every new piece of work. It keeps your branches organized and your workflow clean!

--- a/docs/tutorials/09-worktrees.md
+++ b/docs/tutorials/09-worktrees.md
@@ -1,0 +1,347 @@
+# Tutorial: Git Worktrees for Parallel Development
+
+> **What you'll learn:** Use git worktrees to work on multiple branches simultaneously
+>
+> **Time:** ~10 minutes | **Level:** Intermediate
+> **Version:** v4.1.0+
+
+---
+
+## Prerequisites
+
+Before starting, you should:
+
+- [ ] Completed: [Tutorial 1: Your First Flow Session](01-first-session.md)
+- [ ] Understand basic git concepts (branches, commits)
+- [ ] Have fzf installed (optional, for pickers)
+
+**Verify your setup:**
+
+```bash
+# Check wt dispatcher is available
+wt help
+
+# Check cc wt integration
+cc wt help
+```
+
+---
+
+## What You'll Learn
+
+By the end of this tutorial, you will:
+
+1. Create and manage git worktrees
+2. Launch Claude Code in dedicated worktrees
+3. Work on multiple features in parallel
+4. Clean up worktrees when done
+
+---
+
+## Why Worktrees?
+
+**The Problem:**
+
+```
+# Traditional approach (context switching)
+git stash                    # Save current work
+git checkout feature-b       # Switch branches
+# ... work ...
+git checkout feature-a       # Switch back
+git stash pop                # Restore work
+```
+
+**The Worktree Solution:**
+
+```
+# Parallel development (no context switching!)
+~/project/              # Main worktree (feature-a)
+~/.git-worktrees/
+  └── project/
+      └── feature-b/    # Second worktree (feature-b)
+```
+
+Each worktree is a separate directory with its own working copy.
+
+---
+
+## Part 1: Basic Worktree Management
+
+### Step 1.1: List Existing Worktrees
+
+```bash
+wt list
+```
+
+**Output:**
+
+```
+/Users/you/projects/myproject  abc1234 [main]
+```
+
+### Step 1.2: Create a Worktree
+
+```bash
+# Create worktree for existing branch
+wt create feature/auth
+
+# Or for a new branch (auto-creates)
+wt create feature/new-thing
+```
+
+**What happened:**
+
+```
+✓ Created worktree: ~/.git-worktrees/myproject/feature-auth
+
+Navigate: cd ~/.git-worktrees/myproject/feature-auth
+```
+
+### Step 1.3: Navigate to Worktrees Folder
+
+```bash
+# Go to worktrees base directory
+wt
+```
+
+**Output:**
+
+```
+ℹ Changed to: /Users/you/.git-worktrees
+total 0
+drwxr-xr-x  3 you  staff  96 Dec 29 10:00 myproject
+```
+
+---
+
+## Part 2: Claude Code in Worktrees
+
+### Step 2.1: Launch Claude in a Worktree
+
+```bash
+# Launch Claude in worktree (creates if needed!)
+cc wt feature/auth
+```
+
+**What happened:**
+
+```
+ℹ Creating worktree for feature/auth...
+✓ Created worktree: ~/.git-worktrees/myproject/feature-auth
+✓ Launching Claude in ~/.git-worktrees/myproject/feature-auth
+```
+
+Claude Code opens in the worktree directory, completely isolated from your main work.
+
+### Step 2.2: Pick from Existing Worktrees
+
+```bash
+# fzf picker for worktrees
+cc wt pick
+```
+
+A picker appears showing all worktrees. Select one to launch Claude there.
+
+### Step 2.3: Mode Chaining
+
+Combine worktrees with Claude modes:
+
+```bash
+# YOLO mode in worktree
+cc wt yolo feature/risky
+
+# Plan mode in worktree
+cc wt plan feature/complex
+
+# Opus model in worktree
+cc wt opus feature/important
+
+# Haiku model in worktree
+cc wt haiku feature/quick
+```
+
+---
+
+## Part 3: Aliases for Speed
+
+### Built-in Aliases
+
+```bash
+ccw feature/auth     # = cc wt feature/auth
+ccwy feature/auth    # = cc wt yolo feature/auth
+ccwp                 # = cc wt pick
+```
+
+### Quick Reference
+
+| Alias  | Expands To        | Description              |
+|--------|-------------------|--------------------------|
+| `ccw`  | `cc wt`           | Worktree + Claude        |
+| `ccwy` | `cc wt yolo`      | Worktree + YOLO mode     |
+| `ccwp` | `cc wt pick`      | Worktree picker          |
+
+---
+
+## Part 4: Cleanup
+
+### Step 4.1: Remove a Worktree
+
+```bash
+# Remove specific worktree
+wt remove ~/.git-worktrees/myproject/feature-auth
+```
+
+**Output:**
+
+```
+✓ Removed worktree: ~/.git-worktrees/myproject/feature-auth
+```
+
+### Step 4.2: Clean Stale Worktrees
+
+```bash
+# Prune worktrees with missing directories
+wt clean
+```
+
+**Output:**
+
+```
+✓ Pruned stale worktrees
+```
+
+### Step 4.3: Move Current Branch to Worktree
+
+```bash
+# On feature/something branch
+wt move
+```
+
+Creates a worktree for your current branch. Useful for moving in-progress work to a dedicated directory.
+
+---
+
+## Workflow Patterns
+
+### Pattern 1: Parallel Feature Development
+
+```bash
+# Terminal 1: Main feature
+cc flow
+# ... work on feature-a ...
+
+# Terminal 2: Quick fix
+ccw hotfix/urgent
+# ... fix the bug ...
+# ... commit and push ...
+
+# Back to Terminal 1, no context lost!
+```
+
+### Pattern 2: Code Review
+
+```bash
+# Review PR in isolated worktree
+ccw feature/pr-123
+
+# Claude can help review without affecting your work
+cc wt plan feature/pr-123  # Plan mode for thorough review
+```
+
+### Pattern 3: Experimentation
+
+```bash
+# Try something risky in isolated worktree
+ccwy experiment/new-approach
+
+# If it doesn't work out:
+wt remove ~/.git-worktrees/project/experiment-new-approach
+git branch -D experiment/new-approach
+```
+
+---
+
+## Configuration
+
+### Worktree Base Directory
+
+```bash
+# Default location
+~/.git-worktrees/
+
+# Customize in .zshrc
+export FLOW_WORKTREE_DIR="$HOME/worktrees"
+```
+
+### Directory Structure
+
+Worktrees are organized by project:
+
+```
+~/.git-worktrees/
+├── flow-cli/
+│   ├── feature-auth/
+│   └── hotfix-urgent/
+├── mediationverse/
+│   └── feature-new-method/
+└── my-app/
+    └── feature-dashboard/
+```
+
+---
+
+## Quick Reference
+
+| Command                    | Description                         |
+|----------------------------|-------------------------------------|
+| `wt`                       | Navigate to worktrees folder        |
+| `wt list`                  | List all worktrees                  |
+| `wt create <branch>`       | Create worktree for branch          |
+| `wt move`                  | Move current branch to worktree     |
+| `wt remove <path>`         | Remove a worktree                   |
+| `wt clean`                 | Prune stale worktrees               |
+| `cc wt <branch>`           | Launch Claude in worktree           |
+| `cc wt pick`               | Pick worktree → Claude              |
+| `cc wt yolo <branch>`      | Worktree + YOLO mode                |
+
+---
+
+## Troubleshooting
+
+### "Branch already checked out"
+
+```bash
+# Can't have same branch in two worktrees
+# Solution: Use a different branch name
+wt create feature/auth-v2
+```
+
+### "Worktree not found"
+
+```bash
+# Prune stale references
+wt clean
+
+# Then try again
+wt list
+```
+
+### "Not in a git repository"
+
+```bash
+# Worktree commands must run from a git repo
+cd /path/to/your/repo
+wt list
+```
+
+---
+
+## What's Next?
+
+- **[Git Feature Workflow](08-git-feature-workflow.md)** - Feature branch workflow
+- **[CC Dispatcher Reference](../reference/CC-DISPATCHER-REFERENCE.md)** - Full Claude Code commands
+- **[Dispatcher Reference](../reference/DISPATCHER-REFERENCE.md)** - All dispatchers
+
+---
+
+**Tip:** Use `cc wt` when you need isolation for experiments, reviews, or parallel work. The worktree stays even after Claude exits!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,8 @@ nav:
       - 5. AI-Powered Commands: tutorials/05-ai-commands.md
       - 6. Dopamine Features: tutorials/06-dopamine-features.md
       - 7. Sync Command: tutorials/07-sync-command.md
+      - 8. Git Feature Workflow: tutorials/08-git-feature-workflow.md
+      - 9. Worktrees: tutorials/09-worktrees.md
   - Guides:
       - Dopamine Features: guides/DOPAMINE-FEATURES-GUIDE.md
       - Mermaid Diagrams: guides/MERMAID-DIAGRAMS-QUICK-START.md


### PR DESCRIPTION
## Summary

- Add **Tutorial 8: Git Feature Branch Workflow** - Complete guide to the v4.1.0 git feature workflow (`g feature start/sync/finish`, `g promote`, `g release`, `g feature prune`)
- Add **Tutorial 9: Worktrees** - Parallel development with git worktrees and Claude Code integration (`wt`, `cc wt`)
- Update **WORKFLOWS-QUICK-WINS.md** with workflows 11-12 covering git feature workflow and worktrees
- Update **mkdocs.yml** navigation to include new tutorials

## Test plan

- [x] `mkdocs build --strict` passes
- [x] All internal links validated
- [ ] Preview tutorials on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)