### PR TITLE
fix(ci): add mkdocs-exclude plugin to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,7 @@ jobs:
           pip install mkdocs
           pip install mkdocs-material
           pip install mkdocs-mermaid2-plugin
+          pip install mkdocs-exclude
 
       - name: Build and deploy docs
         run: mkdocs gh-deploy --force --clean --verbose


### PR DESCRIPTION
## Summary
- Add missing `mkdocs-exclude` plugin to pip install in docs workflow
- Fixes docs deployment failure caused by missing plugin

The `mkdocs.yml` uses the exclude plugin but it wasn't being installed in the CI workflow.

## Test plan
- [ ] Verify docs workflow passes after merge
- [ ] Confirm docs deploy to https://data-wise.github.io/flow-cli/

🤖 Generated with [Claude Code](https://claude.com/claude-code)