### PR TITLE
feat(v4.3.0): add branch status, age filtering, and worktree status

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
   - `--branches` flag to also delete the merged branches
   - `--force` to skip confirmation, `--dry-run` to preview
 
+- **wt status** - Show worktree health and disk usage
+  - Shows all worktrees with status (active/merged/stale)
+  - Displays disk usage per worktree
+  - Provides cleanup suggestions
+
+- **g feature status** - Show merged vs active branches
+  - Lists stale branches (merged to dev)
+  - Lists active branches with commit count
+  - Shows age of each branch
+
+- **g feature prune --older-than** - Filter by branch age
+  - `--older-than 30d` - Only branches older than 30 days
+  - `--older-than 1w` - Only branches older than 1 week
+  - `--older-than 2m` - Only branches older than 2 months
+
 ### Changed
 
 - **g feature prune** - Now asks for confirmation before deleting

--- a/docs/planning/V4.3-ROADMAP.md
+++ b/docs/planning/V4.3-ROADMAP.md
@@ -1,7 +1,7 @@
 # v4.3.0+ Roadmap
 
 **Created:** 2025-12-29
-**Status:** In Progress
+**Status:** ✅ Complete
 **Last Updated:** 2025-12-30
 
 This document contains detailed implementation plans for future flow-cli enhancements.
@@ -17,17 +17,20 @@ After completing v4.2.0 (Worktree + Claude Integration), these are the prioritiz
 | P1 | cc wt status | ~1 hour | High | ✅ Done |
 | P1 | cc wt clean | ~45 min | High | See wt prune |
 | P2 | g feature prune --force | ~30 min | Medium | ✅ Done |
-| P2 | g feature prune --older-than | ~1 hour | Medium | Pending |
-| P2 | g feature status | ~45 min | Medium | Pending |
+| P2 | g feature prune --older-than | ~1 hour | Medium | ✅ Done |
+| P2 | g feature status | ~45 min | Medium | ✅ Done |
 | P3 | wt prune | ~1 hour | Medium | ✅ Done |
-| P3 | wt status | ~30 min | Low | Pending |
+| P3 | wt status | ~30 min | Low | ✅ Done |
 | P4 | Remote sync | TBD | Future | Pending |
 
 ### v4.3.0 Completed Features
 
 - **cc wt status** - Shows worktrees with Claude session info (green/yellow/white indicators)
 - **g feature prune --force** - Adds confirmation prompt by default, `--force` to skip
+- **g feature prune --older-than** - Filter branches by age (30d, 1w, 2m)
+- **g feature status** - Show merged vs active branches with age info
 - **wt prune** - Comprehensive cleanup: prunes stale refs + removes merged worktrees + optionally deletes branches
+- **wt status** - Show worktree health, disk usage, and merge status
 
 ---
 


### PR DESCRIPTION
## Summary

This PR completes all planned v4.3.0 features with three new commands:

- **`g feature status`** - Show merged vs active branches with age info
- **`g feature prune --older-than`** - Filter branches by age (30d, 1w, 2m)
- **`wt status`** - Show worktree health, disk usage, and merge status

## What's New

### `g feature status`
Shows an overview of all feature/bugfix/hotfix branches:
- 🧹 Stale branches (merged to dev) with age
- ⚠️ Active branches with commits ahead and age
- Summary with cleanup tip

### `g feature prune --older-than`
Filter merged branches by age before pruning:
- `--older-than 30d` - Only 30+ days old
- `--older-than 1w` - Only 1+ week old  
- `--older-than 2m` - Only 2+ months old

### `wt status`
Show worktree health at a glance:
- ✅ active, 🧹 merged, ⚠️ stale, 🏠 main
- Disk usage per worktree
- Cleanup suggestions

## v4.3.0 Complete

All planned features are now done:
- ✅ cc wt status (#85)
- ✅ g feature prune --force (#85)
- ✅ wt prune (#85)
- ✅ g feature prune --older-than (this PR)
- ✅ g feature status (this PR)
- ✅ wt status (this PR)

## Test plan

- [ ] Run `g feature status` to see branch overview
- [ ] Run `g feature prune --older-than 1w -n` to preview age filtering
- [ ] Run `wt status` to see worktree health

🤖 Generated with [Claude Code](https://claude.com/claude-code)