### PR TITLE
chore: bump version to 4.4.1

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -4,7 +4,7 @@
 ## Project: flow-cli
 ## Type: zsh-plugin
 ## Status: active
-## Phase: v4.2.0 Released
+## Phase: v4.4.0 Released
 ## Priority: 1
 ## Progress: 100
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v4.4.0)
+- **Status:** Production ready (v4.4.1)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -99,7 +99,7 @@ flow doctor       # Health check (verify dependencies)
 flow doctor --fix # Interactive install missing tools
 ```
 
-### Dopamine Features (v4.1.0)
+### Dopamine Features (v4.4.1)
 
 ```bash
 win <text>        # Log accomplishment (auto-categorized)
@@ -454,14 +454,14 @@ export FLOW_DEBUG=1
 - [x] All reference pages cross-linked with "See also"
 - [x] Tutorial 11: TM Dispatcher
 
-### ✅ v4.4.0 Released
+### ✅ v4.4.1 Released
 
 - [x] `tm` dispatcher - Terminal manager (aiterm integration)
   - Shell-native: `tm title`, `tm profile`, `tm which`
   - Aiterm delegation: `tm ghost`, `tm switch`, `tm detect`
   - Aliases: `tmt`, `tmp`, `tmg`, `tms`, `tmd`
 
-### ✅ v4.3.0 Released
+### ✅ v4.4.1 Released
 
 - [x] `g feature status` - Show merged vs active branches
 - [x] `g feature prune --older-than` - Filter by branch age
@@ -470,7 +470,7 @@ export FLOW_DEBUG=1
 - [x] `wt prune` - Comprehensive cleanup with branch deletion
 - [x] `cc wt status` - Show worktrees with Claude session info
 
-### ✅ v4.2.0 Released
+### ✅ v4.4.1 Released
 
 - [x] Worktree + Claude Integration (`cc wt`)
 - [x] Branch cleanup (`g feature prune`)
@@ -552,10 +552,10 @@ git diff
 
 # Commit and tag
 git add -A && git commit -m "chore: bump version to 3.7.0"
-git tag -a v4.1.0 -m "v4.1.0"
+git tag -a v4.4.1 -m "v4.4.1"
 
 # Push (requires PR for protected branch)
-git push origin main && git push origin v4.1.0
+git push origin main && git push origin v4.4.1
 ```
 
 **Files updated by release script:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.3.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.4.1-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
Documentation release v4.4.1

## Changes
- 9 dedicated dispatcher reference pages
- Complete dispatcher documentation set
- Tutorial 11: TM Dispatcher

## Test plan
- [x] Version files updated
- [ ] Tag after merge: `git tag -a v4.4.1 -m 'v4.4.1'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)