### PR TITLE
docs: Add v5.3.0 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,164 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [5.3.0] - 2026-01-11
+
+### 🧪 Test Infrastructure - Comprehensive Coverage
+
+**New Test Suites (76+ tests, 100% passing):**
+
+- **Pick command tests** (`tests/test-pick-command.zsh`, 556 lines, 39 tests)
+  - Function existence tests (6 tests)
+  - Frecency scoring algorithm tests (4 tests)
+  - Project detection & listing tests (9 tests)
+  - Session status indicator tests (4 tests)
+  - Worktree isolation tests (4 tests)
+  - Command invocation tests (3 tests)
+  - Edge case handling tests (6 tests)
+  - Alias validation tests (3 tests)
+
+- **CC dispatcher tests** (`tests/test-cc-dispatcher.zsh`, 722 lines, 37 tests)
+  - Unified grammar mode detection (4 tests)
+  - Shortcut expansion (4 tests)
+  - Explicit HERE targeting (2 tests)
+  - Function existence (4 tests)
+  - Original dispatcher functionality (23 tests)
+
+**Total Test Coverage:**
+
+- 76+ tests across 8 test suites
+- 100% pass rate maintained
+- Sub-10 second execution time
+- All tests fully automated with colored output
+
+### 📖 Documentation - Testing & Onboarding
+
+**New Testing Guide:**
+
+- `docs/guides/TESTING.md` (710 lines) - Comprehensive testing documentation
+  - Test file structure and organization
+  - 6 test writing patterns with copy-paste examples
+  - Mock environment setup (projects, worktrees, sessions)
+  - ANSI code handling techniques
+  - Debugging strategies (4 approaches)
+  - Best practices and TDD workflow
+  - CI integration guidance
+  - Coverage goals and quality standards
+
+**ADHD-Friendly Documentation (#209):**
+
+- `docs/getting-started/im-stuck.md` (300 lines) - Troubleshooting guide
+  - Quick fixes for common issues
+  - Installation problems
+  - Command errors
+  - Performance issues
+  - Step-by-step solutions
+
+- `docs/getting-started/choose-your-path.md` (250 lines) - Role-based onboarding
+  - Different entry points for different user types
+  - Beginner vs experienced developer paths
+  - Project-specific workflows
+  - Learning resources
+
+- `docs/quick-reference-card.md` (200 lines) - Printable command reference
+  - All core commands
+  - Dispatcher shortcuts
+  - Common workflows
+  - Quick lookup table
+
+- `docs/stylesheets/extra.css` (150 lines) - Visual enhancements
+  - ADHD-friendly color coding
+  - Improved readability
+  - Better visual hierarchy
+  - Consistent spacing
+
+**Updated Documentation:**
+
+- `docs/reference/TESTING-QUICK-REF.md` - Added v5.0.0+ test suite section
+- `CLAUDE.md` - Enhanced testing section with coverage table
+- `mkdocs.yml` - Updated navigation for testing docs
+
+### 🔄 Workflow & Planning
+
+**Workflow Protocol Documentation:**
+
+- `docs/contributing/BRANCH-WORKFLOW.md` (295 lines) - Formalized git workflow
+  - Feature branch → worktree workflow
+  - PR creation and review process
+  - Merge strategies
+  - Release procedures
+
+**New Specifications:**
+
+- `docs/specs/SPEC-teaching-workflow.md` - Complete teaching workflow implementation plan
+  - Two-branch workflow (draft + production)
+  - Scholar integration for content generation
+  - examark conversion (Markdown → Canvas QTI)
+  - Automation scripts and GitHub Actions
+
+- `docs/specs/SPEC-project-cache-auto-discovery.md` (949 lines) - Project cache enhancement
+  - Fast project scanning with intelligent caching
+  - Auto-discovery of project types
+  - Performance optimization strategies
+
+### 🔧 Internal
+
+**Configuration:**
+
+- `.claude/settings.local.json` - Added approved Bash commands
+  - `exec zsh` for test re-sourcing
+  - Safe command whitelist
+
+**Status Tracking:**
+
+- `.STATUS` - Updated with test infrastructure accomplishments
+  - Progress: 19% → 20%
+  - Test count: 76+ tests passing
+  - Comprehensive testing guide completed
+
+### ⚡ Performance
+
+- All tests complete in < 10 seconds
+- Documentation build: ~6 seconds
+- No performance regressions
+- ADHD-friendly response times maintained (sub-100ms)
+
+### 🔒 Compatibility
+
+- **No breaking changes** - Fully backward compatible
+- All existing commands work unchanged
+- Documentation is additive
+- Test infrastructure is optional (development-only)
+
+### 📊 Statistics
+
+**Test Coverage:**
+
+- 76+ automated tests (100% passing)
+- 8 test suites
+- 556 lines (pick tests)
+- 722 lines (CC dispatcher tests)
+
+**Documentation:**
+
+- 710 lines (testing guide)
+- 300 lines (troubleshooting)
+- 250 lines (onboarding)
+- 200 lines (quick reference)
+- 949 lines (project cache spec)
+- 295 lines (workflow protocol)
+
+**Total New Content:**
+
+- 3,139+ insertions
+- 10 files changed
+- 4 new test files
+- 6 new documentation files
+
+---
+
 ### 🐛 Fixed - v4.9.1 Bug Fixes (2026-01-06)
 
 **Two critical UX bugs discovered during Phase 2 dogfooding:**


### PR DESCRIPTION
## Summary

Updates CHANGELOG.md with comprehensive v5.3.0 release notes.

## Changes

- Add v5.3.0 release section to CHANGELOG.md
- Document test infrastructure (76+ tests, 100% passing)
- Document 710-line testing guide
- Document ADHD-friendly documentation enhancements
- Document workflow protocol
- Document new specifications

## Release Highlights

### Test Infrastructure
- 39 pick command tests
- 37 CC dispatcher tests
- 100% pass rate across all 76+ tests

### Documentation
- 710-line comprehensive testing guide
- ADHD-friendly onboarding docs
- Troubleshooting guide
- Quick reference card
- Visual enhancements

### Workflow
- Formalized git workflow protocol
- Teaching workflow specification
- Project cache enhancement plan

## Files Changed

- CHANGELOG.md (+158 lines)

## Notes

This PR completes the v5.3.0 release process:
- ✅ PR #212 merged (dev → main)
- ✅ Documentation deployed to GitHub Pages
- ✅ Tag v5.3.0 created and pushed
- ✅ CHANGELOG.md updated (this PR)

After merge, the v5.3.0 release will be fully complete.