### PR TITLE
feat: public release with Homebrew and uninstall

### DIFF
--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -1,0 +1,59 @@
+# typed: false
+# frozen_string_literal: true
+
+class FlowCli < Formula
+  desc "ZSH workflow tools designed for ADHD brains"
+  homepage "https://data-wise.github.io/flow-cli/"
+  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v4.5.3.tar.gz"
+  sha256 "79d2108d0bacd82341f8e5175e3102cb3f4afacab68effc01c802b7ca00d8672"
+  license "MIT"
+  head "https://github.com/Data-Wise/flow-cli.git", branch: "main"
+
+  depends_on "zsh"
+  depends_on "git"
+  depends_on "fzf"
+
+  def install
+    # Install the plugin files
+    prefix.install Dir["*"]
+
+    # Create a loader script
+    (prefix/"bin/flow-cli-init").write <<~EOS
+      #!/bin/zsh
+      # Source this file in your .zshrc to enable flow-cli
+      # Add to .zshrc: eval "$(flow-cli-init)"
+
+      echo "source #{prefix}/flow.plugin.zsh"
+    EOS
+    (prefix/"bin/flow-cli-init").chmod 0755
+  end
+
+  def caveats
+    <<~EOS
+      To activate flow-cli, add this to your ~/.zshrc:
+
+        source #{prefix}/flow.plugin.zsh
+
+      Or use the init script:
+
+        eval "$(#{prefix}/bin/flow-cli-init)"
+
+      Then restart your shell or run:
+        source ~/.zshrc
+
+      Quick start:
+        work my-project    # Start session
+        win "Fixed bug"    # Log accomplishment
+        finish             # End session
+    EOS
+  end
+
+  test do
+    # Test that the plugin file exists
+    assert_predicate prefix/"flow.plugin.zsh", :exist?
+
+    # Test that flow command is defined in the plugin
+    output = shell_output("grep -l 'flow()' #{prefix}/**/*.zsh", 0)
+    assert_match "flow", output
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.5.3-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.5.4-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 
@@ -168,6 +168,7 @@ FLOW_VERSION=v4.5.0 curl -fsSL https://raw.githubusercontent.com/Data-Wise/flow-
 | Method            | Command                                        | Best For       |
 | ----------------- | ---------------------------------------------- | -------------- |
 | **Quick Install** | `curl -fsSL .../install.sh \| bash`            | New users      |
+| **Homebrew**      | `brew install Data-Wise/tap/flow-cli`          | macOS users    |
 | **Antidote**      | Add `Data-Wise/flow-cli` to `.zsh_plugins.txt` | Antidote users |
 | **Zinit**         | `zinit light Data-Wise/flow-cli`               | Zinit users    |
 | **Oh-My-Zsh**     | Clone to `$ZSH_CUSTOM/plugins/`                | OMZ users      |
