### PR TITLE
docs: add status badges to homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,12 @@
 # Flow CLI
 
+[![Version](https://img.shields.io/badge/version-v5.6.0-blue)](https://github.com/Data-Wise/flow-cli/releases/tag/v5.6.0)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Tests](https://img.shields.io/github/actions/workflow/status/Data-Wise/flow-cli/test.yml?label=tests&branch=main)](https://github.com/Data-Wise/flow-cli/actions/workflows/test.yml)
+[![Docs](https://img.shields.io/github/actions/workflow/status/Data-Wise/flow-cli/docs.yml?label=docs&branch=main)](https://github.com/Data-Wise/flow-cli/actions/workflows/docs.yml)
+[![Pure ZSH](https://img.shields.io/badge/pure-ZSH-1f425f)](https://www.zsh.org/)
+[![ADHD-Friendly](https://img.shields.io/badge/ADHD-friendly-purple)](docs/PHILOSOPHY.md)
+
 > **ZSH workflow tools designed for ADHD brains.**
 
 Start working in 10 seconds. Stay motivated with visible wins. No configuration required.


### PR DESCRIPTION
## Summary

Added status badges to the homepage to provide quick visibility into project health and version.

## Badges Added

- **Version**: v5.6.0 (linked to releases)
- **License**: MIT (linked to LICENSE file)
- **CI Tests**: GitHub Actions test workflow status
- **Documentation**: Documentation build status
- **Pure ZSH**: Highlights zero runtime dependencies
- **ADHD-Friendly**: Design philosophy badge (linked to PHILOSOPHY.md)

## Benefits

- Users can quickly see project status
- CI/test health visible at a glance
- Professional presentation
- Maintains ADHD-friendly branding

## Preview

Badges appear on homepage right after title and before tagline.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)