### PR TITLE
docs: add CHANGELOG entry for v4.4.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
+## [4.4.2] - 2025-12-30
+
+### Added
+
+- **Complete dispatcher test coverage** - 85 new tests across 5 files
+  - `test-r-dispatcher.zsh` (16 tests) - R package dev commands
+  - `test-qu-dispatcher.zsh` (17 tests) - Quarto publishing
+  - `test-mcp-dispatcher.zsh` (21 tests) - MCP server management
+  - `test-tm-dispatcher.zsh` (19 tests) - Terminal manager
+  - `test-obs-dispatcher.zsh` (12 tests) - Obsidian integration
+
+### Changed
+
+- All 8 dispatchers now have test coverage (cc, g, wt, mcp, r, qu, tm, obs)
+
+---
+
 ## [4.4.1] - 2025-12-30
 
 ### Added


### PR DESCRIPTION
## Summary

Add CHANGELOG entry for v4.4.2 release.

## v4.4.2 Changes

### Added
- Complete dispatcher test coverage (85 new tests)
  - test-r-dispatcher.zsh (16 tests)
  - test-qu-dispatcher.zsh (17 tests)
  - test-mcp-dispatcher.zsh (21 tests)
  - test-tm-dispatcher.zsh (19 tests)
  - test-obs-dispatcher.zsh (12 tests)

### Changed
- All 8 dispatchers now have test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)