### PR TITLE
feat: add version pinning and Alpine Linux support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         container:
           - ubuntu:22.04
           - debian:bookworm
+          - alpine:3.20
 
     container:
       image: ${{ matrix.container }}
@@ -28,8 +29,12 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y git zsh curl
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache git zsh curl bash
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y git zsh curl
+          fi
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
+## [4.5.2] - 2025-12-31
+
+### Added
+
+- **Version pinning** - Install specific versions with `FLOW_VERSION`
+  - `FLOW_VERSION=v4.5.1 curl -fsSL .../install.sh | bash`
+  - Works with oh-my-zsh and manual install methods
+  - Graceful error if version tag not found
+- **Alpine Linux support** - Docker tests now include Alpine 3.19/3.20
+  - Smaller containers for faster CI
+  - Package manager detection (apk vs apt-get)
+- **26 unit tests** - Added 4 FLOW_VERSION tests
+
+---
+
 ## [4.5.1] - 2025-12-31
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -10,10 +10,22 @@ set -euo pipefail
 # Options:
 #   INSTALL_METHOD=antidote|zinit|omz|manual  (default: auto-detect)
 #   FLOW_INSTALL_DIR=/custom/path             (default: ~/.flow-cli)
+#   FLOW_VERSION=v4.5.1                       (default: latest)
+#
+# Examples:
+#   # Install latest
+#   curl -fsSL .../install.sh | bash
+#
+#   # Install specific version
+#   FLOW_VERSION=v4.5.1 curl -fsSL .../install.sh | bash
+#
+#   # Install with manual method
+#   INSTALL_METHOD=manual curl -fsSL .../install.sh | bash
 
 REPO="Data-Wise/flow-cli"
 PLUGIN_NAME="flow-cli"
 INSTALL_DIR="${FLOW_INSTALL_DIR:-$HOME/.flow-cli}"
+VERSION="${FLOW_VERSION:-}"
 
 # Colors
 RED='\033[0;31m'
@@ -109,6 +121,13 @@ install_omz() {
         success "Installed to $plugin_dir"
     fi
 
+    # Checkout specific version if requested
+    if [[ -n "$VERSION" ]]; then
+        info "Checking out version $VERSION..."
+        git -C "$plugin_dir" checkout --quiet "$VERSION" || error "Version $VERSION not found"
+        success "Using version $VERSION"
+    fi
+
     # Check if plugin is in plugins list
     local zshrc="${ZDOTDIR:-$HOME}/.zshrc"
     if grep -q "plugins=.*$PLUGIN_NAME" "$zshrc" 2>/dev/null; then
@@ -133,6 +152,13 @@ install_manual() {
         info "Cloning repository..."
         git clone --quiet "https://github.com/$REPO.git" "$INSTALL_DIR"
         success "Installed to $INSTALL_DIR"
+    fi
+
+    # Checkout specific version if requested
+    if [[ -n "$VERSION" ]]; then
+        info "Checking out version $VERSION..."
+        git -C "$INSTALL_DIR" checkout --quiet "$VERSION" || error "Version $VERSION not found"
+        success "Using version $VERSION"
     fi
 
     local zshrc="${ZDOTDIR:-$HOME}/.zshrc"

--- a/tests/docker-install-test.sh
+++ b/tests/docker-install-test.sh
@@ -24,6 +24,8 @@ IMAGES=(
     "ubuntu:24.04"
     "debian:bookworm"
     "debian:bullseye"
+    "alpine:3.19"
+    "alpine:3.20"
 )
 
 # Get script directory
@@ -70,12 +72,18 @@ test_install() {
 
     # Create test script to run inside container
     local test_script=$(cat <<'INNERSCRIPT'
-#!/bin/bash
+#!/bin/sh
 set -e
 
-# Install dependencies
-apt-get update -qq
-apt-get install -y -qq git zsh curl >/dev/null 2>&1
+# Install dependencies based on OS
+if command -v apk >/dev/null 2>&1; then
+    # Alpine Linux
+    apk add --no-cache git zsh curl bash >/dev/null 2>&1
+elif command -v apt-get >/dev/null 2>&1; then
+    # Debian/Ubuntu
+    apt-get update -qq
+    apt-get install -y -qq git zsh curl >/dev/null 2>&1
+fi
 
 # Setup test environment
 export HOME=/root

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -495,6 +495,55 @@ test_default_install_dir() {
 }
 
 # ============================================================================
+# FLOW_VERSION TESTS
+# ============================================================================
+
+test_version_variable_defined() {
+    log_test "VERSION variable is defined in install.sh"
+
+    if grep -q 'VERSION="${FLOW_VERSION:-}"' "$INSTALL_SCRIPT"; then
+        pass
+    else
+        fail "VERSION variable not found"
+    fi
+}
+
+test_version_checkout_in_omz() {
+    log_test "install_omz has version checkout logic"
+
+    if grep -A5 "install_omz" "$INSTALL_SCRIPT" | grep -q "Checking out version"; then
+        pass
+    else
+        # Check full file for version checkout in omz context
+        if grep -B5 "Check if plugin is in plugins list" "$INSTALL_SCRIPT" | grep -q "VERSION"; then
+            pass
+        else
+            fail "version checkout not found in install_omz"
+        fi
+    fi
+}
+
+test_version_checkout_in_manual() {
+    log_test "install_manual has version checkout logic"
+
+    if grep -A20 "install_manual()" "$INSTALL_SCRIPT" | grep -q "Checking out version"; then
+        pass
+    else
+        fail "version checkout not found in install_manual"
+    fi
+}
+
+test_version_env_documented() {
+    log_test "FLOW_VERSION is documented in header"
+
+    if grep -q "FLOW_VERSION=" "$INSTALL_SCRIPT"; then
+        pass
+    else
+        fail "FLOW_VERSION not documented in header"
+    fi
+}
+
+# ============================================================================
 # RUN ALL TESTS
 # ============================================================================
 
@@ -544,6 +593,14 @@ run_tests() {
     echo "------------------------"
     test_custom_install_dir
     test_default_install_dir
+
+    echo ""
+    echo -e "${YELLOW}FLOW_VERSION Tests${NC}"
+    echo "-------------------"
+    test_version_variable_defined
+    test_version_checkout_in_omz
+    test_version_checkout_in_manual
+    test_version_env_documented
 
     # Summary
     echo ""


### PR DESCRIPTION
## Summary

- **Version pinning**: Install specific versions with `FLOW_VERSION=v4.5.1`
- **Alpine Linux**: Added to Docker integration tests (3.19, 3.20)
- **26 unit tests**: Added 4 FLOW_VERSION tests

## Changes

### install.sh
- Version checkout in `install_omz` and `install_manual`
- Graceful error if version tag not found

### Docker tests
- Alpine 3.19 and 3.20 added to `docker-install-test.sh`
- Package manager detection (apk vs apt-get) in `release.yml`

### Test suite
- `test_version_variable_defined`
- `test_version_checkout_in_omz`
- `test_version_checkout_in_manual`
- `test_version_env_documented`

## Test plan
- [x] All 26 unit tests pass
- [ ] CI tests pass
- [ ] Docker tests with Alpine

🤖 Generated with [Claude Code](https://claude.com/claude-code)