### PR TITLE
docs: sync site content and CLAUDE.md to current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ v <cmd>       # Vibe coding mode
 ```
 flow-cli/
 ├── flow.plugin.zsh           # Plugin entry point
-├── lib/                      # Core libraries (63 files)
+├── lib/                      # Core libraries (66 files)
 │   ├── core.zsh              # Colors, logging, utilities
 │   ├── git-helpers.zsh       # Git integration + smart commits
 │   ├── keychain-helpers.zsh  # macOS Keychain secrets
@@ -176,7 +176,7 @@ flow-cli/
 ├── hooks/                    # ZSH hooks
 ├── docs/                     # Documentation (MkDocs)
 │   └── internal/             # Internal conventions & contributor templates
-├── tests/                    # 159 test files, 3500+ test functions
+├── tests/                    # 176 test files, 3500+ test functions
 │   └── fixtures/demo-course/ # STAT-101 demo course for E2E
 └── .archive/                 # Archived Node.js CLI
 ```
@@ -242,7 +242,7 @@ Update: `MASTER-DISPATCHER-GUIDE.md`, `QUICK-REFERENCE.md`, `mkdocs.yml`
 
 ## Testing
 
-**159 test files, 3500+ test functions.** Run: `./tests/run-all.sh` or individual suites in `tests/`.
+**176 test files, 3500+ test functions.** Run: `./tests/run-all.sh` (40/40 passing, 0 timeouts) or individual suites in `tests/`.
 
 See `docs/guides/TESTING.md` for patterns, mocks, assertions, TDD workflow.
 
@@ -270,8 +270,8 @@ export FLOW_DEBUG=1                          # Debug mode
 
 ## Current Status
 
-**Version:** v6.4.3 | **Tests:** 3500+ | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v6.4.3 | **Tests:** 3500+ (40/40 suite) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 
-**Last Updated:** 2026-02-04 (v6.4.3)
+**Last Updated:** 2026-02-06 (v6.4.3)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 - **Core commands e2e test** — status CRUD, catch, win/yay, doctor, project type detection for Node/R/Python/Quarto (22 assertions)
 - **Plugin system e2e test** — full lifecycle: create, install, list, dev-mode symlink, remove (18 assertions)
 - **run-all.sh expanded** — 26 to 34 passing tests (8 new + 4 existing wired in)
+- **Non-interactive test conversion** — converted 6 timeout tests (test-dash, test-work, test-doctor, test-adhd, test-flow, e2e-teach-analyze) to non-interactive sourcing pattern. Test suite now at 40/40 passing with 0 timeouts
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ tags:
     **That's it!** No configuration required.
 
 !!! success "🎉 What's New: v6.4.3 - Bug Fix + Test Coverage"
-    Fixed ZSH `local path=` bug that silently broke external commands inside functions. Added 106 new test assertions across 4 test files (regression, dogfood, e2e). Test suite now at 34 passing.
+    Fixed ZSH `local path=` bug that silently broke external commands inside functions. Added 106 new test assertions across 4 test files. Converted 6 timeout tests to non-interactive — test suite now at **40/40 passing** (0 timeouts).
     [→ See what's new](CHANGELOG.md){ .md-button }
     [→ All releases](RELEASES.md){ .md-button }
 


### PR DESCRIPTION
## Summary
- Update file counts in CLAUDE.md (63→66 lib, 159→176 test files)
- Add test suite status (40/40 passing, 0 timeouts)
- Add changelog entry for non-interactive test conversion
- Update docs/index.md with accurate test results

## Test plan
- [x] `mkdocs build --strict` passes
- [x] File counts verified with `find`

🤖 Generated with [Claude Code](https://claude.com/claude-code)