### PR TITLE
docs: update for v4.7.0 remote sync and recent releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,92 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [4.7.0] - 2025-12-31
+
+### ✨ Added
+
+- **iCloud Remote Sync** - Multi-device sync support
+  - `flow sync remote` - Show sync status
+  - `flow sync remote init` - Set up iCloud sync (migrates wins.md, goal.json, sync-state.json)
+  - `flow sync remote disable` - Revert to local storage
+  - Apple handles sync automatically - zero new dependencies
+  - Works offline (syncs when connected)
+
+### 📖 Documentation
+
+- Updated `docs/commands/sync.md` with remote sync section
+
+---
+
+## [4.6.5] - 2025-12-31
+
+### ✨ Added
+
+- **Frecency sorting for worktrees** - Most recently used worktrees appear first
+
+### 🔧 Changed
+
+- Updated CLAUDE.md with v4.6.5 status
+
+---
+
+## [4.6.4] - 2025-12-31
+
+### ✨ Added
+
+- **Frecency decay algorithm** - Time-based priority scoring for projects
+  - < 1 hour: 1000 points
+  - < 24 hours: 520-980 points (decays ~20/hour)
+  - < 7 days: 150-450 points (decays ~50/day)
+  - > 7 days: 1-90 points (decays ~10/week)
+- **Session indicators on projects** - 🟢 recent / 🟡 old based on `.claude` directory activity
+
+---
+
+## [4.6.3] - 2025-12-31
+
+### ✨ Added
+
+- **`pick --recent` flag** - Filter to show only projects with Claude sessions
+- **Frecency sorting** - Projects sorted by recent usage, not alphabetically
+
+### ⚡ Performance
+
+- CI apt package caching - Tests now run in ~17 seconds
+
+---
+
+## [4.6.2] - 2025-12-31
+
+### ⚡ Performance
+
+- **CI smoke tests** - Reduced from full suite to smoke tests (~30s)
+- Created `tests/run-all.sh` for comprehensive local testing
+
+---
+
+## [4.6.1] - 2025-12-31
+
+### ✨ Added
+
+- **Worktrees in pick** - `pick` now shows both projects AND worktrees
+- **Session indicators** - 🟢/🟡 icons show Claude Code activity status
+
+### ⚡ Performance
+
+- Streamlined CI from 4 jobs to 1 (Ubuntu only, ZSH is cross-platform)
+
+---
+
+## [4.6.0] - 2025-12-31
+
+### ✨ Added
+
+- **Worktree-aware pick** - `pick wt` subcommand for worktree navigation
+- **Session age sorting** - Worktrees sorted by most recent Claude session
+
+---
+
 ## [2.0.0-beta.1] - 2025-12-24
 
 ### 🎉 Production-Ready CLI with Clean Architecture

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -31,6 +31,7 @@ flow sync [target] [options]
 | `wins`    | Aggregate project wins to global wins.md    | ~15ms  |
 | `goals`   | Recalculate daily goal progress             | ~5ms   |
 | `git`     | Smart git push/pull with stash handling     | ~1.2s  |
+| `remote`  | iCloud sync for multi-device access         | ~10ms  |
 | `all`     | Run all targets in dependency order         | ~1.4s  |
 | (none)    | Smart sync - auto-detect what needs syncing | ~50ms  |
 
@@ -133,6 +134,36 @@ Recalculates daily goal progress based on wins.
 - **Reads:** `$FLOW_DATA_DIR/goal.json` (for target)
 - **Writes:** Updated `$FLOW_DATA_DIR/goal.json`
 - **Output:** Progress (e.g., "5/3 (100%)")
+
+### `flow sync remote`
+
+iCloud sync for multi-device access (v4.7.0+).
+
+```bash
+flow sync remote              # Show sync status
+flow sync remote init         # Set up iCloud sync
+flow sync remote disable      # Revert to local storage
+```
+
+**Setup:**
+
+1. Run `flow sync remote init` to migrate core data to iCloud
+2. Add `source ~/.config/flow/remote.conf` to your `~/.zshrc`
+3. Restart shell - Apple handles sync automatically
+
+**Synced data:**
+
+- `wins.md` - Daily accomplishments
+- `goal.json` - Daily goal progress
+- `sync-state.json` - Last sync metadata
+
+**Multi-device:**
+
+- Same iCloud account = automatic sync across devices
+- Works offline (syncs when connected)
+- No conflicts with local-only data (worklog, inbox)
+
+**iCloud path:** `~/Library/Mobile Documents/com~apple~CloudDocs/flow-cli/`
 
 ### `flow sync git`
 
@@ -325,6 +356,7 @@ flow sync schedule logs            # View logs
 | ------- | ---------------------------------------------- |
 | v4.0.0  | Initial release with 5 sync targets            |
 | v4.0.1  | Added `schedule` for automated background sync |
+| v4.7.0  | Added `remote` for iCloud multi-device sync    |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add remote sync documentation to `docs/commands/sync.md`
- Add CHANGELOG entries for v4.6.0 through v4.7.0

## Changes
- **sync.md**: Added `remote` target table entry, full `flow sync remote` section
- **CHANGELOG.md**: 7 release entries documenting all today's work

🤖 Generated with [Claude Code](https://claude.com/claude-code)