### PR TITLE
test: convert timeout tests to non-interactive (40/40 pass)

### DIFF
--- a/tests/fixtures/demo-course/.teach/concepts.json
+++ b/tests/fixtures/demo-course/.teach/concepts.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "schema_version": "concept-graph-v1",
   "metadata": {
-    "last_updated": "2026-02-04T22:52:38Z",
+    "last_updated": "2026-02-06T18:43:46Z",
     "course_hash": "361ea9220e2ff2b6771468e18cddb45b5465b3a2",
     "total_concepts": 12,
     "weeks": 5,

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -63,8 +63,8 @@ run_test ./tests/test-dot-chezmoi-safety.zsh
 
 echo ""
 echo "Core command tests:"
-# Note: test-dash, test-work, test-doctor, test-adhd, test-flow may timeout
-# These source flow.plugin.zsh which requires interactive/tmux context
+# These tests source flow.plugin.zsh in non-interactive mode
+# (FLOW_PLUGIN_DIR, FLOW_QUIET, FLOW_ATLAS_ENABLED=no, exec < /dev/null)
 run_test ./tests/test-dash.zsh
 run_test ./tests/test-work.zsh
 run_test ./tests/test-doctor.zsh

--- a/tests/test-adhd.zsh
+++ b/tests/test-adhd.zsh
@@ -35,31 +35,41 @@ fail() {
 # SETUP
 # ============================================================================
 
+# Resolve project root at top level (${0:A} doesn't work inside functions)
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+
 setup() {
     echo ""
     echo "${YELLOW}Setting up test environment...${NC}"
 
-    # Get project root
-    local project_root=""
-    if [[ -n "${0:A}" ]]; then
-        project_root="${0:A:h:h}"
-    fi
-    if [[ -z "$project_root" || ! -f "$project_root/commands/adhd.zsh" ]]; then
-        if [[ -f "$PWD/commands/adhd.zsh" ]]; then
-            project_root="$PWD"
-        elif [[ -f "$PWD/../commands/adhd.zsh" ]]; then
-            project_root="$PWD/.."
-        fi
-    fi
-    if [[ -z "$project_root" || ! -f "$project_root/commands/adhd.zsh" ]]; then
+    if [[ ! -f "$PROJECT_ROOT/flow.plugin.zsh" ]]; then
         echo "${RED}ERROR: Cannot find project root${NC}"
         exit 1
     fi
 
-    echo "  Project root: $project_root"
+    echo "  Project root: $PROJECT_ROOT"
 
-    # Source the plugin
-    source "$project_root/flow.plugin.zsh" 2>/dev/null
+    # Source the plugin (non-interactive mode, no Atlas)
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$PROJECT_ROOT"
+    source "$PROJECT_ROOT/flow.plugin.zsh" 2>/dev/null || {
+        echo "${RED}Plugin failed to load${NC}"
+        exit 1
+    }
+
+    # Close stdin to prevent any interactive commands from blocking
+    exec < /dev/null
+
+    # Create isolated test project root (avoids scanning real ~/projects)
+    TEST_ROOT=$(mktemp -d)
+    trap "rm -rf '$TEST_ROOT'" EXIT
+    mkdir -p "$TEST_ROOT/dev-tools/mock-dev" "$TEST_ROOT/apps/test-app"
+    for dir in "$TEST_ROOT"/dev-tools/mock-dev "$TEST_ROOT"/apps/test-app; do
+        echo "## Status: active\n## Progress: 50" > "$dir/.STATUS"
+    done
+    FLOW_PROJECTS_ROOT="$TEST_ROOT"
 
     echo ""
 }
@@ -341,9 +351,9 @@ test_focus_help_flag() {
 # ============================================================================
 
 test_brk_runs() {
-    log_test "brk runs without error"
+    log_test "brk 0 runs without error (0 min = no sleep)"
 
-    local output=$(brk 2>&1)
+    local output=$(brk 0 2>&1)
     local exit_code=$?
 
     if [[ $exit_code -eq 0 ]]; then

--- a/tests/test-dash.zsh
+++ b/tests/test-dash.zsh
@@ -35,31 +35,45 @@ fail() {
 # SETUP
 # ============================================================================
 
+# Resolve project root at top level (${0:A} doesn't work inside functions)
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+
 setup() {
     echo ""
     echo "${YELLOW}Setting up test environment...${NC}"
 
-    # Get project root
-    local project_root=""
-    if [[ -n "${0:A}" ]]; then
-        project_root="${0:A:h:h}"
-    fi
-    if [[ -z "$project_root" || ! -f "$project_root/commands/dash.zsh" ]]; then
-        if [[ -f "$PWD/commands/dash.zsh" ]]; then
-            project_root="$PWD"
-        elif [[ -f "$PWD/../commands/dash.zsh" ]]; then
-            project_root="$PWD/.."
-        fi
-    fi
-    if [[ -z "$project_root" || ! -f "$project_root/commands/dash.zsh" ]]; then
+    if [[ ! -f "$PROJECT_ROOT/flow.plugin.zsh" ]]; then
         echo "${RED}ERROR: Cannot find project root${NC}"
         exit 1
     fi
 
-    echo "  Project root: $project_root"
+    echo "  Project root: $PROJECT_ROOT"
 
-    # Source the plugin
-    source "$project_root/flow.plugin.zsh" 2>/dev/null
+    # Source the plugin (non-interactive mode, no Atlas)
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$PROJECT_ROOT"
+    source "$PROJECT_ROOT/flow.plugin.zsh" 2>/dev/null || {
+        echo "${RED}Plugin failed to load${NC}"
+        exit 1
+    }
+
+    # Close stdin to prevent any interactive commands from blocking
+    exec < /dev/null
+
+    # Create isolated test project root (avoids scanning real ~/projects)
+    TEST_ROOT=$(mktemp -d)
+    trap "rm -rf '$TEST_ROOT'" EXIT
+    mkdir -p "$TEST_ROOT/dev-tools/mock-dev" "$TEST_ROOT/apps/test-app" \
+             "$TEST_ROOT/r-packages/active/mock-pkg" "$TEST_ROOT/teaching/stat-101" \
+             "$TEST_ROOT/research/mock-study" "$TEST_ROOT/quarto/mock-site"
+    for dir in "$TEST_ROOT"/dev-tools/mock-dev "$TEST_ROOT"/apps/test-app \
+               "$TEST_ROOT"/r-packages/active/mock-pkg "$TEST_ROOT"/teaching/stat-101 \
+               "$TEST_ROOT"/research/mock-study "$TEST_ROOT"/quarto/mock-site; do
+        echo "## Status: active\n## Progress: 50" > "$dir/.STATUS"
+    done
+    FLOW_PROJECTS_ROOT="$TEST_ROOT"
 
     echo ""
 }


### PR DESCRIPTION
## Summary
- Convert 6 timeout tests to non-interactive sourcing pattern (all now pass within 30s)
- Test suite: 40 passed, 0 failed, 0 timeout (was 34 pass / 6 timeout)
- e2e-teach-analyze: source plugin once instead of ~20 separate subshells

## Test plan
- [x] `./tests/run-all.sh` passes 40/40 with 0 timeouts
- [x] Each individual test file passes standalone
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)