### PR TITLE
fix(wt): use %b format for color escape sequences in wt status

### DIFF
--- a/lib/dispatchers/wt-dispatcher.zsh
+++ b/lib/dispatchers/wt-dispatcher.zsh
@@ -308,7 +308,8 @@ _wt_status() {
                         short_path="...${short_path: -37}"
                     fi
 
-                    printf "  %-35s %-20s %-8s %s\n" \
+                    # Use %b for fields with escape sequences
+                    printf "  %-35s %-20b %-8s %b\n" \
                         "${wt_branch:-unknown}" \
                         "$wt_status" \
                         "$wt_size" \


### PR DESCRIPTION
## Summary

Fix color rendering in `wt status` command.

## Problem

`printf %s` doesn't interpret ANSI escape sequences, causing raw escape codes to appear in output.

## Solution

Use `printf %b` for STATUS and PATH columns that contain color codes.

## Test plan

- [x] Run `wt status` - colors now render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)