### PR TITLE
docs: embed GIF demos in Tutorial #20

### DIFF
--- a/docs/tutorials/20-teaching-dates-automation.md
+++ b/docs/tutorials/20-teaching-dates-automation.md
@@ -168,6 +168,10 @@ semester_info:
   exams: []
 ```
 
+**Demo:**
+
+![Initialize date configuration](../demos/tutorials/tutorial-20-dates-init.gif)
+
 !!! success "Checkpoint"
     You now have a centralized date configuration! Next, we'll add deadlines and exams.
 
@@ -356,6 +360,10 @@ DRY RUN MODE - No changes applied
 Run without --dry-run to apply changes
 ```
 
+**Demo:**
+
+![Preview date changes with dry-run](../demos/tutorials/tutorial-20-dates-sync-dry-run.gif)
+
 !!! warning "Check Before Applying"
     The dry-run shows exactly what will change. Review carefully!
 
@@ -414,6 +422,10 @@ Applied changes to 3 files:
 
 Skipped: 0 files
 ```
+
+**Demo:**
+
+![Apply changes interactively](../demos/tutorials/tutorial-20-dates-sync-interactive.gif)
 
 !!! success "Changes Applied"
     All dates are now consistent across your course! 🎉


### PR DESCRIPTION
## Summary

Embeds the three optimized GIF demos into Tutorial #20 at the appropriate sections:

- Step 3: Initialize date configuration demo
- Step 6: Dry-run preview demo  
- Step 7: Interactive sync demo

## Changes

- Added `![...](../demos/tutorials/tutorial-20-*.gif)` embeds at 3 locations
- GIFs already exist and optimized (644KB, 442KB, 1.1MB)

## Why

The GIFs were created and optimized in PR #263 but never embedded in the tutorial markdown. This completes the visual documentation for Tutorial #20.

## Testing

- [x] GIF files exist and are optimized
- [x] Markdown image syntax is correct
- [x] Paths are relative and will work in MkDocs