@@ -210,6 +211,12 @@ echo 'source ~/.flow-cli/flow.plugin.zsh' >> ~/.zshrc
 
 ```bash
 flow doctor        # Health check
+```
+
+### Uninstall
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Data-Wise/flow-cli/main/uninstall.sh | bash
 ```
 
 ---

--- a/docs/AWESOME-ZSH-PLUGINS-ENTRY.md
+++ b/docs/AWESOME-ZSH-PLUGINS-ENTRY.md
@@ -1,0 +1,53 @@
+# awesome-zsh-plugins Entry
+
+Add to the **Plugins** section (alphabetically under "f"):
+
+## Entry
+
+```markdown
+- [flow-cli](https://github.com/Data-Wise/flow-cli) - ADHD-optimized workflow tools with session tracking, win logging, and smart dispatchers for Claude Code, R, Quarto, and Git.
+```
+
+## How to Submit
+
+1. Fork [unixorn/awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins)
+2. Edit `README.md`
+3. Find the Plugins section, locate the "f" entries
+4. Add the entry above (maintaining alphabetical order)
+5. Submit a PR
+
+## Alternative: CLI Submission
+
+```bash
+# Fork and clone
+gh repo fork unixorn/awesome-zsh-plugins --clone
+cd awesome-zsh-plugins
+
+# Create branch
+git checkout -b add-flow-cli
+
+# Edit README.md to add the entry
+# (manually or with sed)
+
+# Commit and push
+git add README.md
+git commit -m "Add flow-cli - ADHD workflow tools"
+git push origin add-flow-cli
+
+# Create PR
+gh pr create --title "Add flow-cli" --body "Adds flow-cli - ZSH workflow tools designed for ADHD brains.
+
+Features:
+- Session tracking with \`work\` / \`finish\`
+- Win logging with dopamine feedback
+- Smart dispatchers for Claude Code, R, Quarto, Git
+- Sub-10ms response time
+
+https://github.com/Data-Wise/flow-cli"
+```
+
+## Category
+
+The plugin fits in:
+- **Plugins** (main listing)
+- Possibly also under **Productivity** if that section exists

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
+## [4.5.4] - 2025-12-31
+
+### Added
+
+- **Repo is now public** - curl install works for everyone
+- **Homebrew formula** - `brew install Data-Wise/tap/flow-cli`
+- **Uninstall script** - `curl .../uninstall.sh | bash`
+- **awesome-zsh-plugins entry** - Ready to submit PR
+
+---
+
 ## [4.5.3] - 2025-12-31
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flow-cli",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flow-cli",
-      "version": "4.5.3",
+      "version": "4.5.4",
       "license": "MIT",
       "workspaces": [
         "cli"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+set -euo pipefail
+
+# flow-cli uninstaller
+# Cleanly removes flow-cli from your system
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Data-Wise/flow-cli/main/uninstall.sh | bash
+#
+# Or run locally:
+#   bash uninstall.sh
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info() { echo -e "${YELLOW}==>${NC} $1"; }
+success() { echo -e "${GREEN}✓${NC} $1"; }
+warn() { echo -e "${YELLOW}!${NC} $1"; }
+
+# Detect installation method
+detect_installation() {
+    local zshrc="${ZDOTDIR:-$HOME}/.zshrc"
+    local plugins_file="${ZDOTDIR:-$HOME}/.zsh_plugins.txt"
+
+    # Check antidote
+    if [[ -f "$plugins_file" ]] && grep -q "flow-cli" "$plugins_file" 2>/dev/null; then
+        echo "antidote"
+        return
+    fi
+
+    # Check zinit
+    if grep -q "zinit.*flow-cli" "$zshrc" 2>/dev/null; then
+        echo "zinit"
+        return
+    fi
+
+    # Check oh-my-zsh
+    local omz_plugin="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/flow-cli"
+    if [[ -d "$omz_plugin" ]]; then
+        echo "omz"
+        return
+    fi
+
+    # Check manual
+    if [[ -d "$HOME/.flow-cli" ]]; then
+        echo "manual"
+        return
+    fi
+
+    echo "none"
+}
+
+# Remove from antidote
+uninstall_antidote() {
+    info "Removing from antidote..."
+    local plugins_file="${ZDOTDIR:-$HOME}/.zsh_plugins.txt"
+
+    if [[ -f "$plugins_file" ]]; then
+        # Remove flow-cli lines (including comment)
+        sed -i.bak '/flow-cli/d' "$plugins_file"
+        rm -f "${plugins_file}.bak"
+        success "Removed from $plugins_file"
+    fi
+
+    # Remove cached plugin
+    local cache_dir="${ANTIDOTE_HOME:-$HOME/.cache/antidote}"
+    if [[ -d "$cache_dir" ]]; then
+        rm -rf "$cache_dir"/*flow-cli* 2>/dev/null || true
+        success "Cleared antidote cache"
+    fi
+
+    warn "Run 'antidote update' to complete removal"
+}
+
+# Remove from zinit
+uninstall_zinit() {
+    info "Removing from zinit..."
+    local zshrc="${ZDOTDIR:-$HOME}/.zshrc"
+
+    if [[ -f "$zshrc" ]]; then
+        # Remove zinit flow-cli lines
+        sed -i.bak '/flow-cli/d' "$zshrc"
+        rm -f "${zshrc}.bak"
+        success "Removed from $zshrc"
+    fi
+
+    # Remove zinit plugin directory
+    local zinit_plugins="${ZINIT_HOME:-$HOME/.zinit}/plugins"
+    if [[ -d "$zinit_plugins" ]]; then
+        rm -rf "$zinit_plugins"/*flow-cli* 2>/dev/null || true
+        success "Removed zinit plugin files"
+    fi
+}
+
+# Remove from oh-my-zsh
+uninstall_omz() {
+    info "Removing from oh-my-zsh..."
+    local plugin_dir="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/flow-cli"
+
+    if [[ -d "$plugin_dir" ]]; then
+        rm -rf "$plugin_dir"
+        success "Removed $plugin_dir"
+    fi
+
+    local zshrc="${ZDOTDIR:-$HOME}/.zshrc"
+    warn "Remember to remove 'flow-cli' from plugins=(...) in $zshrc"
+}
+
+# Remove manual installation
+uninstall_manual() {
+    info "Removing manual installation..."
+    local install_dir="$HOME/.flow-cli"
+    local zshrc="${ZDOTDIR:-$HOME}/.zshrc"
+
+    if [[ -d "$install_dir" ]]; then
+        rm -rf "$install_dir"
+        success "Removed $install_dir"
+    fi
+
+    if [[ -f "$zshrc" ]]; then
+        # Remove source line
+        sed -i.bak '/flow.plugin.zsh/d' "$zshrc"
+        sed -i.bak '/flow-cli.*ZSH workflow/d' "$zshrc"
+        rm -f "${zshrc}.bak"
+        success "Removed from $zshrc"
+    fi
+}
+
+# Main uninstall flow
+main() {
+    echo ""
+    echo -e "${BOLD}flow-cli uninstaller${NC}"
+    echo ""
+
+    local method
+    method=$(detect_installation)
+
+    if [[ "$method" == "none" ]]; then
+        warn "flow-cli installation not detected"
+        echo ""
+        echo "Checked locations:"
+        echo "  - ~/.zsh_plugins.txt (antidote)"
+        echo "  - ~/.zshrc (zinit)"
+        echo "  - ~/.oh-my-zsh/custom/plugins/flow-cli"
+        echo "  - ~/.flow-cli"
+        exit 0
+    fi
+
+    info "Detected installation: ${BOLD}${method}${NC}"
+    echo ""
+
+    case "$method" in
+        antidote) uninstall_antidote ;;
+        zinit)    uninstall_zinit ;;
+        omz)      uninstall_omz ;;
+        manual)   uninstall_manual ;;
+    esac
+
+    echo ""
+    success "flow-cli has been uninstalled"
+    echo ""
+    echo "Restart your shell or run:"
+    echo "  source ~/.zshrc"
+    echo ""
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

The repo is now PUBLIC! This PR adds distribution tools:

### New Features

1. **Homebrew formula**
   ```bash
   brew install Data-Wise/tap/flow-cli
   ```

2. **Uninstall script**
   ```bash
   curl -fsSL https://raw.githubusercontent.com/Data-Wise/flow-cli/main/uninstall.sh | bash
   ```

3. **awesome-zsh-plugins entry** - Ready for submission

### Updated

- README with Homebrew in installation methods table
- README with uninstall section
- CHANGELOG for v4.5.4

## Test plan

- [x] `brew info Data-Wise/tap/flow-cli` works
- [x] `curl .../install.sh | bash` works (repo is public)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)