### PR TITLE
docs: fix broken links in documentation

### DIFF
--- a/docs/architecture/TEACHING-DATES-ARCHITECTURE.md
+++ b/docs/architecture/TEACHING-DATES-ARCHITECTURE.md
@@ -951,7 +951,6 @@ teach dates import-calendar university-calendar.ics
 - [Date Parser API Reference](../reference/DATE-PARSER-API-REFERENCE.md) - Function documentation
 - [Teaching Dates Guide](../guides/TEACHING-DATES-GUIDE.md) - User guide
 - [Config Schema Reference](../reference/TEACH-CONFIG-DATES-SCHEMA.md) - Schema docs
-- [Developer Guide](../development/DATES-DEVELOPER-GUIDE.md) - Extension guide
 
 ---
 

--- a/docs/reference/DISPATCHER-REFERENCE.md
+++ b/docs/reference/DISPATCHER-REFERENCE.md
@@ -808,9 +808,10 @@ teach init "TEST 101"            # Run again to set up branches
 ```
 
 **See also:**
+
 - [teach-init.md](../commands/teach-init.md) - Full initialization reference
 - [TEACHING-WORKFLOW.md](../guides/TEACHING-WORKFLOW.md) - Complete workflow guide
-- [git-helpers.zsh](../../lib/git-helpers.zsh) - Git integration functions
+- `lib/git-helpers.zsh` - Git integration functions (source code)
 
 ---
 

--- a/docs/reference/SCHOLAR-ENHANCEMENT-API.md
+++ b/docs/reference/SCHOLAR-ENHANCEMENT-API.md
@@ -1124,10 +1124,10 @@ teach slides "Topic" --style computational --diagrams
 ## See Also
 
 - [Teach Dispatcher Reference](TEACH-DISPATCHER-REFERENCE.md)
-- [Implementation Phases 1-2](../../IMPLEMENTATION-PHASES-1-2.md)
-- [Implementation Phases 3-4](../../IMPLEMENTATION-PHASES-3-4.md)
-- [Implementation Phases 5-6](../../IMPLEMENTATION-PHASES-5-6.md)
-- [Test Analysis](../../TEST-ANALYSIS-PHASES-1-2.md)
+- [Implementation Phases 1-2](../reports/IMPLEMENTATION-PHASES-1-2.md)
+- [Implementation Phases 3-4](../reports/IMPLEMENTATION-PHASES-3-4.md)
+- [Implementation Phases 5-6](../reports/IMPLEMENTATION-PHASES-5-6.md)
+- [Test Analysis](../reports/TEST-ANALYSIS-PHASES-1-2.md)
 
 ---
 

--- a/docs/reference/WT-ENHANCEMENT-API.md
+++ b/docs/reference/WT-ENHANCEMENT-API.md
@@ -2,7 +2,7 @@
 
 **Version:** v5.13.0
 **Date:** 2026-01-17
-**Spec:** [SPEC-wt-workflow-enhancement-2026-01-17.md](../../docs/specs/SPEC-wt-workflow-enhancement-2026-01-17.md)
+**Spec:** [SPEC-wt-workflow-enhancement-2026-01-17.md](../specs/SPEC-wt-workflow-enhancement-2026-01-17.md)
 
 ---
 

--- a/docs/specs/SPEC-teach-dates-automation-2026-01-16.md
+++ b/docs/specs/SPEC-teach-dates-automation-2026-01-16.md
@@ -2,7 +2,7 @@
 
 **Status:** draft
 **Created:** 2026-01-16
-**From Brainstorm:** [BRAINSTORM-teach-dates-automation-2026-01-16.md](../../BRAINSTORM-teach-dates-automation-2026-01-16.md)
+**From Brainstorm:** BRAINSTORM-teach-dates-automation-2026-01-16.md (project root)
 **Target Release:** v5.12.0
 **Effort Estimate:** 12-17 hours (5 phases)
 **Priority:** High
@@ -668,7 +668,8 @@ teach dates validate          # Validate date config
 - **Option D** (`dates` dispatcher): Shorter, but breaks flow-cli convention and less discoverable
 
 **References:**
-- [Command naming brainstorm](../../BRAINSTORM-teach-dates-command-naming-2026-01-16.md)
+
+- Command naming brainstorm: BRAINSTORM-teach-dates-command-naming-2026-01-16.md (project root)
 - [Dispatcher reference](../reference/DISPATCHER-REFERENCE.md)
 
 ---

--- a/docs/specs/SPEC-teach-scholar-enhancement-2026-01-17.md
+++ b/docs/specs/SPEC-teach-scholar-enhancement-2026-01-17.md
@@ -11,15 +11,15 @@
 
 ## Metadata
 
-| Field | Value |
-|-------|-------|
-| **Status** | Draft |
-| **Priority** | High (enables 10x faster course material creation) |
-| **Complexity** | Medium-High (20-24 hours) |
-| **Risk Level** | Low (enhances existing teach dispatcher) |
-| **Dependencies** | Claude Code CLI 2.1.12+, Scholar plugin, yq 4.0+ |
-| **Target Users** | Academic instructors (ADHD-friendly required) |
-| **Branch Strategy** | feature/teach-scholar-enhancement → dev → main |
+| Field               | Value                                              |
+| ------------------- | -------------------------------------------------- |
+| **Status**          | Draft                                              |
+| **Priority**        | High (enables 10x faster course material creation) |
+| **Complexity**      | Medium-High (20-24 hours)                          |
+| **Risk Level**      | Low (enhances existing teach dispatcher)           |
+| **Dependencies**    | Claude Code CLI 2.1.12+, Scholar plugin, yq 4.0+   |
+| **Target Users**    | Academic instructors (ADHD-friendly required)      |
+| **Branch Strategy** | feature/teach-scholar-enhancement → dev → main     |
 
 ---
 
@@ -58,10 +58,12 @@ The teach dispatcher already has solid infrastructure (config validation, post-g
 ### Secondary Stories
 
 **Story 2: Content Customization**
+
 - As an instructor, I want to specify content style (conceptual, computational, rigorous, applied)
 - So that generated materials match my teaching approach
 
 **Story 3: Iterative Refinement**
+
 - As an instructor reviewing content, I want to refine materials through revision
 - So that I get content matching my teaching style
 
@@ -124,39 +126,40 @@ The teach dispatcher already has solid infrastructure (config validation, post-g
 
 ### New Flags Summary
 
-| Flag | Short | Purpose | Example |
-|------|-------|---------|---------|
-| `--topic` | `-t` | Explicit topic (bypasses lesson plan) | `teach slides --topic "Regression"` |
-| `--week` | `-w` | Week number (uses lesson plan if exists) | `teach slides -w 8` |
-| `--style` | | Content style preset | `teach slides -w 8 --style rigorous` |
-| `--interactive` | `-i` | Step-by-step wizard | `teach slides -i` |
-| `--revise` | | Improve existing file | `teach slides --revise slides/w8.qmd` |
-| `--context` | | Include course context | `teach exam "Midterm" --context` |
+| Flag            | Short | Purpose                                  | Example                               |
+| --------------- | ----- | ---------------------------------------- | ------------------------------------- |
+| `--topic`       | `-t`  | Explicit topic (bypasses lesson plan)    | `teach slides --topic "Regression"`   |
+| `--week`        | `-w`  | Week number (uses lesson plan if exists) | `teach slides -w 8`                   |
+| `--style`       |       | Content style preset                     | `teach slides -w 8 --style rigorous`  |
+| `--interactive` | `-i`  | Step-by-step wizard                      | `teach slides -i`                     |
+| `--revise`      |       | Improve existing file                    | `teach slides --revise slides/w8.qmd` |
+| `--context`     |       | Include course context                   | `teach exam "Midterm" --context`      |
 
 ### Content Flags (9 total)
 
-| Flag | Short | Negation | Description |
-|------|-------|----------|-------------|
-| `--explanation` | `-e` | `--no-explanation` | Conceptual explanations |
-| `--proof` | | `--no-proof` | Mathematical proofs |
-| `--math` | `-m` | `--no-math` | Formal math notation |
-| `--examples` | `-x` | `--no-examples` | Worked numerical examples |
-| `--code` | `-c` | `--no-code` | Code demonstrations (R/Python) |
-| `--diagrams` | `-d` | `--no-diagrams` | Visual diagrams/plots (always opt-in) |
-| `--practice-problems` | `-p` | `--no-practice-problems` | Practice exercises |
-| `--definitions` | | `--no-definitions` | Formal definitions |
-| `--references` | `-r` | `--no-references` | Citations (always opt-in) |
+| Flag                  | Short | Negation                 | Description                           |
+| --------------------- | ----- | ------------------------ | ------------------------------------- |
+| `--explanation`       | `-e`  | `--no-explanation`       | Conceptual explanations               |
+| `--proof`             |       | `--no-proof`             | Mathematical proofs                   |
+| `--math`              | `-m`  | `--no-math`              | Formal math notation                  |
+| `--examples`          | `-x`  | `--no-examples`          | Worked numerical examples             |
+| `--code`              | `-c`  | `--no-code`              | Code demonstrations (R/Python)        |
+| `--diagrams`          | `-d`  | `--no-diagrams`          | Visual diagrams/plots (always opt-in) |
+| `--practice-problems` | `-p`  | `--no-practice-problems` | Practice exercises                    |
+| `--definitions`       |       | `--no-definitions`       | Formal definitions                    |
+| `--references`        | `-r`  | `--no-references`        | Citations (always opt-in)             |
 
 ### Style Presets (4 total)
 
-| Preset | Includes | Use Case |
-|--------|----------|----------|
-| **conceptual** | explanation, definitions, examples | Intuition-focused, theory introduction |
-| **computational** | explanation, examples, code, practice-problems | Hands-on, lab-style |
-| **rigorous** | definitions, explanation, math, proof | Graduate level, formal treatment |
-| **applied** | explanation, examples, code, practice-problems | Real-world applications |
+| Preset            | Includes                                       | Use Case                               |
+| ----------------- | ---------------------------------------------- | -------------------------------------- |
+| **conceptual**    | explanation, definitions, examples             | Intuition-focused, theory introduction |
+| **computational** | explanation, examples, code, practice-problems | Hands-on, lab-style                    |
+| **rigorous**      | definitions, explanation, math, proof          | Graduate level, formal treatment       |
+| **applied**       | explanation, examples, code, practice-problems | Real-world applications                |
 
 **Notes:**
+
 - `diagrams` and `references` are always opt-in (never preset-included)
 - Use `--no-*` to remove from preset: `--style rigorous --no-proof`
 
@@ -424,12 +427,12 @@ test_teach_slides_revision_workflow()
 
 ## Dependencies
 
-| Dependency | Version | Purpose |
-|------------|---------|---------|
-| Claude Code CLI | 2.1.12+ | AI generation via `claude -p` |
-| Scholar plugin | 2.3.0+ | Teaching commands |
-| yq | 4.0+ | YAML parsing |
-| fzf | Optional | Interactive selection |
+| Dependency      | Version  | Purpose                       |
+| --------------- | -------- | ----------------------------- |
+| Claude Code CLI | 2.1.12+  | AI generation via `claude -p` |
+| Scholar plugin  | 2.3.0+   | Teaching commands             |
+| yq              | 4.0+     | YAML parsing                  |
+| fzf             | Optional | Interactive selection         |
 
 ---
 
@@ -449,6 +452,7 @@ test_teach_slides_revision_workflow()
 ## Supersedes
 
 This spec supersedes and merges:
+
 - `SPEC-teaching-integration-2026-01-17.md`
 - `SPEC-teaching-flags-enhancement-2026-01-17.md`
 
@@ -458,8 +462,8 @@ These files should be archived after this spec is approved.
 
 ## History
 
-| Date | Change | Author |
-|------|--------|--------|
+| Date       | Change                                                  | Author      |
+| ---------- | ------------------------------------------------------- | ----------- |
 | 2026-01-17 | Merged from teaching-integration + teaching-flags specs | Claude + DT |
 
 ---

--- a/docs/specs/SPEC-teaching-git-integration-2026-01-16.md
+++ b/docs/specs/SPEC-teaching-git-integration-2026-01-16.md
@@ -2,7 +2,7 @@
 
 **Status:** draft
 **Created:** 2026-01-16
-**From Brainstorm:** [BRAINSTORM-teaching-git-integration-2026-01-16.md](../../BRAINSTORM-teaching-git-integration-2026-01-16.md)
+**From Brainstorm:** BRAINSTORM-teaching-git-integration-2026-01-16.md (project root)
 **Target Release:** v5.11.0
 **Effort Estimate:** 11-16 hours (5 phases)
 **Priority:** High

--- a/docs/specs/_archive/SPEC-teaching-flags-enhancement-2026-01-17.md
+++ b/docs/specs/_archive/SPEC-teaching-flags-enhancement-2026-01-17.md
@@ -529,8 +529,8 @@ test_teach_slides_conflict_error()
 ## Related Documents
 
 - [Teaching Integration Spec](SPEC-teaching-integration-2026-01-17.md) - Parent spec
-- [Main Plugin Integration Spec](SPEC-claude-code-plugin-integration-2026-01-17.md) - Overview
-- [Teach Dispatcher Reference](../reference/TEACH-DISPATCHER-REFERENCE.md) - Current implementation
+- [Main Plugin Integration Spec](../SPEC-claude-code-plugin-integration-2026-01-17.md) - Overview
+- [Teach Dispatcher Reference](../../reference/TEACH-DISPATCHER-REFERENCE.md) - Current implementation
 
 ---
 

--- a/docs/specs/_archive/SPEC-teaching-integration-2026-01-17.md
+++ b/docs/specs/_archive/SPEC-teaching-integration-2026-01-17.md
@@ -433,6 +433,6 @@ Your choice [1-6]: _
 
 ## Related Documents
 
-- [Main Plugin Integration Spec](SPEC-claude-code-plugin-integration-2026-01-17.md)
-- [Teach Dispatcher Reference](../reference/TEACH-DISPATCHER-REFERENCE.md)
-- [Quick Reference Card](../reference/TEACH-GENERATION-QUICK-REFERENCE.md) (created by UX agent)
+- [Main Plugin Integration Spec](../SPEC-claude-code-plugin-integration-2026-01-17.md)
+- [Teach Dispatcher Reference](../../reference/TEACH-DISPATCHER-REFERENCE.md)
+- [Quick Reference Card](../../reference/TEACH-GENERATION-QUICK-REFERENCE.md) (created by UX agent)

--- a/docs/tutorials/18-lazyvim-showcase.md
+++ b/docs/tutorials/18-lazyvim-showcase.md
@@ -774,9 +774,10 @@ gr             # Find references
 4. Create project-specific `.nvim.lua` files
 
 **Resources:**
+
 - [LazyVim Documentation](https://lazyvim.org)
 - [Nvim Quick Reference](../reference/NVIM-QUICK-REFERENCE.md)
-- [Interactive Tutorial](../tutorials/interactive-nvim-tutorial.md)
+- [Nvim Quick Start Tutorial](15-nvim-quick-start.md)
 
 **Troubleshooting:**
 - `:checkhealth` - diagnose issues

--- a/docs/tutorials/scholar-enhancement/03-advanced.md
+++ b/docs/tutorials/scholar-enhancement/03-advanced.md
@@ -651,9 +651,10 @@ You've mastered advanced Scholar Enhancement!
 - [Architecture Guide](../../architecture/SCHOLAR-ENHANCEMENT-ARCHITECTURE.md) - How it works
 
 **Implementation Details:**
-- [Phases 1-2](../../IMPLEMENTATION-PHASES-1-2.md) - Flag system
-- [Phases 3-4](../../IMPLEMENTATION-PHASES-3-4.md) - Lesson plans
-- [Phases 5-6](../../IMPLEMENTATION-PHASES-5-6.md) - Revision & polish
+
+- [Phases 1-2](../../reports/IMPLEMENTATION-PHASES-1-2.md) - Flag system
+- [Phases 3-4](../../reports/IMPLEMENTATION-PHASES-3-4.md) - Lesson plans
+- [Phases 5-6](../../reports/IMPLEMENTATION-PHASES-5-6.md) - Revision & polish
 
 ### Contribute
 

--- a/docs/tutorials/scholar-enhancement/index.md
+++ b/docs/tutorials/scholar-enhancement/index.md
@@ -262,10 +262,11 @@ Track your progress:
 - [Architecture Guide](../../architecture/SCHOLAR-ENHANCEMENT-ARCHITECTURE.md) - System design
 
 **Implementation Details:**
-- [Phases 1-2](../../IMPLEMENTATION-PHASES-1-2.md) - Flag infrastructure
-- [Phases 3-4](../../IMPLEMENTATION-PHASES-3-4.md) - Lesson plans & interactive
-- [Phases 5-6](../../IMPLEMENTATION-PHASES-5-6.md) - Revision & polish
-- [Complete Summary](../../SCHOLAR-ENHANCEMENT-COMPLETE.md) - Feature overview
+
+- [Phases 1-2](../../reports/IMPLEMENTATION-PHASES-1-2.md) - Flag infrastructure
+- [Phases 3-4](../../reports/IMPLEMENTATION-PHASES-3-4.md) - Lesson plans & interactive
+- [Phases 5-6](../../reports/IMPLEMENTATION-PHASES-5-6.md) - Revision & polish
+- [Complete Summary](../../reports/SCHOLAR-ENHANCEMENT-COMPLETE.md) - Feature overview
 
 ### Community
 


### PR DESCRIPTION
## Summary

Fix all broken link warnings in mkdocs build:

- Fix relative paths in `SCHOLAR-ENHANCEMENT-API.md` (reports/ directory)
- Fix spec link in `WT-ENHANCEMENT-API.md`
- Fix archive spec links (_archive/ relative paths)
- Remove broken external brainstorm links (files in project root, not docs)
- Fix tutorial links to implementation phases
- Remove non-existent `DATES-DEVELOPER-GUIDE` link
- Replace source code link with reference text

## Test plan

- [x] `mkdocs gh-deploy --force` shows no warnings
- [x] Documentation site builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)