### PR TITLE
chore: release v4.5.1 - Test Infrastructure

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -4,7 +4,7 @@
 ## Project: flow-cli
 ## Type: zsh-plugin
 ## Status: active
-## Phase: v4.5.0 Released
+## Phase: v4.5.1 Released
 ## Priority: 1
 ## Progress: 100
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v4.5.0)
+- **Status:** Production ready (v4.5.1)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -99,7 +99,7 @@ flow doctor       # Health check (verify dependencies)
 flow doctor --fix # Interactive install missing tools
 ```
 
-### Dopamine Features (v4.5.0)
+### Dopamine Features (v4.5.1)
 
 ```bash
 win <text>        # Log accomplishment (auto-categorized)
@@ -446,7 +446,7 @@ export FLOW_DEBUG=1
 
 ## Current Status (2025-12-30)
 
-### ✅ v4.5.0 Released (Documentation)
+### ✅ v4.5.1 Released (Documentation)
 
 - [x] 9 dedicated dispatcher reference pages:
   - CC, G, MCP, OBS, QU, R, TM, WT dispatchers
@@ -454,14 +454,14 @@ export FLOW_DEBUG=1
 - [x] All reference pages cross-linked with "See also"
 - [x] Tutorial 11: TM Dispatcher
 
-### ✅ v4.5.0 Released
+### ✅ v4.5.1 Released
 
 - [x] `tm` dispatcher - Terminal manager (aiterm integration)
   - Shell-native: `tm title`, `tm profile`, `tm which`
   - Aiterm delegation: `tm ghost`, `tm switch`, `tm detect`
   - Aliases: `tmt`, `tmp`, `tmg`, `tms`, `tmd`
 
-### ✅ v4.5.0 Released
+### ✅ v4.5.1 Released
 
 - [x] `g feature status` - Show merged vs active branches
 - [x] `g feature prune --older-than` - Filter by branch age
@@ -470,7 +470,7 @@ export FLOW_DEBUG=1
 - [x] `wt prune` - Comprehensive cleanup with branch deletion
 - [x] `cc wt status` - Show worktrees with Claude session info
 
-### ✅ v4.5.0 Released
+### ✅ v4.5.1 Released
 
 - [x] Worktree + Claude Integration (`cc wt`)
 - [x] Branch cleanup (`g feature prune`)
@@ -485,7 +485,7 @@ export FLOW_DEBUG=1
 - **Documentation:** https://Data-Wise.github.io/flow-cli/
 - **Tests:** 100+ tests across all features
 
-### 📋 Next: v4.5.0 - Installation Improvements
+### 📋 Next: v4.5.1 - Installation Improvements
 
 **Priority:** Immediate | **Plan:** `docs/planning/INSTALL-IMPROVEMENTS.md`
 
@@ -563,10 +563,10 @@ git diff
 
 # Commit and tag
 git add -A && git commit -m "chore: bump version to 3.7.0"
-git tag -a v4.5.0 -m "v4.5.0"
+git tag -a v4.5.1 -m "v4.5.1"
 
 # Push (requires PR for protected branch)
-git push origin main && git push origin v4.5.0
+git push origin main && git push origin v4.5.1
 ```
 
 **Files updated by release script:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.5.0-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.5.1-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
+## [4.5.1] - 2025-12-31
+
+### Added
+
+- **Install script tests** - 22 unit tests for `install.sh`
+  - Detection tests for all 4 plugin managers
+  - Idempotency tests
+  - Script validation tests
+- **Docker integration tests** - End-to-end install testing
+  - Ubuntu 22.04, 24.04
+  - Debian Bookworm, Bullseye
+  - Full plugin sourcing and command verification
+- **CI improvements**
+  - Install tests run on Ubuntu and macOS
+  - Release workflow requires install tests to pass
+
+---
+
 ## [4.5.0] - 2025-12-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Release v4.5.1 with comprehensive test infrastructure for install.sh.

### New in v4.5.1
- 22 unit tests for install.sh (detection, idempotency, validation)
- Docker integration tests (Ubuntu 22.04/24.04, Debian Bookworm/Bullseye)
- CI runs install tests on Ubuntu and macOS
- Release workflow requires install tests to pass

## Test plan

- [x] All CI checks pass
- [x] Docker tests pass locally (4/4 images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)