### PR TITLE
feat: version pinning for antidote and zinit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.5.2-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.5.3-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
+## [4.5.3] - 2025-12-31
+
+### Added
+
+- **Version pinning for all install methods**
+  - Antidote: `FLOW_VERSION=v4.5.0` → adds `Data-Wise/flow-cli@v4.5.0`
+  - Zinit: `FLOW_VERSION=v4.5.0` → uses `zinit ice ver"v4.5.0"`
+  - Oh-my-zsh/Manual: Git checkout after clone
+- **28 unit tests** - Added 2 plugin manager version tests
+
+---
+
 ## [4.5.2] - 2025-12-31
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -73,11 +73,18 @@ install_antidote() {
         touch "$plugins_file"
     fi
 
+    # Build plugin entry (with optional version tag)
+    local plugin_entry="$REPO"
+    if [[ -n "$VERSION" ]]; then
+        plugin_entry="${REPO}@${VERSION}"
+        info "Pinning to version $VERSION"
+    fi
+
     if ! grep -q "$REPO" "$plugins_file" 2>/dev/null; then
         echo "" >> "$plugins_file"
         echo "# flow-cli - ZSH workflow tools" >> "$plugins_file"
-        echo "$REPO" >> "$plugins_file"
-        success "Added $REPO to $plugins_file"
+        echo "$plugin_entry" >> "$plugins_file"
+        success "Added $plugin_entry to $plugins_file"
     else
         success "Already in $plugins_file"
     fi
@@ -89,12 +96,20 @@ install_antidote() {
 install_zinit() {
     info "Installing with zinit..."
     local zshrc="${ZDOTDIR:-$HOME}/.zshrc"
-    local zinit_line="zinit light $REPO"
+
+    # Build zinit command (with optional version ice)
+    local zinit_cmd
+    if [[ -n "$VERSION" ]]; then
+        zinit_cmd="zinit ice ver\"$VERSION\"; zinit light $REPO"
+        info "Pinning to version $VERSION"
+    else
+        zinit_cmd="zinit light $REPO"
+    fi
 
     if ! grep -q "zinit.*$PLUGIN_NAME" "$zshrc" 2>/dev/null; then
         echo "" >> "$zshrc"
         echo "# flow-cli - ZSH workflow tools" >> "$zshrc"
-        echo "$zinit_line" >> "$zshrc"
+        echo "$zinit_cmd" >> "$zshrc"
         success "Added zinit configuration to $zshrc"
     else
         success "Already configured in $zshrc"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flow-cli",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flow-cli",
-      "version": "4.5.2",
+      "version": "4.5.3",
       "license": "MIT",
       "workspaces": [
         "cli"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -543,6 +543,28 @@ test_version_env_documented() {
     fi
 }
 
+test_version_pinning_antidote() {
+    log_test "antidote version pinning uses @tag syntax"
+
+    # Check that install_antidote has VERSION handling with @ syntax
+    if grep -A15 "install_antidote()" "$INSTALL_SCRIPT" | grep -q '@\${VERSION}'; then
+        pass
+    else
+        fail "antidote version pinning not found"
+    fi
+}
+
+test_version_pinning_zinit() {
+    log_test "zinit version pinning uses ice ver syntax"
+
+    # Check that install_zinit has VERSION handling with ver ice
+    if grep -A15 "install_zinit()" "$INSTALL_SCRIPT" | grep -q 'ver\\"'; then
+        pass
+    else
+        fail "zinit version pinning not found"
+    fi
+}
+
 # ============================================================================
 # RUN ALL TESTS
 # ============================================================================
@@ -601,6 +623,8 @@ run_tests() {
     test_version_checkout_in_omz
     test_version_checkout_in_manual
     test_version_env_documented
+    test_version_pinning_antidote
+    test_version_pinning_zinit
 
     # Summary
     echo ""


### PR DESCRIPTION
## Summary

Extends version pinning to work with all plugin managers:

| Method | Version Pinning Syntax |
|--------|------------------------|
| Antidote | `Data-Wise/flow-cli@v4.5.0` |
| Zinit | `zinit ice ver"v4.5.0"; zinit light ...` |
| Oh-my-zsh | `git checkout v4.5.0` after clone |
| Manual | `git checkout v4.5.0` after clone |

## Usage

```bash
# All methods support version pinning via FLOW_VERSION env var
FLOW_VERSION=v4.5.0 bash install.sh
```

## Test Results

**Unit tests:** 28/28 pass (2 new tests)
- `test_version_pinning_antidote`
- `test_version_pinning_zinit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)