### PR TITLE
feat(teach): add lecture-to-slides conversion

### DIFF
--- a/lib/dispatchers/teach-dispatcher.zsh
+++ b/lib/dispatchers/teach-dispatcher.zsh
@@ -2711,64 +2711,68 @@ _teach_convert_lecture_to_slides() {
         # Convert H1 to slide title (level 1 becomes title slide)
         if [[ "$line" =~ ^#\  && ! "$line" =~ ^##\  ]]; then
             # H1 becomes a section title slide
-            echo "" >> "$output_file"
-            echo "$line {.center}" >> "$output_file"
-            echo "" >> "$output_file"
+            printf '\n' >> "$output_file"
+            printf '%s {.center}\n' "$line" >> "$output_file"
+            printf '\n' >> "$output_file"
             ((slide_count++))
             continue
         fi
 
         # H2 becomes new slide
         if [[ "$line" =~ ^##\  && ! "$line" =~ ^###\  ]]; then
-            echo "" >> "$output_file"
-            echo "$line" >> "$output_file"
+            printf '\n' >> "$output_file"
+            printf '%s\n' "$line" >> "$output_file"
             ((slide_count++))
             continue
         fi
 
         # H3 with content becomes slide with incremental reveal
         if [[ "$line" =~ ^###\  ]]; then
-            echo "" >> "$output_file"
-            echo "$line" >> "$output_file"
+            printf '\n' >> "$output_file"
+            printf '%s\n' "$line" >> "$output_file"
             continue
         fi
 
         # Convert TL;DR boxes to callout-note for slides
         if [[ "$line" =~ ':::.+\{\.tldr-box\}' ]]; then
-            echo "::: {.callout-tip}" >> "$output_file"
-            echo "## Key Points" >> "$output_file"
+            printf '::: {.callout-tip}\n' >> "$output_file"
+            printf '## Key Points\n' >> "$output_file"
             continue
         fi
 
         # Convert checkpoint questions to interactive elements
         if [[ "$line" =~ "Checkpoint Question" ]]; then
-            echo "" >> "$output_file"
-            echo "::: {.callout-warning}" >> "$output_file"
-            echo "## 🤔 Checkpoint" >> "$output_file"
+            printf '\n' >> "$output_file"
+            printf '::: {.callout-warning}\n' >> "$output_file"
+            printf '## 🤔 Checkpoint\n' >> "$output_file"
             continue
         fi
 
         # Pass through code chunks (important for R examples)
+        # Use printf '%s\n' to preserve LaTeX backslashes like \tau, \beta, \alpha
         if [[ "$in_code_block" == "true" ]] || [[ "$line" =~ ^\`\`\` ]]; then
-            echo "$line" >> "$output_file"
+            printf '%s\n' "$line" >> "$output_file"
             continue
         fi
 
         # Convert columns to slide-friendly format
         if [[ "$line" =~ ':::.+\{\.columns\}' ]]; then
-            echo "" >> "$output_file"
-            echo ":::: {.columns}" >> "$output_file"
+            printf '\n' >> "$output_file"
+            printf ':::: {.columns}\n' >> "$output_file"
             continue
         fi
 
         if [[ "$line" =~ ':::.+\{\.column' ]]; then
-            echo "" >> "$output_file"
-            echo "$line" >> "$output_file"
+            printf '\n' >> "$output_file"
+            printf '%s\n' "$line" >> "$output_file"
             continue
         fi
 
         # Pass through most content
-        echo "$line" >> "$output_file"
+        # IMPORTANT: Use printf '%s\n' instead of echo to preserve LaTeX backslashes
+        # echo interprets escape sequences like \t (tab), \b (backspace), \v (vertical tab)
+        # which corrupts LaTeX commands like \tau, \beta, \varepsilon, \underbrace, \alpha
+        printf '%s\n' "$line" >> "$output_file"
 
     done < "$input_file"
 


### PR DESCRIPTION
## Summary

- Add `teach slides --from-lecture <file>` to convert lecture .qmd files to RevealJS slides
- Add `teach slides --week N` to auto-detect and convert lecture files from teach-config.yml
- Preserve R code chunks, callouts, and mathematical notation
- Fix LaTeX backslash preservation (printf instead of echo)

## Key Features

- **Auto-detection**: `--week N` looks up lecture files from config
- **Multi-part support**: Handles weeks with multiple lecture parts
- **Dry-run mode**: Preview content analysis before generating
- **LaTeX preservation**: Uses printf to prevent backslash interpretation

## Testing

- Functional tests pass (dry-run, generation, LaTeX preservation)
- All existing tests pass (37 cc-dispatcher, 20 pick, 33 teach-dates)
- Manual verification of generated slide output

## Usage

```bash
# Convert specific file
teach slides --from-lecture lectures/week-05.qmd

# Auto-detect from config by week
teach slides --week 5

# Preview without generating
teach slides --from-lecture lectures/week-05.qmd --dry-run
```

## Previous PR

This re-submits the work from closed PR #280 after rebasing on current dev.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>