### PR TITLE
docs: update CHANGELOG for Homebrew installation changes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Documentation overhaul** - Homebrew now the primary installation method (#165)
+  - README.md: Homebrew moved to top with ⭐ designation
+  - docs/index.md: Homebrew tab added first with "No shell config needed!" note
+  - docs/getting-started/installation.md: Complete rewrite
+    - Homebrew as first method with benefits list
+    - "No reload needed" note for Homebrew users
+    - Added Homebrew sections to Updating and Uninstalling
+    - Added Homebrew-specific troubleshooting
+  - docs/getting-started/faq.md: Added "How do I install flow-cli?" with Homebrew first
+  - Better onboarding: One command (`brew install`) vs plugin manager configuration
+  - Faster time-to-first-command: ~30 seconds vs ~5-10 minutes
+
+---
+
 ## [4.5.5] - 2025-12-31
 
 ### Fixed


### PR DESCRIPTION
## Summary

Update CHANGELOG.md to document the Homebrew installation documentation changes from PR #165.

## Changes

- Added new [Unreleased] section following Keep a Changelog format
- Documented all Homebrew-first documentation updates
- Noted improved onboarding time: ~30 seconds vs ~5-10 minutes

## Details

This is a documentation-only change that adds a changelog entry for the recent Homebrew installation documentation overhaul (PR #165).

Following Keep a Changelog best practices, changes are added to [Unreleased] section which will be renamed to a version number when the next release is cut.
