### PR TITLE
feat(v4.3.0): add cc wt status, wt prune, and g feature prune --force

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.2.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.3.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,28 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
+## [4.3.0] - 2025-12-30
+
+### Added
+
+- **cc wt status** - Show worktrees with Claude session info
+  - 🟢 Recent session (< 24h), 🟡 Old session, ⚪ No session
+  - Shows branch name and last session timestamp
+
+- **wt prune** - Comprehensive worktree cleanup
+  - Prunes stale worktree references
+  - Removes worktrees for merged feature branches
+  - `--branches` flag to also delete the merged branches
+  - `--force` to skip confirmation, `--dry-run` to preview
+
+### Changed
+
+- **g feature prune** - Now asks for confirmation before deleting
+  - `--force` flag to skip confirmation (for scripting)
+  - Safer default behavior
+
+---
+
 ## [4.2.0] - 2025-12-29
 
 ### Added

--- a/docs/planning/V4.3-ROADMAP.md
+++ b/docs/planning/V4.3-ROADMAP.md
@@ -1,8 +1,8 @@
 # v4.3.0+ Roadmap
 
 **Created:** 2025-12-29
-**Status:** Planning
-**Last Updated:** 2025-12-29
+**Status:** In Progress
+**Last Updated:** 2025-12-30
 
 This document contains detailed implementation plans for future flow-cli enhancements.
 
@@ -12,16 +12,22 @@ This document contains detailed implementation plans for future flow-cli enhance
 
 After completing v4.2.0 (Worktree + Claude Integration), these are the prioritized enhancements for future versions.
 
-| Priority | Feature | Effort | Value |
-|----------|---------|--------|-------|
-| P1 | cc wt status | ~1 hour | High |
-| P1 | cc wt clean | ~45 min | High |
-| P2 | g feature prune --force | ~30 min | Medium |
-| P2 | g feature prune --older-than | ~1 hour | Medium |
-| P2 | g feature status | ~45 min | Medium |
-| P3 | wt prune | ~1 hour | Medium |
-| P3 | wt status | ~30 min | Low |
-| P4 | Remote sync | TBD | Future |
+| Priority | Feature | Effort | Value | Status |
+|----------|---------|--------|-------|--------|
+| P1 | cc wt status | ~1 hour | High | ✅ Done |
+| P1 | cc wt clean | ~45 min | High | See wt prune |
+| P2 | g feature prune --force | ~30 min | Medium | ✅ Done |
+| P2 | g feature prune --older-than | ~1 hour | Medium | Pending |
+| P2 | g feature status | ~45 min | Medium | Pending |
+| P3 | wt prune | ~1 hour | Medium | ✅ Done |
+| P3 | wt status | ~30 min | Low | Pending |
+| P4 | Remote sync | TBD | Future | Pending |
+
+### v4.3.0 Completed Features
+
+- **cc wt status** - Shows worktrees with Claude session info (green/yellow/white indicators)
+- **g feature prune --force** - Adds confirmation prompt by default, `--force` to skip
+- **wt prune** - Comprehensive cleanup: prunes stale refs + removes merged worktrees + optionally deletes branches
 
 ---
 

--- a/lib/dispatchers/wt-dispatcher.zsh
+++ b/lib/dispatchers/wt-dispatcher.zsh
@@ -85,11 +85,19 @@ wt() {
             ;;
 
         # ─────────────────────────────────────────────────────────────
-        # CLEAN
+        # CLEAN (basic)
         # ─────────────────────────────────────────────────────────────
-        clean|prune)
+        clean)
             git worktree prune
             echo -e "${_C_GREEN}✓ Pruned stale worktrees${_C_NC}"
+            ;;
+
+        # ─────────────────────────────────────────────────────────────
+        # PRUNE (comprehensive cleanup)
+        # ─────────────────────────────────────────────────────────────
+        prune)
+            shift
+            _wt_prune "$@"
             ;;
 
         # ─────────────────────────────────────────────────────────────
@@ -224,6 +232,187 @@ _wt_remove() {
 }
 
 # ═══════════════════════════════════════════════════════════════════
