### PR TITLE
chore: bump version to 4.3.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
+## [4.3.1] - 2025-12-30
+
+### Fixed
+
+- **wt status** - Fixed color rendering (use `%b` format for ANSI escape sequences)
+
+---
+
 ## [4.3.0] - 2025-12-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Bump version to 4.3.1 for the wt status color fix.

## Changes

- `package.json`: 4.3.0 → 4.3.1
- `CHANGELOG.md`: Added 4.3.1 section with fix note

🤖 Generated with [Claude Code](https://claude.com/claude-code)