### PR TITLE
fix: sync FLOW_VERSION to 4.5.5

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -502,9 +502,9 @@ _g_feature_status() {
 - 2025-12-25: Legacy 140KB functions archived
 - 2025-12-25: Symlink-only external integrations
 
-## wins: Created install improvements plan (2025-12-30)
-## streak: 6
-## last_active: 2025-12-30 18:30
+## wins: Updated docs (2025-12-30), Added unit tests (2025-12-30), Fixed the login bug (2025-12-30), Created install improvements plan (2025-12-30)
+## streak: 0
+## last_active: 2025-12-30 18:17
 
 ## Next: v4.5.0 - Installation Improvements
 - [ ] Create install.sh (curl one-liner, auto-detect plugin manager)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-cli
 
-[![Version](https://img.shields.io/badge/version-4.5.4-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
+[![Version](https://img.shields.io/badge/version-4.5.5-blue.svg)](https://github.com/Data-Wise/flow-cli/releases)
 [![Tests](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml/badge.svg)](https://github.com/Data-Wise/flow-cli/actions)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://data-wise.github.io/flow-cli/)
 

--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -120,7 +120,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="3.6.0"
+export FLOW_VERSION="4.5.5"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,7 +35,11 @@ sed -i '' "s/releases\/tag\/v[0-9]*\.[0-9]*\.[0-9]*/releases\/tag\/v$VERSION/" R
 echo "📝 Updating CLAUDE.md..."
 sed -i '' "s/v[0-9]*\.[0-9]*\.[0-9]*/v$VERSION/g" CLAUDE.md
 
-# 4. Update CC-DISPATCHER-REFERENCE.md
+# 4. Update flow.plugin.zsh
+echo "🔌 Updating flow.plugin.zsh..."
+sed -i '' "s/FLOW_VERSION=\"[^\"]*\"/FLOW_VERSION=\"$VERSION\"/" flow.plugin.zsh
+
+# 5. Update CC-DISPATCHER-REFERENCE.md
 echo "📖 Updating CC-DISPATCHER-REFERENCE.md..."
 sed -i '' "s/Version: v[0-9]*\.[0-9]*\.[0-9]*/Version: v$VERSION/" docs/reference/CC-DISPATCHER-REFERENCE.md
 


### PR DESCRIPTION
## Summary
- Fixed FLOW_VERSION in flow.plugin.zsh (was stuck at 3.6.0)
- Added flow.plugin.zsh to release script for future releases
- Bumped version to 4.5.5

`flow --version` now correctly shows 4.5.5 instead of 3.6.0.

## Test plan
- [ ] `flow --version` shows v4.5.5
- [ ] Homebrew formula update after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)