### PR TITLE
docs: add cross-references to aiterm and obs projects

### DIFF
--- a/docs/reference/MCP-DISPATCHER-REFERENCE.md
+++ b/docs/reference/MCP-DISPATCHER-REFERENCE.md
@@ -239,14 +239,23 @@ mcp cd statistical-research
 cc                    # Claude in MCP server dir
 ```
 
-### With aiterm
+### With aiterm (Rich Features)
 
-For richer output:
+For advanced MCP management, aiterm provides enhanced capabilities:
 
 ```bash
-ait mcp list          # Rich table output
-ait mcp validate      # Detailed config validation
+ait mcp list          # Rich table view with status indicators
+ait mcp validate      # Full JSON validation with error details
+ait mcp test-all      # Batch health checking with timing
+ait mcp info <name>   # Detailed config with masked secrets
 ```
+
+**When to use aiterm:**
+- Validating MCP configuration before deployment
+- Debugging server connection issues
+- Getting detailed timing and health metrics
+
+**Documentation:** [aiterm MCP Integration Guide](https://github.com/data-wise/aiterm/blob/main/docs/MCP-INTEGRATION.md)
 
 ---
 

--- a/docs/reference/OBS-DISPATCHER-REFERENCE.md
+++ b/docs/reference/OBS-DISPATCHER-REFERENCE.md
@@ -245,7 +245,19 @@ obs version
 ## Related
 
 - [DISPATCHER-REFERENCE.md](DISPATCHER-REFERENCE.md) - All dispatchers
-- [obsidian-cli-ops documentation](https://data-wise.github.io/obsidian-cli-ops/)
+
+## Full Documentation
+
+The `obs` dispatcher is part of the **obsidian-cli-ops** project. For comprehensive documentation:
+
+| Resource | URL |
+|----------|-----|
+| **User Guide** | [data-wise.github.io/obsidian-cli-ops](https://data-wise.github.io/obsidian-cli-ops/) |
+| **AI Setup** | See `obs ai setup` for configuration wizard |
+| **Graph Analysis** | Deep dive in obsidian-cli-ops docs |
+| **Source Code** | [github.com/data-wise/obsidian-cli-ops](https://github.com/data-wise/obsidian-cli-ops) |
+
+**Note:** This reference covers the flow-cli dispatcher integration. For advanced features, vault management strategies, and AI configuration, refer to the obsidian-cli-ops documentation.
 
 ---
 


### PR DESCRIPTION
## Summary
Add cross-references to external documentation per 3-layer architecture coordination.

### Changes
- **MCP-DISPATCHER-REFERENCE.md**: Enhanced aiterm integration section
  - Document `ait mcp` commands for rich validation
  - Link to aiterm MCP Integration Guide (591 lines)
  
- **OBS-DISPATCHER-REFERENCE.md**: Add full documentation section
  - Table linking to obsidian-cli-ops docs site
  - Clarify dispatcher is part of external project

### Rationale
Following the 3-layer architecture:
- flow-cli (ZSH) → instant commands
- aiterm (Python) → rich visualization
- External projects → comprehensive docs

Users are directed to authoritative sources instead of duplicating content.

## Test plan
- [x] mkdocs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)