### PR TITLE
feat(pick): add frecency sorting and --recent flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install zsh
-        run: sudo apt-get update && sudo apt-get install -y zsh
+      - name: Cache apt packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: zsh
+          version: 1.0
 
       - name: Record start time
         id: start


### PR DESCRIPTION
## Summary

- Cache apt packages in CI using `awalsh128/cache-apt-pkgs-action` for faster builds
- Add frecency sorting to projects (most recently used first based on Claude session activity)
- Add `--recent` / `-r` flag to show only projects with active Claude sessions
- Both projects and worktrees now sorted by last session activity

## Usage

```bash
pick              # All projects, frecency sorted (most recent first)
pick --recent     # Only projects with Claude sessions
pick -r dev       # Recent dev-tools only
```

## Changes

| File | Change |
|------|--------|
| `.github/workflows/test.yml` | Add apt package caching |
| `commands/pick.zsh` | Frecency sorting + --recent flag |

## Test plan

- [x] `zsh ./tests/test-pick-wt.zsh` - 22/22 pass
- [x] `_proj_list_all ""` - shows frecency sorted
- [x] `_proj_list_all "" "recent"` - filters to recent only
- [x] `pick --help` shows `-r, --recent` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)