### PR TITLE
fix(dot): resolve file paths as absolute for chezmoi source-path

### DIFF
--- a/BUG-FIX-dot-wc-sanitization.md
+++ b/BUG-FIX-dot-wc-sanitization.md
@@ -145,7 +145,39 @@ count="${count%%*( )}"    # Remove trailing spaces
 
 ---
 
+## Additional Fix: Path Resolution (2026-01-10)
+
+**Issue:** `dot edit .test-dotfile` fails with "Could not determine source path"
+
+**Root Cause:** `_dot_resolve_file_path()` returned relative paths (`.test-dotfile-for-e2e`) but `chezmoi source-path` requires absolute paths (`~/.test-dotfile-for-e2e`).
+
+### Fix Applied
+
+```zsh
+# Before:
+echo "$matched_files"  # Returns: .test-dotfile-for-e2e
+
+# After:
+echo "$HOME/$matched_files"  # Returns: /Users/dt/.test-dotfile-for-e2e
+```
+
+### Verification
+
+```bash
+# Before fix:
+$ dot edit test-dotfile
+✗ Could not determine source path for: .test-dotfile-for-e2e
+
+# After fix:
+$ _dot_resolve_file_path "test-dotfile"
+/Users/dt/.test-dotfile-for-e2e
+$ chezmoi source-path /Users/dt/.test-dotfile-for-e2e
+/Users/dt/.local/share/chezmoi/dot_test-dotfile-for-e2e
+```
+
+---
+
 **Fixed:** 2026-01-10
-**Files changed:** 2
-**Lines added:** 20 (15 fixes + 5 test lines)
+**Files changed:** 2 → 1 additional (dotfile-helpers.zsh)
+**Lines added:** 20 → 23 (+3 lines for path fix)
 **Tests added:** 4

--- a/lib/dotfile-helpers.zsh
+++ b/lib/dotfile-helpers.zsh
@@ -391,12 +391,14 @@ _dot_resolve_file_path() {
   [[ "$match_count" =~ ^[0-9]+$ ]] || match_count=0
 
   if [[ $match_count -eq 1 ]]; then
-    # Single match - return it
-    echo "$matched_files"
+    # Single match - return absolute path (chezmoi managed returns relative paths)
+    echo "$HOME/$matched_files"
     return 0
   else
-    # Multiple matches - return all for selection
-    echo "$matched_files"
+    # Multiple matches - return all as absolute paths for selection
+    echo "$matched_files" | while read -r file; do
+      echo "$HOME/$file"
+    done
     return 2  # Signal multiple matches
   fi
 }


### PR DESCRIPTION
## Summary
- Fix `_dot_resolve_file_path()` to return absolute paths instead of relative paths
- `chezmoi managed` returns relative paths (e.g., `.zshrc`) but `chezmoi source-path` requires absolute paths (e.g., `~/.zshrc`)
- This fix allows `dot edit` to work correctly

## Test plan
- [x] E2E tests pass: `_dot_resolve_file_path "test-dotfile"` returns `/Users/dt/.test-dotfile-for-e2e`
- [x] `chezmoi source-path` works with resolved path
- [x] All 56 DOT dispatcher tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)