### PR TITLE
docs: update for pick command bug fix (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Apple handles sync automatically - zero new dependencies
   - Works offline (syncs when connected)
 
+### 🐛 Fixed
+
+- **pick command crash** - Fixed "bad math expression" error when `wc` output contains non-numeric data (#155)
+  - Added input sanitization in `_proj_show_git_status()` to handle terminal control codes
+  - Strip whitespace and validate numeric format with fallback to `0`
+  - Added regression test to prevent future occurrences
+  - Affects: `pick`, `pick wt`, worktree navigation with Ctrl-O/Ctrl-Y keybindings
+
 ### 📖 Documentation
 
 - Updated `docs/commands/sync.md` with remote sync section
+- Added `BUG-FIX-git-status-math-error.md` with technical details
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,13 @@ export FLOW_DEBUG=1
 
 ## Current Status (2025-12-31)
 
+### ✅ v4.7.0 Released - Bug Fix: Pick Command Crash
+
+- [x] Fixed "bad math expression" error in `_proj_show_git_status()` (#155)
+- [x] Added input sanitization for `wc` output (handles terminal control codes)
+- [x] Added regression test to prevent future occurrences
+- [x] All 23 tests passing
+
 ### ✅ v4.7.0 Released - Frecency & Session Indicators
 
 - [x] Frecency decay scoring (time-based priority decay)


### PR DESCRIPTION
## Summary
Documentation updates for the bug fix merged in #155.

## Changes
- **CHANGELOG.md**: Added "🐛 Fixed" section to v4.7.0 documenting the pick command crash fix
- **CLAUDE.md**: Added bug fix to current status section with completion checkmarks

## Context
This PR documents the sanitization fix that prevents "bad math expression" errors in `_proj_show_git_status()` when `wc` output contains non-numeric data.

The fix itself was already merged in #155. This PR adds user-facing and developer-facing documentation.

## Test Plan
- [x] CHANGELOG follows Keep a Changelog format
- [x] CLAUDE.md maintains consistent status update format
- [x] Both files auto-formatted by lint-staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>