### PR TITLE
ci: add install.sh tests to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,11 @@ jobs:
           cd ~/projects/dev-tools/flow-cli
           bash ./tests/cli/automated-tests.sh
 
+      - name: Run install.sh tests
+        run: |
+          cd ~/projects/dev-tools/flow-cli
+          bash ./tests/test-install.sh
+
       - name: Performance Summary
         if: always()
         run: |
@@ -169,6 +174,11 @@ jobs:
         run: |
           cd ~/projects/dev-tools/flow-cli
           zsh ./tests/test-sync.zsh
+
+      - name: Run install.sh tests
+        run: |
+          cd ~/projects/dev-tools/flow-cli
+          bash ./tests/test-install.sh
 
       - name: Performance Summary
         if: always()


### PR DESCRIPTION
## Summary

Add `test-install.sh` to CI workflow on both Ubuntu and macOS.

### Changes
- Added "Run install.sh tests" step to Ubuntu job
- Added "Run install.sh tests" step to macOS job

### Tests Run
- 22 tests for install.sh (detection, idempotency, validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)