### PR TITLE
test: add dispatcher tests for r, qu, mcp, tm (#101)

### DIFF
--- a/tests/test-mcp-dispatcher.zsh
+++ b/tests/test-mcp-dispatcher.zsh
@@ -1,0 +1,407 @@
+#!/usr/bin/env zsh
+# Test script for mcp dispatcher
+# Tests: help, subcommand detection, error handling
+
+# ============================================================================
+# TEST FRAMEWORK
+# ============================================================================
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_test() {
+    echo -n "${CYAN}Testing:${NC} $1 ... "
+}
+
+pass() {
+    echo "${GREEN}✓ PASS${NC}"
+    ((TESTS_PASSED++))
+}
+
+fail() {
+    echo "${RED}✗ FAIL${NC} - $1"
+    ((TESTS_FAILED++))
+}
+
+# ============================================================================
+# SETUP
+# ============================================================================
+
+setup() {
+    echo ""
+    echo "${YELLOW}Setting up test environment...${NC}"
+
+    # Get project root
+    local project_root=""
+
+    if [[ -n "${0:A}" ]]; then
+        project_root="${0:A:h:h}"
+    fi
+
+    if [[ -z "$project_root" || ! -f "$project_root/lib/dispatchers/mcp-dispatcher.zsh" ]]; then
+        if [[ -f "$PWD/lib/dispatchers/mcp-dispatcher.zsh" ]]; then
+            project_root="$PWD"
+        elif [[ -f "$PWD/../lib/dispatchers/mcp-dispatcher.zsh" ]]; then
+            project_root="$PWD/.."
+        fi
+    fi
+
+    if [[ -z "$project_root" || ! -f "$project_root/lib/dispatchers/mcp-dispatcher.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root - run from project directory${NC}"
+        exit 1
+    fi
+
+    echo "  Project root: $project_root"
+
+    # Source mcp dispatcher
+    source "$project_root/lib/dispatchers/mcp-dispatcher.zsh"
+
+    echo "  Loaded: mcp-dispatcher.zsh"
+    echo ""
+}
+
+# ============================================================================
+# FUNCTION EXISTENCE TESTS
+# ============================================================================
+
+test_mcp_function_exists() {
+    log_test "mcp function is defined"
+
+    if (( $+functions[mcp] )); then
+        pass
+    else
+        fail "mcp function not defined"
+    fi
+}
+
+test_mcp_help_function_exists() {
+    log_test "_mcp_help function is defined"
+
+    if (( $+functions[_mcp_help] )); then
+        pass
+    else
+        fail "_mcp_help function not defined"
+    fi
+}
+
+test_mcp_list_function_exists() {
+    log_test "_mcp_list function is defined"
+
+    if (( $+functions[_mcp_list] )); then
+        pass
+    else
+        fail "_mcp_list function not defined"
+    fi
+}
+
+test_mcp_cd_function_exists() {
+    log_test "_mcp_cd function is defined"
+
+    if (( $+functions[_mcp_cd] )); then
+        pass
+    else
+        fail "_mcp_cd function not defined"
+    fi
+}
+
+# ============================================================================
+# HELP TESTS
+# ============================================================================
+
+test_mcp_help() {
+    log_test "mcp help shows usage"
+
+    local output=$(mcp help 2>&1)
+
+    if echo "$output" | grep -q "MCP Server Management"; then
+        pass
+    else
+        fail "Help header not found"
+    fi
+}
+
+test_mcp_help_h_flag() {
+    log_test "mcp -h works"
+
+    local output=$(mcp -h 2>&1)
+
+    if echo "$output" | grep -q "MCP Server Management"; then
+        pass
+    else
+        fail "-h flag not working"
+    fi
+}
+
+test_mcp_help_long_flag() {
+    log_test "mcp --help works"
+
+    local output=$(mcp --help 2>&1)
+
+    if echo "$output" | grep -q "MCP Server Management"; then
+        pass
+    else
+        fail "--help flag not working"
+    fi
+}
+
+test_mcp_help_h_shortcut() {
+    log_test "mcp h works (shortcut)"
+
+    local output=$(mcp h 2>&1)
+
+    if echo "$output" | grep -q "MCP Server Management"; then
+        pass
+    else
+        fail "h shortcut not working"
+    fi
+}
+
+# ============================================================================
+# HELP CONTENT TESTS
+# ============================================================================
+
+test_help_shows_list() {
+    log_test "help shows list command"
+
+    local output=$(mcp help 2>&1)
+
+    if echo "$output" | grep -q "mcp list"; then
+        pass
+    else
+        fail "list not in help"
+    fi
+}
+
+test_help_shows_cd() {
+    log_test "help shows cd command"
+
+    local output=$(mcp help 2>&1)
+
+    if echo "$output" | grep -q "mcp cd"; then
+        pass
+    else
+        fail "cd not in help"
+    fi
+}
+
+test_help_shows_test() {
+    log_test "help shows test command"
+
+    local output=$(mcp help 2>&1)
+
+    if echo "$output" | grep -q "mcp test"; then
+        pass
+    else
+        fail "test not in help"
+    fi
+}
+
+test_help_shows_edit() {
+    log_test "help shows edit command"
+
+    local output=$(mcp help 2>&1)
+
+    if echo "$output" | grep -q "mcp edit"; then
+        pass
+    else
+        fail "edit not in help"
+    fi
+}
+
+test_help_shows_status() {
+    log_test "help shows status command"
+
+    local output=$(mcp help 2>&1)
+
+    if echo "$output" | grep -q "mcp status"; then
+        pass
+    else
+        fail "status not in help"
+    fi
+}
+
+test_help_shows_pick() {
+    log_test "help shows pick command"
+
+    local output=$(mcp help 2>&1)
+
+    if echo "$output" | grep -q "mcp pick"; then
+        pass
+    else
+        fail "pick not in help"
+    fi
+}
+
+test_help_shows_shortcuts() {
+    log_test "help shows short forms section"
+
+    local output=$(mcp help 2>&1)
+
+    if echo "$output" | grep -q "SHORT FORMS"; then
+        pass
+    else
+        fail "short forms section not found"
+    fi
+}
+
+test_help_shows_locations() {
+    log_test "help shows locations section"
+
+    local output=$(mcp help 2>&1)
+
+    if echo "$output" | grep -q "LOCATIONS"; then
+        pass
+    else
+        fail "locations section not found"
+    fi
+}
+
+# ============================================================================
+# UNKNOWN COMMAND TESTS
+# ============================================================================
+
+test_unknown_command() {
+    log_test "mcp unknown-cmd shows error"
+
+    local output=$(mcp unknown-xyz-command 2>&1)
+
+    if echo "$output" | grep -q "unknown action"; then
+        pass
+    else
+        fail "Unknown action error not shown"
+    fi
+}
+
+test_unknown_command_suggests_help() {
+    log_test "unknown command suggests mcp help"
+
+    local output=$(mcp foobar 2>&1)
+
+    if echo "$output" | grep -q "mcp help"; then
+        pass
+    else
+        fail "Doesn't suggest mcp help"
+    fi
+}
+
+# ============================================================================
+# EDIT COMMAND VALIDATION TESTS
+# ============================================================================
+
+test_edit_no_args() {
+    log_test "mcp edit with no args shows usage"
+
+    local output=$(mcp edit 2>&1)
+
+    if echo "$output" | grep -q "mcp edit"; then
+        pass
+    else
+        fail "Usage message not shown"
+    fi
+}
+
+test_edit_nonexistent() {
+    log_test "mcp edit with nonexistent server shows error"
+
+    local output=$(mcp edit nonexistent-server-xyz 2>&1)
+
+    if echo "$output" | grep -q "server not found"; then
+        pass
+    else
+        fail "Error message not shown for missing server"
+    fi
+}
+
+# ============================================================================
+# CD COMMAND TESTS
+# ============================================================================
+
+test_cd_nonexistent() {
+    log_test "mcp cd with nonexistent server shows error"
+
+    local output=$(mcp cd nonexistent-server-xyz 2>&1)
+
+    if echo "$output" | grep -q "server not found"; then
+        pass
+    else
+        fail "Error message not shown for missing server"
+    fi
+}
+
+# ============================================================================
+# RUN TESTS
+# ============================================================================
+
+main() {
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════╗"
+    echo "║  MCP Dispatcher Tests                                      ║"
+    echo "╚════════════════════════════════════════════════════════════╝"
+
+    setup
+
+    echo "${YELLOW}Function Existence Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_mcp_function_exists
+    test_mcp_help_function_exists
+    test_mcp_list_function_exists
+    test_mcp_cd_function_exists
+    echo ""
+
+    echo "${YELLOW}Help Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_mcp_help
+    test_mcp_help_h_flag
+    test_mcp_help_long_flag
+    test_mcp_help_h_shortcut
+    echo ""
+
+    echo "${YELLOW}Help Content Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_help_shows_list
+    test_help_shows_cd
+    test_help_shows_test
+    test_help_shows_edit
+    test_help_shows_status
+    test_help_shows_pick
+    test_help_shows_shortcuts
+    test_help_shows_locations
+    echo ""
+
+    echo "${YELLOW}Unknown Command Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_unknown_command
+    test_unknown_command_suggests_help
+    echo ""
+
+    echo "${YELLOW}Validation Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_edit_no_args
+    test_edit_nonexistent
+    test_cd_nonexistent
+    echo ""
+
+    echo "════════════════════════════════════════"
+    echo "${CYAN}Summary${NC}"
+    echo "────────────────────────────────────────"
+    echo "  Passed: ${GREEN}$TESTS_PASSED${NC}"
+    echo "  Failed: ${RED}$TESTS_FAILED${NC}"
+    echo ""
+
+    if [[ $TESTS_FAILED -eq 0 ]]; then
+        echo "${GREEN}✓ All tests passed!${NC}"
+        exit 0
+    else
+        echo "${RED}✗ Some tests failed${NC}"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tests/test-qu-dispatcher.zsh
+++ b/tests/test-qu-dispatcher.zsh
@@ -1,0 +1,366 @@
+#!/usr/bin/env zsh
+# Test script for qu dispatcher
+# Tests: help, subcommand detection, keyword recognition, clean command
+
+# ============================================================================
+# TEST FRAMEWORK
+# ============================================================================
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_test() {
+    echo -n "${CYAN}Testing:${NC} $1 ... "
+}
+
+pass() {
+    echo "${GREEN}✓ PASS${NC}"
+    ((TESTS_PASSED++))
+}
+
+fail() {
+    echo "${RED}✗ FAIL${NC} - $1"
+    ((TESTS_FAILED++))
+}
+
+# ============================================================================
+# SETUP
+# ============================================================================
+
+setup() {
+    echo ""
+    echo "${YELLOW}Setting up test environment...${NC}"
+
+    # Get project root
+    local project_root=""
+
+    if [[ -n "${0:A}" ]]; then
+        project_root="${0:A:h:h}"
+    fi
+
+    if [[ -z "$project_root" || ! -f "$project_root/lib/dispatchers/qu-dispatcher.zsh" ]]; then
+        if [[ -f "$PWD/lib/dispatchers/qu-dispatcher.zsh" ]]; then
+            project_root="$PWD"
+        elif [[ -f "$PWD/../lib/dispatchers/qu-dispatcher.zsh" ]]; then
+            project_root="$PWD/.."
+        fi
+    fi
+
+    if [[ -z "$project_root" || ! -f "$project_root/lib/dispatchers/qu-dispatcher.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root - run from project directory${NC}"
+        exit 1
+    fi
+
+    echo "  Project root: $project_root"
+
+    # Source qu dispatcher
+    source "$project_root/lib/dispatchers/qu-dispatcher.zsh"
+
+    echo "  Loaded: qu-dispatcher.zsh"
+    echo ""
+}
+
+# ============================================================================
+# FUNCTION EXISTENCE TESTS
+# ============================================================================
+
+test_qu_function_exists() {
+    log_test "qu function is defined"
+
+    if (( $+functions[qu] )); then
+        pass
+    else
+        fail "qu function not defined"
+    fi
+}
+
+test_qu_help_function_exists() {
+    log_test "_qu_help function is defined"
+
+    if (( $+functions[_qu_help] )); then
+        pass
+    else
+        fail "_qu_help function not defined"
+    fi
+}
+
+# ============================================================================
+# HELP TESTS
+# ============================================================================
+
+test_qu_help() {
+    log_test "qu help shows usage"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "Quarto Publishing"; then
+        pass
+    else
+        fail "Help header not found"
+    fi
+}
+
+test_qu_help_h_flag() {
+    log_test "qu -h works"
+
+    local output=$(qu -h 2>&1)
+
+    if echo "$output" | grep -q "Quarto Publishing"; then
+        pass
+    else
+        fail "-h flag not working"
+    fi
+}
+
+test_qu_help_long_flag() {
+    log_test "qu --help works"
+
+    local output=$(qu --help 2>&1)
+
+    if echo "$output" | grep -q "Quarto Publishing"; then
+        pass
+    else
+        fail "--help flag not working"
+    fi
+}
+
+# ============================================================================
+# HELP CONTENT TESTS
+# ============================================================================
+
+test_help_shows_preview() {
+    log_test "help shows preview command"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "qu preview"; then
+        pass
+    else
+        fail "preview not in help"
+    fi
+}
+
+test_help_shows_render() {
+    log_test "help shows render command"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "qu render"; then
+        pass
+    else
+        fail "render not in help"
+    fi
+}
+
+test_help_shows_pdf() {
+    log_test "help shows pdf command"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "qu pdf"; then
+        pass
+    else
+        fail "pdf not in help"
+    fi
+}
+
+test_help_shows_html() {
+    log_test "help shows html command"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "qu html"; then
+        pass
+    else
+        fail "html not in help"
+    fi
+}
+
+test_help_shows_docx() {
+    log_test "help shows docx command"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "qu docx"; then
+        pass
+    else
+        fail "docx not in help"
+    fi
+}
+
+test_help_shows_publish() {
+    log_test "help shows publish command"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "qu publish"; then
+        pass
+    else
+        fail "publish not in help"
+    fi
+}
+
+test_help_shows_clean() {
+    log_test "help shows clean command"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "qu clean"; then
+        pass
+    else
+        fail "clean not in help"
+    fi
+}
+
+test_help_shows_new() {
+    log_test "help shows new command"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "qu new"; then
+        pass
+    else
+        fail "new not in help"
+    fi
+}
+
+test_help_shows_smart_default() {
+    log_test "help shows smart default workflow"
+
+    local output=$(qu help 2>&1)
+
+    if echo "$output" | grep -q "SMART DEFAULT"; then
+        pass
+    else
+        fail "smart default section not found"
+    fi
+}
+
+# ============================================================================
+# UNKNOWN COMMAND TESTS
+# ============================================================================
+
+test_unknown_command() {
+    log_test "qu unknown-cmd shows error"
+
+    local output=$(qu unknown-xyz-command 2>&1)
+
+    if echo "$output" | grep -q "unknown command"; then
+        pass
+    else
+        fail "Unknown command error not shown"
+    fi
+}
+
+test_unknown_command_suggests_help() {
+    log_test "unknown command suggests qu help"
+
+    local output=$(qu foobar 2>&1)
+
+    if echo "$output" | grep -q "qu help"; then
+        pass
+    else
+        fail "Doesn't suggest qu help"
+    fi
+}
+
+# ============================================================================
+# CLEAN COMMAND TEST (safe to run)
+# ============================================================================
+
+test_clean_command() {
+    log_test "qu clean removes cache directories"
+
+    # Create temp dir with Quarto cache directories
+    local temp_dir=$(mktemp -d)
+    mkdir -p "$temp_dir/_site"
+    mkdir -p "$temp_dir/document_cache"
+    mkdir -p "$temp_dir/document_files"
+
+    # Run clean in that directory
+    (cd "$temp_dir" && qu clean 2>&1)
+
+    # Check directories were removed
+    if [[ ! -d "$temp_dir/_site" ]]; then
+        pass
+    else
+        fail "_site not removed"
+    fi
+
+    # Cleanup
+    rm -rf "$temp_dir"
+}
+
+# ============================================================================
+# RUN TESTS
+# ============================================================================
+
+main() {
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════╗"
+    echo "║  QU Dispatcher Tests                                       ║"
+    echo "╚════════════════════════════════════════════════════════════╝"
+
+    setup
+
+    echo "${YELLOW}Function Existence Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_qu_function_exists
+    test_qu_help_function_exists
+    echo ""
+
+    echo "${YELLOW}Help Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_qu_help
+    test_qu_help_h_flag
+    test_qu_help_long_flag
+    echo ""
+
+    echo "${YELLOW}Help Content Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_help_shows_preview
+    test_help_shows_render
+    test_help_shows_pdf
+    test_help_shows_html
+    test_help_shows_docx
+    test_help_shows_publish
+    test_help_shows_clean
+    test_help_shows_new
+    test_help_shows_smart_default
+    echo ""
+
+    echo "${YELLOW}Unknown Command Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_unknown_command
+    test_unknown_command_suggests_help
+    echo ""
+
+    echo "${YELLOW}Clean Command Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_clean_command
+    echo ""
+
+    echo "════════════════════════════════════════"
+    echo "${CYAN}Summary${NC}"
+    echo "────────────────────────────────────────"
+    echo "  Passed: ${GREEN}$TESTS_PASSED${NC}"
+    echo "  Failed: ${RED}$TESTS_FAILED${NC}"
+    echo ""
+
+    if [[ $TESTS_FAILED -eq 0 ]]; then
+        echo "${GREEN}✓ All tests passed!${NC}"
+        exit 0
+    else
+        echo "${RED}✗ Some tests failed${NC}"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tests/test-r-dispatcher.zsh
+++ b/tests/test-r-dispatcher.zsh
@@ -1,0 +1,360 @@
+#!/usr/bin/env zsh
+# Test script for r dispatcher
+# Tests: help, subcommand detection, keyword recognition, cleanup commands
+
+# ============================================================================
+# TEST FRAMEWORK
+# ============================================================================
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_test() {
+    echo -n "${CYAN}Testing:${NC} $1 ... "
+}
+
+pass() {
+    echo "${GREEN}✓ PASS${NC}"
+    ((TESTS_PASSED++))
+}
+
+fail() {
+    echo "${RED}✗ FAIL${NC} - $1"
+    ((TESTS_FAILED++))
+}
+
+# ============================================================================
+# SETUP
+# ============================================================================
+
+setup() {
+    echo ""
+    echo "${YELLOW}Setting up test environment...${NC}"
+
+    # Get project root
+    local project_root=""
+
+    if [[ -n "${0:A}" ]]; then
+        project_root="${0:A:h:h}"
+    fi
+
+    if [[ -z "$project_root" || ! -f "$project_root/lib/dispatchers/r-dispatcher.zsh" ]]; then
+        if [[ -f "$PWD/lib/dispatchers/r-dispatcher.zsh" ]]; then
+            project_root="$PWD"
+        elif [[ -f "$PWD/../lib/dispatchers/r-dispatcher.zsh" ]]; then
+            project_root="$PWD/.."
+        fi
+    fi
+
+    if [[ -z "$project_root" || ! -f "$project_root/lib/dispatchers/r-dispatcher.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root - run from project directory${NC}"
+        exit 1
+    fi
+
+    echo "  Project root: $project_root"
+
+    # Source r dispatcher
+    source "$project_root/lib/dispatchers/r-dispatcher.zsh"
+
+    echo "  Loaded: r-dispatcher.zsh"
+    echo ""
+}
+
+# ============================================================================
+# FUNCTION EXISTENCE TESTS
+# ============================================================================
+
+test_r_function_exists() {
+    log_test "r function is defined"
+
+    if (( $+functions[r] )); then
+        pass
+    else
+        fail "r function not defined"
+    fi
+}
+
+test_r_help_function_exists() {
+    log_test "_r_help function is defined"
+
+    if (( $+functions[_r_help] )); then
+        pass
+    else
+        fail "_r_help function not defined"
+    fi
+}
+
+# ============================================================================
+# HELP TESTS
+# ============================================================================
+
+test_r_help() {
+    log_test "r help shows usage"
+
+    local output=$(r help 2>&1)
+
+    if echo "$output" | grep -q "R Package Development"; then
+        pass
+    else
+        fail "Help header not found"
+    fi
+}
+
+test_r_help_flag() {
+    log_test "r h works (shortcut)"
+
+    local output=$(r h 2>&1)
+
+    if echo "$output" | grep -q "R Package Development"; then
+        pass
+    else
+        fail "h shortcut not working"
+    fi
+}
+
+# ============================================================================
+# HELP CONTENT TESTS
+# ============================================================================
+
+test_help_shows_test() {
+    log_test "help shows test command"
+
+    local output=$(r help 2>&1)
+
+    if echo "$output" | grep -q "r test"; then
+        pass
+    else
+        fail "test not in help"
+    fi
+}
+
+test_help_shows_cycle() {
+    log_test "help shows cycle command"
+
+    local output=$(r help 2>&1)
+
+    if echo "$output" | grep -q "r cycle"; then
+        pass
+    else
+        fail "cycle not in help"
+    fi
+}
+
+test_help_shows_doc() {
+    log_test "help shows doc command"
+
+    local output=$(r help 2>&1)
+
+    if echo "$output" | grep -q "r doc"; then
+        pass
+    else
+        fail "doc not in help"
+    fi
+}
+
+test_help_shows_check() {
+    log_test "help shows check command"
+
+    local output=$(r help 2>&1)
+
+    if echo "$output" | grep -q "r check"; then
+        pass
+    else
+        fail "check not in help"
+    fi
+}
+
+test_help_shows_build() {
+    log_test "help shows build command"
+
+    local output=$(r help 2>&1)
+
+    if echo "$output" | grep -q "r build"; then
+        pass
+    else
+        fail "build not in help"
+    fi
+}
+
+test_help_shows_cran() {
+    log_test "help shows cran command"
+
+    local output=$(r help 2>&1)
+
+    if echo "$output" | grep -q "r cran"; then
+        pass
+    else
+        fail "cran not in help"
+    fi
+}
+
+test_help_shows_shortcuts() {
+    log_test "help shows version bumps section"
+
+    local output=$(r help 2>&1)
+
+    if echo "$output" | grep -q "VERSION BUMPS"; then
+        pass
+    else
+        fail "version bumps section not found"
+    fi
+}
+
+test_help_shows_cleanup() {
+    log_test "help shows cleanup section"
+
+    local output=$(r help 2>&1)
+
+    if echo "$output" | grep -q "CLEANUP"; then
+        pass
+    else
+        fail "cleanup section not found"
+    fi
+}
+
+# ============================================================================
+# UNKNOWN COMMAND TESTS
+# ============================================================================
+
+test_unknown_command() {
+    log_test "r unknown-cmd shows error"
+
+    local output=$(r unknown-xyz-command 2>&1)
+
+    if echo "$output" | grep -q "Unknown action"; then
+        pass
+    else
+        fail "Unknown action error not shown"
+    fi
+}
+
+test_unknown_command_suggests_help() {
+    log_test "unknown command suggests r help"
+
+    local output=$(r foobar 2>&1)
+
+    if echo "$output" | grep -q "r help"; then
+        pass
+    else
+        fail "Doesn't suggest r help"
+    fi
+}
+
+# ============================================================================
+# CLEANUP COMMAND TESTS (safe to run)
+# ============================================================================
+
+test_clean_command() {
+    log_test "r clean removes files (in temp dir)"
+
+    # Create temp dir with test files
+    local temp_dir=$(mktemp -d)
+    touch "$temp_dir/.Rhistory"
+    touch "$temp_dir/.RData"
+
+    # Run clean in that directory
+    local output=$(cd "$temp_dir" && r clean 2>&1)
+
+    if echo "$output" | grep -q "Removed .Rhistory"; then
+        pass
+    else
+        fail "clean command message not shown"
+    fi
+
+    # Cleanup
+    rm -rf "$temp_dir"
+}
+
+test_tex_command() {
+    log_test "r tex removes LaTeX files (in temp dir)"
+
+    # Create temp dir with test files
+    local temp_dir=$(mktemp -d)
+    touch "$temp_dir/test.aux"
+    touch "$temp_dir/test.log"
+
+    # Run tex in that directory
+    local output=$(cd "$temp_dir" && r tex 2>&1)
+
+    if echo "$output" | grep -q "Removed LaTeX"; then
+        pass
+    else
+        fail "tex command message not shown"
+    fi
+
+    # Cleanup
+    rm -rf "$temp_dir"
+}
+
+# ============================================================================
+# RUN TESTS
+# ============================================================================
+
+main() {
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════╗"
+    echo "║  R Dispatcher Tests                                        ║"
+    echo "╚════════════════════════════════════════════════════════════╝"
+
+    setup
+
+    echo "${YELLOW}Function Existence Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_r_function_exists
+    test_r_help_function_exists
+    echo ""
+
+    echo "${YELLOW}Help Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_r_help
+    test_r_help_flag
+    echo ""
+
+    echo "${YELLOW}Help Content Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_help_shows_test
+    test_help_shows_cycle
+    test_help_shows_doc
+    test_help_shows_check
+    test_help_shows_build
+    test_help_shows_cran
+    test_help_shows_shortcuts
+    test_help_shows_cleanup
+    echo ""
+
+    echo "${YELLOW}Unknown Command Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_unknown_command
+    test_unknown_command_suggests_help
+    echo ""
+
+    echo "${YELLOW}Cleanup Command Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_clean_command
+    test_tex_command
+    echo ""
+
+    echo "════════════════════════════════════════"
+    echo "${CYAN}Summary${NC}"
+    echo "────────────────────────────────────────"
+    echo "  Passed: ${GREEN}$TESTS_PASSED${NC}"
+    echo "  Failed: ${RED}$TESTS_FAILED${NC}"
+    echo ""
+
+    if [[ $TESTS_FAILED -eq 0 ]]; then
+        echo "${GREEN}✓ All tests passed!${NC}"
+        exit 0
+    else
+        echo "${RED}✗ Some tests failed${NC}"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tests/test-tm-dispatcher.zsh
+++ b/tests/test-tm-dispatcher.zsh
@@ -1,0 +1,386 @@
+#!/usr/bin/env zsh
+# Test script for tm dispatcher
+# Tests: help, subcommand detection, shell-native commands
+
+# ============================================================================
+# TEST FRAMEWORK
+# ============================================================================
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_test() {
+    echo -n "${CYAN}Testing:${NC} $1 ... "
+}
+
+pass() {
+    echo "${GREEN}✓ PASS${NC}"
+    ((TESTS_PASSED++))
+}
+
+fail() {
+    echo "${RED}✗ FAIL${NC} - $1"
+    ((TESTS_FAILED++))
+}
+
+# ============================================================================
+# SETUP
+# ============================================================================
+
+setup() {
+    echo ""
+    echo "${YELLOW}Setting up test environment...${NC}"
+
+    # Get project root
+    local project_root=""
+
+    if [[ -n "${0:A}" ]]; then
+        project_root="${0:A:h:h}"
+    fi
+
+    if [[ -z "$project_root" || ! -f "$project_root/lib/dispatchers/tm-dispatcher.zsh" ]]; then
+        if [[ -f "$PWD/lib/dispatchers/tm-dispatcher.zsh" ]]; then
+            project_root="$PWD"
+        elif [[ -f "$PWD/../lib/dispatchers/tm-dispatcher.zsh" ]]; then
+            project_root="$PWD/.."
+        fi
+    fi
+
+    if [[ -z "$project_root" || ! -f "$project_root/lib/dispatchers/tm-dispatcher.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root - run from project directory${NC}"
+        exit 1
+    fi
+
+    echo "  Project root: $project_root"
+
+    # Source tm dispatcher
+    source "$project_root/lib/dispatchers/tm-dispatcher.zsh"
+
+    echo "  Loaded: tm-dispatcher.zsh"
+    echo ""
+}
+
+# ============================================================================
+# FUNCTION EXISTENCE TESTS
+# ============================================================================
+
+test_tm_function_exists() {
+    log_test "tm function is defined"
+
+    if (( $+functions[tm] )); then
+        pass
+    else
+        fail "tm function not defined"
+    fi
+}
+
+test_tm_help_function_exists() {
+    log_test "_tm_help function is defined"
+
+    if (( $+functions[_tm_help] )); then
+        pass
+    else
+        fail "_tm_help function not defined"
+    fi
+}
+
+test_tm_detect_terminal_function_exists() {
+    log_test "_tm_detect_terminal function is defined"
+
+    if (( $+functions[_tm_detect_terminal] )); then
+        pass
+    else
+        fail "_tm_detect_terminal function not defined"
+    fi
+}
+
+test_tm_set_title_function_exists() {
+    log_test "_tm_set_title function is defined"
+
+    if (( $+functions[_tm_set_title] )); then
+        pass
+    else
+        fail "_tm_set_title function not defined"
+    fi
+}
+
+# ============================================================================
+# HELP TESTS
+# ============================================================================
+
+test_tm_help() {
+    log_test "tm help shows usage"
+
+    local output=$(tm help 2>&1)
+
+    if echo "$output" | grep -q "Terminal Manager"; then
+        pass
+    else
+        fail "Help header not found"
+    fi
+}
+
+test_tm_help_h_flag() {
+    log_test "tm -h works"
+
+    local output=$(tm -h 2>&1)
+
+    if echo "$output" | grep -q "Terminal Manager"; then
+        pass
+    else
+        fail "-h flag not working"
+    fi
+}
+
+test_tm_help_long_flag() {
+    log_test "tm --help works"
+
+    local output=$(tm --help 2>&1)
+
+    if echo "$output" | grep -q "Terminal Manager"; then
+        pass
+    else
+        fail "--help flag not working"
+    fi
+}
+
+test_tm_no_args_shows_help() {
+    log_test "tm with no args shows help"
+
+    local output=$(tm 2>&1)
+
+    if echo "$output" | grep -q "Terminal Manager"; then
+        pass
+    else
+        fail "No args doesn't show help"
+    fi
+}
+
+# ============================================================================
+# HELP CONTENT TESTS
+# ============================================================================
+
+test_help_shows_title() {
+    log_test "help shows title command"
+
+    local output=$(tm help 2>&1)
+
+    if echo "$output" | grep -q "tm title"; then
+        pass
+    else
+        fail "title not in help"
+    fi
+}
+
+test_help_shows_profile() {
+    log_test "help shows profile command"
+
+    local output=$(tm help 2>&1)
+
+    if echo "$output" | grep -q "tm profile"; then
+        pass
+    else
+        fail "profile not in help"
+    fi
+}
+
+test_help_shows_ghost() {
+    log_test "help shows ghost command"
+
+    local output=$(tm help 2>&1)
+
+    if echo "$output" | grep -q "tm ghost"; then
+        pass
+    else
+        fail "ghost not in help"
+    fi
+}
+
+test_help_shows_switch() {
+    log_test "help shows switch command"
+
+    local output=$(tm help 2>&1)
+
+    if echo "$output" | grep -q "tm switch"; then
+        pass
+    else
+        fail "switch not in help"
+    fi
+}
+
+test_help_shows_detect() {
+    log_test "help shows detect command"
+
+    local output=$(tm help 2>&1)
+
+    if echo "$output" | grep -q "tm detect"; then
+        pass
+    else
+        fail "detect not in help"
+    fi
+}
+
+test_help_shows_shortcuts() {
+    log_test "help shows shortcuts section"
+
+    local output=$(tm help 2>&1)
+
+    if echo "$output" | grep -q "SHORTCUTS"; then
+        pass
+    else
+        fail "shortcuts section not found"
+    fi
+}
+
+test_help_shows_aliases() {
+    log_test "help shows aliases section"
+
+    local output=$(tm help 2>&1)
+
+    if echo "$output" | grep -q "ALIASES"; then
+        pass
+    else
+        fail "aliases section not found"
+    fi
+}
+
+# ============================================================================
+# TITLE COMMAND TESTS
+# ============================================================================
+
+test_title_no_args() {
+    log_test "tm title with no args shows usage"
+
+    local output=$(tm title 2>&1)
+
+    if echo "$output" | grep -q "Usage: tm title"; then
+        pass
+    else
+        fail "Usage message not shown"
+    fi
+}
+
+# ============================================================================
+# VAR COMMAND TESTS
+# ============================================================================
+
+test_var_no_args() {
+    log_test "tm var with no args shows usage"
+
+    local output=$(tm var 2>&1)
+
+    if echo "$output" | grep -q "Usage: tm var"; then
+        pass
+    else
+        fail "Usage message not shown"
+    fi
+}
+
+test_var_one_arg() {
+    log_test "tm var with one arg shows usage"
+
+    local output=$(tm var key 2>&1)
+
+    if echo "$output" | grep -q "Usage: tm var"; then
+        pass
+    else
+        fail "Usage message not shown for incomplete args"
+    fi
+}
+
+# ============================================================================
+# WHICH COMMAND TESTS
+# ============================================================================
+
+test_which_returns_terminal() {
+    log_test "tm which returns terminal name"
+
+    local output=$(tm which 2>&1)
+
+    # Should return one of the known terminal names
+    if [[ "$output" =~ (iterm2|ghostty|terminal|vscode|kitty|alacritty|wezterm|unknown) ]]; then
+        pass
+    else
+        fail "Unexpected terminal: $output"
+    fi
+}
+
+# ============================================================================
+# RUN TESTS
+# ============================================================================
+
+main() {
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════╗"
+    echo "║  TM Dispatcher Tests                                       ║"
+    echo "╚════════════════════════════════════════════════════════════╝"
+
+    setup
+
+    echo "${YELLOW}Function Existence Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_tm_function_exists
+    test_tm_help_function_exists
+    test_tm_detect_terminal_function_exists
+    test_tm_set_title_function_exists
+    echo ""
+
+    echo "${YELLOW}Help Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_tm_help
+    test_tm_help_h_flag
+    test_tm_help_long_flag
+    test_tm_no_args_shows_help
+    echo ""
+
+    echo "${YELLOW}Help Content Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_help_shows_title
+    test_help_shows_profile
+    test_help_shows_ghost
+    test_help_shows_switch
+    test_help_shows_detect
+    test_help_shows_shortcuts
+    test_help_shows_aliases
+    echo ""
+
+    echo "${YELLOW}Title Command Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_title_no_args
+    echo ""
+
+    echo "${YELLOW}Var Command Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_var_no_args
+    test_var_one_arg
+    echo ""
+
+    echo "${YELLOW}Which Command Tests${NC}"
+    echo "────────────────────────────────────────"
+    test_which_returns_terminal
+    echo ""
+
+    echo "════════════════════════════════════════"
+    echo "${CYAN}Summary${NC}"
+    echo "────────────────────────────────────────"
+    echo "  Passed: ${GREEN}$TESTS_PASSED${NC}"
+    echo "  Failed: ${RED}$TESTS_FAILED${NC}"
+    echo ""
+
+    if [[ $TESTS_FAILED -eq 0 ]]; then
+        echo "${GREEN}✓ All tests passed!${NC}"
+        exit 0
+    else
+        echo "${RED}✗ Some tests failed${NC}"
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for 4 dispatchers that were missing tests:

| Test File | Tests | Dispatcher |
|-----------|-------|------------|
| `test-r-dispatcher.zsh` | 16 | R package dev commands |
| `test-qu-dispatcher.zsh` | 17 | Quarto publishing |
| `test-mcp-dispatcher.zsh` | 21 | MCP server management |
| `test-tm-dispatcher.zsh` | 19 | Terminal manager |

**Total: 73 new tests**

## Test Coverage

Each test file covers:
- Function existence tests
- Help output (`help`, `-h`, `--help`, shortcuts)
- Help content documentation
- Unknown command handling
- Input validation
- Safe-to-run commands (e.g., `r clean`, `qu clean`)

## Dispatcher Test Status

After this PR:
| Dispatcher | Tests |
|------------|-------|
| ✅ cc | test-cc-dispatcher.zsh |
| ✅ g | test-g-feature.zsh, test-g-feature-prune.zsh |
| ✅ wt | test-wt-dispatcher.zsh |
| ✅ mcp | **NEW** test-mcp-dispatcher.zsh |
| ✅ r | **NEW** test-r-dispatcher.zsh |
| ✅ qu | **NEW** test-qu-dispatcher.zsh |
| ✅ tm | **NEW** test-tm-dispatcher.zsh |
| ⏳ obs | Not added (delegates to obsidian-cli-ops) |

## Test Plan

- [x] All 73 tests pass locally
- [x] Tests follow existing pattern from test-cc-dispatcher.zsh
- [x] Tests are safe to run (no side effects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)