### PR TITLE
fix(ci): remove pip cache from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
-          cache: 'pip'
 
       - name: Install MkDocs and dependencies
         run: |


### PR DESCRIPTION
Fixes docs deployment failure. The pip cache requires requirements.txt which doesn't exist.