### PR TITLE
docs: Tutorial 27 + guide updates for teach plan

### DIFF
--- a/docs/guides/HELP-SYSTEM-GUIDE.md
+++ b/docs/guides/HELP-SYSTEM-GUIDE.md
@@ -158,6 +158,14 @@ AI-powered content generation:
 | `teach config` | `_teach_config_help()` | Manage configuration |
 | `teach profiles` | `_teach_profiles_help()` | Quarto profile management |
 
+### Lesson Plan Management (1)
+
+| Command | Help Function | Purpose |
+|---------|---------------|---------|
+| `teach plan` | `_teach_plan_help()` | CRUD management of lesson plan weeks |
+
+**Note:** `teach plan help` shows all subcommands: create, list, show, edit, delete.
+
 ---
 
 ## Progressive Disclosure Pattern

--- a/docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md
+++ b/docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md
@@ -167,27 +167,50 @@ Choose output format for generated content:
 
 **Why it matters:** Generate content in your preferred format without manual conversion.
 
-### 6. Lesson Plan Integration
+### 6. Lesson Plan Management (v5.22.0)
 
-Create `lesson-plan.yml` in your project root:
+Create and manage lesson plans with the `teach plan` command:
+
+```bash
+# Create a week with topic and style
+teach plan create 5 --topic "Multiple Regression" --style computational
+
+# Create interactively (prompted for details)
+teach plan create 6
+
+# Auto-populate topic from teach-config.yml
+teach plan create 7 --style applied
+
+# List all plans with gap detection
+teach plan list
+
+# View a specific week
+teach plan show 5
+
+# Edit in $EDITOR (jumps to correct line)
+teach plan edit 5
+```
+
+Plans are stored in `.flow/lesson-plans.yml`:
 
 ```yaml
-course: STAT 440
-semester: Spring 2026
 weeks:
   - number: 5
     topic: "Multiple Regression"
-    learning_objectives:
+    style: "computational"
+    objectives:
       - "Understand multicollinearity"
       - "Interpret regression coefficients"
-    key_concepts:
-      - "Adjusted R-squared"
-      - "VIF"
+    subtopics: []
+    key_concepts: []
+    prerequisites: []
 ```
 
-Scholar commands automatically load this for enhanced context.
+Scholar commands automatically load plans for enhanced context.
 
 **Why it matters:** More targeted, course-specific content generation.
+
+**See:** [Tutorial 27: Lesson Plan Management](../tutorials/27-lesson-plan-management.md)
 
 ### 7. Smart Initialization
 
@@ -620,28 +643,25 @@ teach init "STAT 440" --github
   - `syllabi/`
   - `rubrics/`
 
-### Step 3: Create Lesson Plan (Optional but Recommended)
+### Step 3: Create Lesson Plans (Optional but Recommended)
+
+Use `teach plan` to create structured lesson plans that Scholar reads automatically:
 
 ```bash
-cat > lesson-plan.yml <<EOF
-course: STAT 440
-semester: Spring 2026
-instructor: Dr. Smith
+# Create first few weeks
+teach plan create 1 --topic "Introduction to Regression" --style conceptual
+teach plan create 2 --topic "Simple Linear Regression" --style computational
+teach plan create 3 --topic "Model Diagnostics" --style applied
 
-weeks:
-  - number: 1
-    topic: "Introduction to Regression"
-    learning_objectives:
-      - "Understand correlation vs causation"
-      - "Learn simple linear regression"
-    key_concepts:
-      - "Least squares"
-      - "R-squared"
-      - "Residuals"
-EOF
+# Review what you've created
+teach plan list
 ```
 
-Scholar will automatically use this for enhanced context.
+Plans are stored in `.flow/lesson-plans.yml` and loaded by Scholar for targeted content generation.
+
+**Tip:** If your `teach-config.yml` has week topics, `teach plan create N` auto-populates the topic.
+
+**See:** [Tutorial 27: Lesson Plan Management](../tutorials/27-lesson-plan-management.md) for the complete workflow.
 
 ### Step 4: Verify Setup
 
@@ -1349,23 +1369,26 @@ teach dates init
 
 **Create at semester start:**
 
-```yaml
-# lesson-plan.yml
-course: STAT 440
-semester: Spring 2026
+```bash
+# Create plans for key weeks
+teach plan create 1 --topic "Introduction" --style conceptual
+teach plan create 2 --topic "Foundations" --style computational
 
