### PR TITLE
feat(pick): add worktree docs and session-age sorting

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -4,7 +4,7 @@
 ## Project: flow-cli
 ## Type: zsh-plugin
 ## Status: active
-## Phase: v4.5.5 Released
+## Phase: v4.6.1 Released
 ## Priority: 1
 ## Progress: 100
 

--- a/docs/reference/PICK-COMMAND-REFERENCE.md
+++ b/docs/reference/PICK-COMMAND-REFERENCE.md
@@ -67,6 +67,48 @@ When you run `pick` with no args and have a recent session:
 
 Sessions expire after 24 hours.
 
+### Worktree Integration (v4.6.1)
+
+By default, `pick` shows **both projects AND worktrees**:
+
+```text
+flow-cli             🔧 dev
+mediationverse       📦 r
+medrobust            📦 r
+flow-cli (feature-x) 🌳 wt   🟢 2h
+aiterm (bugfix)      🌳 wt   🟡 old
+```
+
+**Key features:**
+
+- **🌳 icon** indicates a git worktree
+- **Session indicators** show Claude Code activity:
+  - 🟢 Recent session (within 24h) with time since last activity
+  - 🟡 Old session (>24h ago)
+- **Sorted by recency** - most recently used worktrees appear first
+
+**Worktree-only view:**
+
+```bash
+pick wt              # Show only worktrees
+pick wt flow         # Filter worktrees for "flow" project
+```
+
+**Requirements:**
+
+Worktrees must be organized under `~/.git-worktrees` (default):
+
+```
+~/.git-worktrees/
+├── flow-cli/
+│   ├── feature-x/       # worktree for feature-x branch
+│   └── bugfix/          # worktree for bugfix branch
+└── aiterm/
+    └── develop/         # worktree for develop branch
+```
+
+To create a worktree: `wt create <branch>` or `git worktree add ~/.git-worktrees/<project>/<branch> <branch>`
+
 ### Categories
 
 All category names are case-insensitive and support multiple aliases:
@@ -79,6 +121,7 @@ All category names are case-insensitive and support multiple aliases:
 | **teach** | `teach`, `teaching`                  | Teaching courses  |
 | **rs**    | `rs`, `research`, `res`              | Research projects |
 | **app**   | `app`, `apps`                        | Applications      |
+| **wt**    | `wt`, `worktree`, `worktrees`        | Git worktrees     |
 
 ---
 
@@ -115,6 +158,7 @@ apple-notes-sync     🔧 dev
 - 📚 - Teaching courses (`teach`)
 - 🔬 - Research projects (`rs`)
 - 📱 - Applications (`app`)
+- 🌳 - Git worktrees (`wt`)
 
 ---
 
@@ -250,5 +294,5 @@ printf '\033[32m✅\033[0m'  # Single quotes don't interpret escapes
 
 ---
 
-**Last Updated:** 2025-12-26
-**Status:** ✅ Fully implemented (v2.0 - smart defaults)
+**Last Updated:** 2025-12-31
+**Status:** ✅ Fully implemented (v4.6.1 - worktree integration)


### PR DESCRIPTION
## Summary

- Update PICK-COMMAND-REFERENCE.md with worktree integration section
- Add `wt` to categories table with aliases
- Add 🌳 to icons list
- Implement session-age sorting for worktrees (newest first)
- Add `_proj_get_session_mtime()` helper function

## Changes

| File | Change |
|------|--------|
| `docs/reference/PICK-COMMAND-REFERENCE.md` | Add worktree documentation section |
| `commands/pick.zsh` | Add session-age sorting for worktrees |

## Test plan

- [x] Run `zsh ./tests/test-pick-wt.zsh` - 22/22 tests pass
- [x] Verify sorting: `source ./flow.plugin.zsh && _proj_list_worktrees`
- [x] Most recent worktree (🟢) appears first

🤖 Generated with [Claude Code](https://claude.com/claude-code)