+# COMPREHENSIVE PRUNE
+# ═══════════════════════════════════════════════════════════════════
+
+_wt_prune() {
+    local dry_run=false
+    local force_flag=false
+    local branches_flag=false
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run|-n) dry_run=true ;;
+            --force|-f) force_flag=true ;;
+            --branches|-b) branches_flag=true ;;
+            --help|-h) _wt_prune_help; return 0 ;;
+            *) echo -e "${_C_RED}✗ Unknown option: $1${_C_NC}"; return 1 ;;
+        esac
+        shift
+    done
+
+    echo -e "${_C_BOLD}Worktree Cleanup${_C_NC}"
+    echo -e "${_C_DIM}────────────────────────────────────────${_C_NC}"
+
+    # Step 1: Prune stale worktree references
+    echo -e "\n${_C_BLUE}Step 1:${_C_NC} Pruning stale worktree references..."
+    if [[ "$dry_run" == true ]]; then
+        git worktree prune --dry-run 2>&1 | sed 's/^/  /'
+        echo -e "  ${_C_YELLOW}(dry run)${_C_NC}"
+    else
+        git worktree prune
+        echo -e "  ${_C_GREEN}✓ Pruned stale references${_C_NC}"
+    fi
+
+    # Step 2: Find worktrees for merged branches
+    echo -e "\n${_C_BLUE}Step 2:${_C_NC} Checking for worktrees with merged branches..."
+
+    # Get base branch
+    local base_branch="dev"
+    if ! git show-ref --verify --quiet refs/heads/dev 2>/dev/null; then
+        base_branch="main"
+    fi
+
+    local protected="main master dev develop"
+    local current_branch=$(git branch --show-current 2>/dev/null)
+    local worktrees_to_remove=()
+    local branches_to_delete=()
+
+    # Parse worktree list
+    local wt_path wt_branch
+    while IFS= read -r line; do
+        case "$line" in
+            "worktree "*)
+                wt_path="${line#worktree }"
+                ;;
+            "branch "*)
+                wt_branch="${line#branch refs/heads/}"
+                ;;
+            "")
+                if [[ -n "$wt_path" && -n "$wt_branch" ]]; then
+                    # Skip protected branches
+                    if [[ " $protected " == *" $wt_branch "* ]]; then
+                        wt_path="" wt_branch=""
+                        continue
+                    fi
+                    # Skip current branch
+                    if [[ "$wt_branch" == "$current_branch" ]]; then
+                        wt_path="" wt_branch=""
+                        continue
+                    fi
+                    # Check if merged
+                    if git branch --merged "$base_branch" 2>/dev/null | grep -q "^\s*$wt_branch$"; then
+                        if [[ "$wt_branch" == feature/* || "$wt_branch" == bugfix/* || "$wt_branch" == hotfix/* ]]; then
+                            worktrees_to_remove+=("$wt_path|$wt_branch")
+                            branches_to_delete+=("$wt_branch")
+                        fi
+                    fi
+                fi
+                wt_path="" wt_branch=""
+                ;;
+        esac
+    done < <(git worktree list --porcelain 2>/dev/null; echo "")
+
+    if [[ ${#worktrees_to_remove[@]} -eq 0 ]]; then
+        echo -e "  ${_C_GREEN}✓ No merged worktrees to clean${_C_NC}"
+    else
+        echo -e "\n  ${_C_BOLD}Worktrees with merged branches:${_C_NC}"
+        for entry in "${worktrees_to_remove[@]}"; do
+            local path="${entry%%|*}"
+            local branch="${entry##*|}"
+            local short_path="${path/#$HOME/~}"
+            echo -e "    ${_C_DIM}•${_C_NC} $short_path ${_C_DIM}[$branch]${_C_NC}"
+        done
+
+        if [[ "$dry_run" == true ]]; then
+            echo -e "\n  ${_C_YELLOW}(dry run - no changes made)${_C_NC}"
+        else
+            # Confirm unless --force
+            if [[ "$force_flag" != true ]]; then
+                echo ""
+                echo -n "  Remove ${#worktrees_to_remove[@]} worktree(s)? [y/N] "
+                read -r confirm
+                if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+                    echo -e "  ${_C_YELLOW}Cancelled${_C_NC}"
+                    return 0
+                fi
+            fi
+
+            # Remove worktrees
+            local removed=0
+            for entry in "${worktrees_to_remove[@]}"; do
+                local path="${entry%%|*}"
+                if git worktree remove "$path" 2>/dev/null; then
+                    echo -e "  ${_C_GREEN}✓ Removed${_C_NC} $path"
+                    ((removed++))
+                else
+                    echo -e "  ${_C_RED}✗ Failed${_C_NC} $path"
+                fi
+            done
+            echo -e "\n  ${_C_GREEN}Removed $removed worktree(s)${_C_NC}"
+
+            # Also delete branches if --branches flag
+            if [[ "$branches_flag" == true && ${#branches_to_delete[@]} -gt 0 ]]; then
+                echo -e "\n${_C_BLUE}Step 3:${_C_NC} Deleting merged branches..."
+                local deleted=0
+                for branch in "${branches_to_delete[@]}"; do
+                    if git branch -d "$branch" 2>/dev/null; then
+                        echo -e "  ${_C_GREEN}✓ Deleted${_C_NC} $branch"
+                        ((deleted++))
+                    else
+                        echo -e "  ${_C_RED}✗ Failed${_C_NC} $branch"
+                    fi
+                done
+                echo -e "\n  ${_C_GREEN}Deleted $deleted branch(es)${_C_NC}"
+            fi
+        fi
+    fi
+
+    echo ""
+}
+
+_wt_prune_help() {
+    echo -e "
+${_C_BOLD}wt prune${_C_NC} - Comprehensive worktree cleanup
+
+${_C_YELLOW}USAGE${_C_NC}:
+  ${_C_CYAN}wt prune${_C_NC}              Clean worktrees for merged branches
+  ${_C_CYAN}wt prune --branches${_C_NC}   Also delete the merged branches
+  ${_C_CYAN}wt prune --force${_C_NC}      Skip confirmation prompts
+  ${_C_CYAN}wt prune --dry-run${_C_NC}    Show what would be cleaned
+
+${_C_YELLOW}OPTIONS${_C_NC}:
+  ${_C_CYAN}--branches, -b${_C_NC}  Also delete merged branches
+  ${_C_CYAN}--force, -f${_C_NC}     Skip confirmation prompts
+  ${_C_CYAN}--dry-run, -n${_C_NC}   Preview without changes
+  ${_C_CYAN}--help, -h${_C_NC}      Show this help
+
+${_C_YELLOW}WHAT IT DOES${_C_NC}:
+  1. Prunes stale worktree references
+  2. Finds worktrees for merged feature branches
+  3. Removes those worktrees (with confirmation)
+  4. Optionally deletes the merged branches
+
+${_C_YELLOW}SAFE BY DEFAULT${_C_NC}:
+  • Asks for confirmation before removing
+  • Only targets merged feature/bugfix/hotfix branches
+  • Never removes main, master, dev, develop
+  • Never removes current branch
+
+${_C_YELLOW}EXAMPLES${_C_NC}:
+  ${_C_DIM}\$${_C_NC} wt prune             ${_C_DIM}# Clean merged worktrees${_C_NC}
+  ${_C_DIM}\$${_C_NC} wt prune -n          ${_C_DIM}# Preview what would be cleaned${_C_NC}
+  ${_C_DIM}\$${_C_NC} wt prune -b          ${_C_DIM}# Also delete branches${_C_NC}
+  ${_C_DIM}\$${_C_NC} wt prune -bf         ${_C_DIM}# Delete all, no confirmation${_C_NC}
+
+${_C_YELLOW}SEE ALSO${_C_NC}:
+  ${_C_DIM}g feature prune${_C_NC}     Clean merged branches (without worktrees)
+  ${_C_DIM}wt clean${_C_NC}            Simple git worktree prune
+"
+}
+
+# ═══════════════════════════════════════════════════════════════════
 # HELP SYSTEM
 # ═══════════════════════════════════════════════════════════════════
 
@@ -252,7 +441,8 @@ ${_C_BLUE}📋 COMMANDS${_C_NC}:
   ${_C_CYAN}wt create <b>${_C_NC}    Create worktree for branch
   ${_C_CYAN}wt move${_C_NC}          Move current branch to worktree
   ${_C_CYAN}wt remove <path>${_C_NC} Remove a worktree
-  ${_C_CYAN}wt clean${_C_NC}         Prune stale worktrees
+  ${_C_CYAN}wt clean${_C_NC}         Prune stale worktree references
+  ${_C_CYAN}wt prune${_C_NC}         Clean worktrees for merged branches
 
 ${_C_BLUE}⚙️ CONFIGURATION${_C_NC}:
   ${_C_DIM}FLOW_WORKTREE_DIR${_C_NC}  Worktree base directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Implements v4.3.0 features from the roadmap:

### New Features

**cc wt status** - Show worktrees with Claude session info
- 🟢 Recent session (< 24h)
- 🟡 Old session
- ⚪ No session
- Shows branch name and last session timestamp

**wt prune** - Comprehensive worktree cleanup
- Prunes stale worktree references
- Removes worktrees for merged feature branches
- `--branches` flag to also delete merged branches
- `--force` to skip confirmation
- `--dry-run` to preview

**g feature prune --force** - Safety improvement
- Now asks for confirmation before deleting (safer default)
- `--force` flag skips confirmation for scripting

### Version Bump
- 4.2.0 → 4.3.0

## Test plan

- [x] Help commands work: `g feature prune --help`, `wt prune --help`, `cc wt help`
- [ ] Manual testing of prune commands
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)