### PR TITLE
chore: update Homebrew formula to v4.5.5

### DIFF
--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -4,8 +4,8 @@
 class FlowCli < Formula
   desc "ZSH workflow tools designed for ADHD brains"
   homepage "https://data-wise.github.io/flow-cli/"
-  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v4.5.3.tar.gz"
-  sha256 "79d2108d0bacd82341f8e5175e3102cb3f4afacab68effc01c802b7ca00d8672"
+  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v4.5.5.tar.gz"
+  sha256 "415d996c120606463b2ea089e735124b65a92c0a70521b58d0513b36700189ac"
   license "MIT"
   head "https://github.com/Data-Wise/flow-cli.git", branch: "main"
 


### PR DESCRIPTION
Sync formula in repo with homebrew-tap