### PR TITLE
chore: bump version to 4.4.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v4.4.2)
+- **Status:** Production ready (v4.4.3)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -99,7 +99,7 @@ flow doctor       # Health check (verify dependencies)
 flow doctor --fix # Interactive install missing tools
 ```
 
-### Dopamine Features (v4.4.2)
+### Dopamine Features (v4.4.3)
 
 ```bash
 win <text>        # Log accomplishment (auto-categorized)
@@ -446,7 +446,7 @@ export FLOW_DEBUG=1
 
 ## Current Status (2025-12-30)
 
-### ✅ v4.4.2 Released (Documentation)
+### ✅ v4.4.3 Released (Documentation)
 
 - [x] 9 dedicated dispatcher reference pages:
   - CC, G, MCP, OBS, QU, R, TM, WT dispatchers
@@ -454,14 +454,14 @@ export FLOW_DEBUG=1
 - [x] All reference pages cross-linked with "See also"
 - [x] Tutorial 11: TM Dispatcher
 
-### ✅ v4.4.2 Released
+### ✅ v4.4.3 Released
 
 - [x] `tm` dispatcher - Terminal manager (aiterm integration)
   - Shell-native: `tm title`, `tm profile`, `tm which`
   - Aiterm delegation: `tm ghost`, `tm switch`, `tm detect`
   - Aliases: `tmt`, `tmp`, `tmg`, `tms`, `tmd`
 
-### ✅ v4.4.2 Released
+### ✅ v4.4.3 Released
 
 - [x] `g feature status` - Show merged vs active branches
 - [x] `g feature prune --older-than` - Filter by branch age
@@ -470,7 +470,7 @@ export FLOW_DEBUG=1
 - [x] `wt prune` - Comprehensive cleanup with branch deletion
 - [x] `cc wt status` - Show worktrees with Claude session info
 
-### ✅ v4.4.2 Released
+### ✅ v4.4.3 Released
 
 - [x] Worktree + Claude Integration (`cc wt`)
 - [x] Branch cleanup (`g feature prune`)
@@ -552,10 +552,10 @@ git diff
 
 # Commit and tag
 git add -A && git commit -m "chore: bump version to 3.7.0"
-git tag -a v4.4.2 -m "v4.4.2"
+git tag -a v4.4.3 -m "v4.4.3"
 
 # Push (requires PR for protected branch)
-git push origin main && git push origin v4.4.2
+git push origin main && git push origin v4.4.3
 ```
 
 **Files updated by release script:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.4.2-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.4.3-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
Release v4.4.3 - CI automation improvements

### Changes
- All 8 dispatcher tests in CI workflow (PR #107)
- TM tests gracefully skip when aiterm not installed
- Split tm tests on macOS for continue-on-error handling

### Version Updates
- package.json: 4.4.3
- README.md badge: 4.4.3
- CLAUDE.md references: 4.4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)