### PR TITLE
fix: add missing _flow_log_muted function

### DIFF
--- a/lib/core.zsh
+++ b/lib/core.zsh
@@ -46,6 +46,7 @@ _flow_log_success() { _flow_log success "✓ $*" }
 _flow_log_warning() { _flow_log warning "⚠ $*" }
 _flow_log_error()   { _flow_log error "✗ $*" }
 _flow_log_info()    { _flow_log info "ℹ $*" }
+_flow_log_muted()   { echo -e "${FLOW_COLORS[muted]}$*${FLOW_COLORS[reset]}" }
 
 _flow_log_debug() {
   [[ -n "$FLOW_DEBUG" ]] && echo -e "${FLOW_COLORS[muted]}[debug] $*${FLOW_COLORS[reset]}"


### PR DESCRIPTION
Fixes missing function error when running `work` command.

## Problem

When running `work flow-cli`, users encountered:
```
zsh: command not found: _flow_log_muted Editor '...' not found - skipping
```

## Solution

Added `_flow_log_muted()` function to `lib/core.zsh`:
```zsh
_flow_log_muted()   { echo -e "${FLOW_COLORS[muted]}$*${FLOW_COLORS[reset]}" }
```

This function is used in `commands/work.zsh:198` when an editor is not found, to display a muted message instead of throwing an error.

## Testing

```bash
# Before: error
work flow-cli  # → zsh: command not found: _flow_log_muted

# After: works
work flow-cli  # → Shows muted message if editor not found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)