### PR TITLE
fix: remove broken doc links

### DIFF
--- a/.archive/brainstorms-2026-01/DISPATCHER-CONSOLIDATION-REPORT-2025-12-19.md
+++ b/.archive/brainstorms-2026-01/DISPATCHER-CONSOLIDATION-REPORT-2025-12-19.md
@@ -10,14 +10,14 @@
 
 ### ✅ What Was Delivered
 
-| Component | Status | Details |
-|-----------|--------|---------|
-| **New Dispatchers** | ✅ Created | timer (9 keywords), peek (10 keywords) |
-| **Enhanced Dispatchers** | ✅ LIVE | r (+4), qu (+6), v (+5), cc (verified), gm (+1) |
-| **Cleanup Plan** | ✅ Ready | 10 items to remove (from 54 checked) |
-| **Reorganization** | ✅ Ready | 65 functions mapped, script created |
-| **Documentation** | ✅ Complete | 17 files, 100+ KB |
-| **Tests** | ✅ Passed | 22/22 (100%) |
+| Component                | Status      | Details                                         |
+| ------------------------ | ----------- | ----------------------------------------------- |
+| **New Dispatchers**      | ✅ Created  | timer (9 keywords), peek (10 keywords)          |
+| **Enhanced Dispatchers** | ✅ LIVE     | r (+4), qu (+6), v (+5), cc (verified), gm (+1) |
+| **Cleanup Plan**         | ✅ Ready    | 10 items to remove (from 54 checked)            |
+| **Reorganization**       | ✅ Ready    | 65 functions mapped, script created             |
+| **Documentation**        | ✅ Complete | 17 files, 100+ KB                               |
+| **Tests**                | ✅ Passed   | 22/22 (100%)                                    |
 
 ### 📈 Impact
 
@@ -71,6 +71,7 @@
 **Created:** `/tmp/dispatcher_additions.zsh`
 
 **Contents:**
+
 - `timer()` dispatcher - 9 keywords (focus, deep, break, long, stop, status, pom, help)
 - `peek()` dispatcher - 10 keywords (r, rd, qu, md, desc, news, status, log, help, auto-detect)
 
@@ -126,6 +127,7 @@
 **Key Finding:** Of 54 requested removals, only **10 items actually exist**
 
 **Items to Remove:**
+
 - 5 pick aliases (pickr, pickdev, pickq, pickteach, pickrs)
 - 2 R functions (rcycle, rquick)
 - 3 commented lines from .zshrc
@@ -212,6 +214,7 @@ zsh -c 'source ~/.zshrc && peek help'
 ### Phase 4: File Reorganization (5-6 hours)
 
 Choose implementation approach:
+
 - **Conservative (Recommended):** 3 weeks, very low risk
 - **Aggressive:** 2 sessions, medium risk
 - **Incremental:** 3-4 weeks, minimal risk
@@ -380,6 +383,7 @@ Agent 2's 22/22 test pass rate provides confidence that all enhancements work co
 **Solution:** Created `timer()` dispatcher that supersedes all focus() implementations
 
 **Migration:**
+
 ```bash
 focus → timer focus
 unfocus → timer stop

--- a/docs/guides/MONOREPO-COMMANDS-TUTORIAL.md
+++ b/docs/guides/MONOREPO-COMMANDS-TUTORIAL.md
@@ -495,15 +495,7 @@ Congratulations! You now know:
 
 ### If you want to learn more:
 
-1. **Read the full audit:**
-   - [MONOREPO-AUDIT-2025-12-20.md](MONOREPO-AUDIT-2025-12-20.md)
-   - More technical details about the setup
-
-2. **Read the implementation summary:**
-   - [OPTION-A-IMPLEMENTATION-2025-12-20.md](OPTION-A-IMPLEMENTATION-2025-12-20.md)
-   - See what changed and why
-
-3. **Explore the workspaces:**
+1. **Explore the workspaces:**
    - `app/README.md` - Desktop app documentation
    - `cli/README.md` - CLI integration documentation
 

--- a/docs/guides/PROJECT-SCOPE.md
+++ b/docs/guides/PROJECT-SCOPE.md
@@ -208,8 +208,6 @@ Fast fuzzy finder for switching between projects.
 └─────────────────────────────────────────────────────────┘
 ```
 
-See [ARCHITECTURE-INTEGRATION.md](ARCHITECTURE-INTEGRATION.md) for complete details.
-
 ---
 
 ## Integration with Existing Dev-Tools
@@ -276,8 +274,6 @@ See [ARCHITECTURE-INTEGRATION.md](ARCHITECTURE-INTEGRATION.md) for complete deta
 **Goal:** Set up architecture and port essential functions
 
 - [x] Create PROJECT-SCOPE.md (this document)
-- [x] Create ARCHITECTURE-INTEGRATION.md
-- [x] Create PROPOSAL-MERGE-OR-PORT.md (decided to port)
 - [x] Update documents to reflect porting approach
 - [ ] Create directory structure (cli/core, cli/vendor, data/sessions)
 - [ ] Port zsh-claude-workflow functions (~300 lines, 3 hours)


### PR DESCRIPTION
## Summary

- Archive `00-START-HERE.md` (historical report with many dead links)
- Remove broken links from `MONOREPO-COMMANDS-TUTORIAL.md`
- Remove broken links from `PROJECT-SCOPE.md`

Fixes mkdocs build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)