### PR TITLE
chore: update CLAUDE.md, add frecency to worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management.
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Status:** Production ready (v4.6.1)
+- **Status:** Production ready (v4.6.4)
 - **Install:** Via plugin manager (antidote, zinit, oh-my-zsh)
 - **Optional:** Atlas integration for enhanced state management
 - **Health Check:** `flow doctor` for dependency verification
@@ -99,7 +99,7 @@ flow doctor       # Health check (verify dependencies)
 flow doctor --fix # Interactive install missing tools
 ```
 
-### Dopamine Features (v4.6.1)
+### Dopamine Features (v4.6.4)
 
 ```bash
 win <text>        # Log accomplishment (auto-categorized)
@@ -159,7 +159,7 @@ tm detect             # Detect project context
 
 **Aliases:** `tmt` = title, `tmp` = profile, `tmg` = ghost, `tms` = switch
 
-### Pick - Project Picker (v4.6.0)
+### Pick - Project Picker (v4.6.4)
 
 ```bash
 pick                # FZF picker (all projects)
@@ -465,28 +465,41 @@ export FLOW_DEBUG=1
 
 ## Current Status (2025-12-31)
 
+### ✅ v4.6.4 Released - Frecency & Session Indicators
+
+- [x] Frecency decay scoring (time-based priority decay)
+- [x] Session indicators (🟢/🟡) on regular projects, not just worktrees
+- [x] Projects sorted by recent Claude activity
+
+### ✅ v4.6.3 Released - Frecency Sorting
+
+- [x] `pick --recent` / `pick -r` - Show only projects with Claude sessions
+- [x] Frecency sorting (most recently used first)
+- [x] CI apt caching (~17s vs 5+ min)
+
+### ✅ v4.6.2 Released - CI Optimization
+
+- [x] CI reduced to smoke tests (~30s)
+- [x] `./tests/run-all.sh` for local full test suite
+- [x] Pick worktree docs and session-age sorting
+
 ### ✅ v4.6.1 Released
 
-- [x] `pick` shows worktrees in default view (🌳 icons + session indicators)
-- [x] CI streamlined: 4 jobs → 1 job, ~60s (was 5+ min)
+- [x] `pick` shows worktrees in default view (🌳 icons)
+- [x] CI streamlined: 4 jobs → 1 job
 
 ### ✅ v4.6.0 Released - Worktree-Aware Pick
 
 - [x] `pick wt` - List all worktrees from `~/.git-worktrees/`
-- [x] `pick wt <project>` - Filter worktrees by project name
-- [x] Session indicators: 🟢 recent / 🟡 old / (none)
-- [x] Ctrl-O - cd + launch Claude (cc mode)
-- [x] Ctrl-Y - cd + launch Claude YOLO (ccy mode)
-- [x] `--no-claude` flag for cc dispatcher integration
-- [x] `pickwt` alias
-- [x] Tests for new pick wt functionality (22 tests)
+- [x] Session indicators: 🟢 recent / 🟡 old
+- [x] Ctrl-O/Y - cd + launch Claude
 
 ### 🎯 Production Ready
 
-- **Version:** 4.6.1
+- **Version:** 4.6.4
 - **Released:** 2025-12-31
 - **Status:** Production use phase
-- **Performance:** Sub-10ms for core commands
+- **Performance:** Sub-10ms for core commands, CI ~17s
 - **Documentation:** https://Data-Wise.github.io/flow-cli/
 - **Tests:** 100+ tests across all features
 

--- a/commands/pick.zsh
+++ b/commands/pick.zsh
@@ -282,12 +282,15 @@ _proj_list_worktrees() {
             local session_mtime=$(_proj_get_session_mtime "${wt_dir%/}")
             local session_status=$(_proj_get_claude_session_status "${wt_dir%/}")
 
-            # Store with mtime prefix for sorting (mtime|data)
-            worktree_data+=("${session_mtime}|${display_name}|wt|🌳|${wt_dir%/}|${session_status}")
+            # Calculate frecency score for sorting (same decay as projects)
+            local frecency=$(_proj_frecency_score "$session_mtime")
+
+            # Store with frecency prefix for sorting
+            worktree_data+=("${frecency}|${display_name}|wt|🌳|${wt_dir%/}|${session_status}")
         done
     done
 
-    # Sort by mtime (descending - newest first) and output without mtime prefix
+    # Sort by frecency (descending - newest first) and output without score prefix
     printf '%s\n' "${worktree_data[@]}" | sort -t'|' -k1 -rn | cut -d'|' -f2-
 }
 


### PR DESCRIPTION
## Summary

- Update CLAUDE.md version references to v4.6.4
- Update status section with v4.6.0-v4.6.4 releases
- Apply frecency scoring to worktrees (same decay algorithm as projects)

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | Version refs, status section |
| `commands/pick.zsh` | Worktree frecency sorting |

## Test plan

- [x] `zsh ./tests/test-pick-wt.zsh` - 22/22 pass
- [x] Worktrees now sorted by frecency, not raw mtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)