### PR TITLE
fix(ci): Add shell: bash to install script test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         run: bash ./tests/test-install.sh
 
       - name: Test curl install (dry run simulation)
+        shell: bash
         run: |
           # Test that install.sh can be executed standalone
           bash -n ./install.sh


### PR DESCRIPTION
## Summary

Fix CI failure in release workflow - the install script test uses bash syntax (`[[`) but GitHub Actions defaults to `sh`.

## Changes

- Add `shell: bash` to the "Test curl install" step in release.yml

## Test Plan

- [x] CI will pass after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)