-weeks:
-  - number: 1
-    topic: "Introduction"
-    learning_objectives: [...]
-    key_concepts: [...]
+# Or create all weeks using config auto-populate
+for w in $(seq 1 15); do
+    teach plan create $w --style conceptual
+done
+
+# Review for gaps
+teach plan list
 ```
 
 **Benefits:**
 
 - Scholar generates more targeted content
 - Consistent terminology across materials
-- Easy to revise and reuse
+- Easy to revise with `teach plan edit N`
+- Gap detection warns about missing weeks
 
 ### 2. Regular Health Checks
 

--- a/docs/tutorials/27-lesson-plan-management.md
+++ b/docs/tutorials/27-lesson-plan-management.md
@@ -1,0 +1,343 @@
+# Tutorial: Lesson Plan Management
+
+> **What you'll learn:** Create, manage, and use lesson plans with `teach plan` to drive AI content generation
+>
+> **Time:** ~15 minutes | **Level:** Beginner
+> **Version:** v5.22.0
+
+---
+
+## Prerequisites
+
+Before starting, you should:
+
+- [ ] Have an initialized course (`teach init`)
+- [ ] Have flow-cli v5.22.0+ installed
+- [ ] Have `yq` installed (`brew install yq`)
+
+**Verify your setup:**
+
+```bash
+# Check version
+flow --version  # Should show 5.22.0+
+
+# Check you're in a course directory
+ls .flow/teach-config.yml
+
+# Check yq is available
+yq --version
+```
+
+---
+
+## What You'll Learn
+
+By the end of this tutorial, you will:
+
+1. Understand the lesson plan structure and purpose
+2. Create lesson plans for individual weeks
+3. List and review plans with gap detection
+4. View detailed plan content
+5. Edit plans in your editor
+6. Use plans with Scholar for content generation
+7. Manage plans over a semester lifecycle
+
+---
+
+## Step 1: Understanding Lesson Plans
+
+### What Is a Lesson Plan?
+
+A lesson plan is a structured YAML entry for a single week that captures:
+
+- **Topic** - What the week covers
+- **Style** - Teaching approach (conceptual, computational, rigorous, applied)
+- **Objectives** - What students should learn
+- **Subtopics** - Detailed breakdown
+- **Key concepts** and **prerequisites** - For dependency tracking
+
+### Where Are Plans Stored?
+
+All plans live in a single centralized file:
+
+```
+.flow/lesson-plans.yml
+```
+
+This is different from the old format where plans were embedded in `teach-config.yml`. If you have an existing config with embedded weeks, see [Tutorial 25: Migration](25-lesson-plan-migration.md) first.
+
+### Why Use Lesson Plans?
+
+Plans inform Scholar's content generation. When you run:
+
+```bash
+teach slides --week 5
+teach lecture --week 5
+teach exam --week 5
+```
+
+Scholar reads the plan for week 5 to generate more targeted, course-specific content.
+
+---
+
+## Step 2: Create Your First Plan
+
+### With Flags (Quick)
+
+```bash
+teach plan create 1 --topic "Introduction to Regression" --style conceptual
+```
+
+You'll be prompted for optional objectives and subtopics:
+
+```
+Objectives (comma-separated, Enter to skip): Define regression, Identify variables
+Subtopics (comma-separated, Enter to skip): Dependent vs independent, Scatter plots
+
+✓ Created lesson plan for Week 1: "Introduction to Regression" (conceptual)
+```
+
+### Fully Interactive
+
+Just provide the week number:
+
+```bash
+teach plan create 2
+```
+
+You'll be prompted for everything:
+
+```
+Topic for Week 2: Multiple Regression
+Style [conceptual/computational/rigorous/applied] (default: conceptual): computational
+Objectives (comma-separated, Enter to skip): Fit multiple regression, Interpret coefficients
+Subtopics (comma-separated, Enter to skip): Matrix formulation, Adjusted R-squared
+```
+
+### Auto-Populate from Config
+
+If your `teach-config.yml` has week topics defined, they're used automatically:
+
+```bash
+# Creates week 5 with topic from config — no --topic needed
+teach plan create 5 --style applied
+```
+
+```
+ℹ Auto-populated topic from config: "Polynomial Regression"
+```
+
+---
+
+## Step 3: List and Review Plans
+
+### Table View
+
+```bash
+teach plan list
+```
+
+```
+  Week   Topic                               Style           Objectives
+  ────   ─────────────────────────────────── ─────────────── ──────────
+  1      Introduction to Regression          conceptual      2
+  2      Multiple Regression                 computational   2
+  5      Polynomial Regression               applied         0
+
+  3 week(s) total
+  ⚠ Gaps: weeks 3 4
+```
+
+The gap detection tells you which weeks still need plans.
+
+### JSON Output (for Scripts)
+
+```bash
+teach plan list --json
+```
+
+```json
+[
+  {"number": 1, "topic": "Introduction to Regression", "style": "conceptual", ...},
+  {"number": 2, "topic": "Multiple Regression", "style": "computational", ...},
+  {"number": 5, "topic": "Polynomial Regression", "style": "applied", ...}
+]
+```
+
+---
+
+## Step 4: View Plan Details
+
+### Formatted Display
+
+```bash
+teach plan show 1
+```
+
+```
+╔════════════════════════════════════════════════════╗
+║  Week 1: Introduction to Regression
+╚════════════════════════════════════════════════════╝
+
+  Style:          conceptual
+
+  Objectives:
+    • Define regression
+    • Identify variables
+
+  Subtopics:
+    - Dependent vs independent
+    - Scatter plots
+
+  Edit:   teach plan edit 1
+  Delete: teach plan delete 1
+```
+
+### Quick View (Shortcut)
+
+```bash
+teach plan 1    # Same as teach plan show 1
+```
+
+### JSON Output
+
+```bash
+teach plan show 1 --json
+```
+
+---
+
+## Step 5: Edit Plans
+
+Open a plan in your `$EDITOR` — it jumps directly to the correct line:
+
+```bash
+teach plan edit 1
+```
+
+```
+ℹ Week 1 starts at line 3
+```
+
+Your editor opens `lesson-plans.yml` at the right position. After saving, YAML is validated automatically:
+
+```
+✓ YAML validated successfully
+```
+
+If the YAML is invalid after editing, you get up to 3 retries:
+
+```
+✗ Invalid YAML detected after edit
+Re-open editor to fix? [Y/n]:
+```
+
+---
+
+## Step 6: Use Plans with Scholar
+
+Plans integrate directly with content generation commands:
+
+```bash
+# Generate slides — uses plan topic, style, and objectives
+teach slides --week 1
+
+# Generate lecture notes — includes plan context
+teach lecture --week 2
+
+# Generate exam — references key concepts
+teach exam --week 5
+```
+
+Scholar reads the plan and adjusts its output:
+
+- **Topic** drives the content focus
+- **Style** affects the approach (proofs for rigorous, examples for applied)
+- **Objectives** become learning outcomes in generated materials
+- **Prerequisites** inform assumed knowledge
+
+---
+
+## Step 7: Semester Lifecycle
+
+### Build Out All Weeks
+
+```bash
+# Create remaining weeks (auto-populate topics from config)
+for w in 3 4 6 7 8 9 10 11 12 13 14 15; do
+    teach plan create $w --style conceptual
+done
+
+# Review the full semester
+teach plan list
+```
+
+### Modify a Plan
+
+```bash
+# Overwrite an existing week
+teach plan create 5 --topic "Updated Topic" --style rigorous --force
+```
+
+### Remove a Week
+
+```bash
+# With confirmation prompt
+teach plan delete 8
+
+# Skip confirmation
+teach plan delete 8 --force
+```
+
+### Review Before Content Generation
+
+Before generating materials for a week, check the plan:
+
+```bash
+teach plan 5           # Review plan
+teach slides --week 5  # Generate slides
+```
+
+---
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Create week | `teach plan create 3 --topic "T" --style S` |
+| Create interactively | `teach plan create 3` |
+| List all | `teach plan list` |
+| List as JSON | `teach plan list --json` |
+| Show week | `teach plan show 3` or `teach plan 3` |
+| Edit in editor | `teach plan edit 3` |
+| Delete week | `teach plan delete 3 --force` |
+| Overwrite week | `teach plan create 3 --force` |
+
+**Shortcuts:** `teach pl` = `teach plan`, `c` = create, `ls` = list, `s` = show, `e` = edit, `del` = delete
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "yq not found" | yq not installed | `brew install yq` |
+| ".flow directory not found" | Not in a course dir | `teach init` or `cd` to course |
+| "Week N already exists" | Duplicate week | Use `--force` to overwrite |
+| "Week must be between 1 and 20" | Invalid week number | Use weeks 1-20 |
+| "Invalid style" | Typo in style name | Use: conceptual, computational, rigorous, applied |
+
+---
+
+## Next Steps
+
+- **Add detail** to plans with `teach plan edit` (key concepts, prerequisites)
+- **Generate content** using `teach slides --week N`, `teach lecture --week N`
+- **Export** plans with `teach plan list --json` for integration
+- See [REFCARD: Lesson Plans](../reference/REFCARD-TEACH-PLAN.md) for complete reference
+- See [Tutorial 25: Migration](25-lesson-plan-migration.md) if upgrading from embedded config
+
+---
+
+**Version:** v5.22.0
+**Last Updated:** 2026-01-29

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - 24. Template Management: tutorials/24-template-management.md
       - 25. Lesson Plan Migration: tutorials/25-lesson-plan-migration.md
       - 26. LaTeX Macros: tutorials/26-latex-macros.md
+      - 27. Lesson Plan Management: tutorials/27-lesson-plan-management.md
       - 🎓 Scholar Enhancement:
           - Overview & Learning Path: tutorials/scholar-enhancement/index.md
           - Level 1 - Getting Started: tutorials/scholar-enhancement/01-getting-started.md


### PR DESCRIPTION
## Summary

- **Tutorial 27: Lesson Plan Management** — Step-by-step guide (~300 lines) for creating, managing, and using lesson plans with Scholar content generation
- **HELP-SYSTEM-GUIDE.md** — Added `_teach_plan_help()` to function registry (18 → 19 functions)
- **TEACHING-WORKFLOW-V3-GUIDE.md** — Updated 3 sections from manual `cat > lesson-plan.yml` approach to `teach plan` commands
- **mkdocs.yml** — Added Tutorial 27 to navigation

## Test plan

- [ ] Verify `mkdocs serve` builds without errors
- [ ] Check Tutorial 27 renders correctly
- [ ] Verify help guide table formatting
- [ ] Confirm V3 guide code blocks are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)