### PR TITLE
docs: fix final broken documentation links

### DIFF
--- a/docs/guides/00-START-HERE.md
+++ b/docs/guides/00-START-HERE.md
@@ -103,7 +103,6 @@ Example: `cc help`, `r help`, `qu help`
 ### Alias & Shortcut References
 
 - **[Alias Reference Card](../reference/ALIAS-REFERENCE-CARD.md)** - All 28 aliases
-- **[Git Alias Reference](../reference/GIT-ALIAS-REFERENCE.md)** - Git shortcuts
 
 ---
 

--- a/docs/specs/SPEC-cc-unified-grammar-2026-01-02.md
+++ b/docs/specs/SPEC-cc-unified-grammar-2026-01-02.md
@@ -1,8 +1,8 @@
 # SPEC: CC Unified Grammar
 
-**Status:** Draft
+**Status:** Implemented
 **Created:** 2026-01-02
-**From Brainstorm:** [BRAINSTORM-cc-pick-placement-2026-01-02.md](../../BRAINSTORM-cc-pick-placement-2026-01-02.md)
+**Released:** v4.8.0
 **Target Version:** v4.8.0
 
 ---


### PR DESCRIPTION
This PR eliminates the final mkdocs warnings by fixing broken links.

## Changes
- Removed reference to non-existent GIT-ALIAS-REFERENCE.md from START-HERE guide
- Updated SPEC-cc-unified-grammar status to 'Implemented' (was 'Draft')
- Removed broken brainstorm file reference from spec

## Result
- Eliminates 2 remaining WARNING messages from mkdocs deployment
- All documentation links now point to existing files
- Spec file status reflects v4.8.0 release completion