### PR TITLE
chore: release v4.5.0 - One-liner Installation

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -4,11 +4,11 @@
 ## Project: flow-cli
 ## Type: zsh-plugin
 ## Status: active
-## Phase: v4.4.3 Released
+## Phase: v4.5.0 Released
 ## Priority: 1
 ## Progress: 100
 
-## Focus: v4.2.0 RELEASED - Worktree + Claude Integration
+## Focus: v4.5.0 RELEASED - One-liner Installation
 
 ## Quick Context
 Pure ZSH workflow plugin with optional atlas integration for state management.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v4.4.3)
+- **Status:** Production ready (v4.5.0)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -99,7 +99,7 @@ flow doctor       # Health check (verify dependencies)
 flow doctor --fix # Interactive install missing tools
 ```
 
-### Dopamine Features (v4.4.3)
+### Dopamine Features (v4.5.0)
 
 ```bash
 win <text>        # Log accomplishment (auto-categorized)
@@ -446,7 +446,7 @@ export FLOW_DEBUG=1
 
 ## Current Status (2025-12-30)
 
-### ✅ v4.4.3 Released (Documentation)
+### ✅ v4.5.0 Released (Documentation)
 
 - [x] 9 dedicated dispatcher reference pages:
   - CC, G, MCP, OBS, QU, R, TM, WT dispatchers
@@ -454,14 +454,14 @@ export FLOW_DEBUG=1
 - [x] All reference pages cross-linked with "See also"
 - [x] Tutorial 11: TM Dispatcher
 
-### ✅ v4.4.3 Released
+### ✅ v4.5.0 Released
 
 - [x] `tm` dispatcher - Terminal manager (aiterm integration)
   - Shell-native: `tm title`, `tm profile`, `tm which`
   - Aiterm delegation: `tm ghost`, `tm switch`, `tm detect`
   - Aliases: `tmt`, `tmp`, `tmg`, `tms`, `tmd`
 
-### ✅ v4.4.3 Released
+### ✅ v4.5.0 Released
 
 - [x] `g feature status` - Show merged vs active branches
 - [x] `g feature prune --older-than` - Filter by branch age
@@ -470,7 +470,7 @@ export FLOW_DEBUG=1
 - [x] `wt prune` - Comprehensive cleanup with branch deletion
 - [x] `cc wt status` - Show worktrees with Claude session info
 
-### ✅ v4.4.3 Released
+### ✅ v4.5.0 Released
 
 - [x] Worktree + Claude Integration (`cc wt`)
 - [x] Branch cleanup (`g feature prune`)
@@ -563,10 +563,10 @@ git diff
 
 # Commit and tag
 git add -A && git commit -m "chore: bump version to 3.7.0"
-git tag -a v4.4.3 -m "v4.4.3"
+git tag -a v4.5.0 -m "v4.5.0"
 
 # Push (requires PR for protected branch)
-git push origin main && git push origin v4.4.3
+git push origin main && git push origin v4.5.0
 ```
 
 **Files updated by release script:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.4.3-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.5.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
+## [4.5.0] - 2025-12-31
+
+### Added
+
+- **One-liner installer** - `curl -fsSL .../install.sh | bash`
+  - Auto-detects plugin manager (antidote → zinit → oh-my-zsh → manual)
+  - Idempotent installation (safe to run multiple times)
+  - Color-coded output with quick start guide
+- **Installation methods table** in README for easy comparison
+- **Improved installation docs** with time estimates, checkpoints, and tabs
+
+### Changed
+
+- Rewrote `docs/getting-started/installation.md` with MkDocs Material tabs
+- Added troubleshooting and uninstalling sections
+
+---
+
 ## [4.4.3] - 2025-12-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Release v4.5.0 with one-liner installation support.

### New Features
- `curl -fsSL .../install.sh | bash` - Auto-detecting installer
- Installation methods comparison table in README
- Improved installation docs with MkDocs Material tabs

### Files Updated
- `install.sh` (new) - Auto-detecting installer script
- `README.md` - Added installation table
- `docs/getting-started/installation.md` - Complete rewrite
- `docs/CHANGELOG.md` - v4.5.0 entry
- `.STATUS` - Updated phase

## Test plan

- [x] All CI checks pass
- [x] install.sh tested with 4 plugin manager scenarios
- [x] mkdocs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)