### PR TITLE
docs: bump doc version stamps to v7.1.0

### DIFF
--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -519,5 +519,5 @@ The `doctor` command follows these principles:
 ---
 
 **Last Updated:** 2026-02-12
-**Command Version:** v7.0.1 (doctor v2.0 — email integration)
+**Command Version:** v7.1.0 (doctor v2.0 — email integration)
 **Status:** ✅ Production ready with interactive install + email diagnostics

--- a/docs/reference/MASTER-DISPATCHER-GUIDE.md
+++ b/docs/reference/MASTER-DISPATCHER-GUIDE.md
@@ -2612,7 +2612,7 @@ als           # List all aliases by category
 
 **Domain:** Email management via himalaya CLI
 **File:** `lib/dispatchers/email-dispatcher.zsh` + `lib/em-himalaya.zsh`, `lib/em-ai.zsh`, `lib/em-cache.zsh`, `lib/em-render.zsh`
-**Version:** v7.0.0+
+**Version:** v7.1.0+
 
 ### Overview
 

--- a/docs/reference/REFCARD-DOCTOR.md
+++ b/docs/reference/REFCARD-DOCTOR.md
@@ -318,5 +318,5 @@ teach doctor --verbose
 
 ---
 
-**Version:** v7.0.1
+**Version:** v7.1.0
 **Last Updated:** 2026-02-12

--- a/docs/reference/REFCARD-EMAIL-DISPATCHER.md
+++ b/docs/reference/REFCARD-EMAIL-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `em` subcommands at a glance. For detailed guides, see linked documentation.
 >
-> **Version:** v7.0.1 | **Dispatcher:** `lib/dispatchers/email-dispatcher.zsh`
+> **Version:** v7.1.0 | **Dispatcher:** `lib/dispatchers/email-dispatcher.zsh`
 
 ## Command Taxonomy
 
@@ -682,6 +682,6 @@ em p                           # Try again
 
 ---
 
-**Version:** v7.0.1
+**Version:** v7.1.0
 **Last Updated:** 2026-02-12
 **Commands:** 18 total (4 core + 2 search + 3 AI + 3 info + 3 util + 2 infra + 1 help)


### PR DESCRIPTION
## Summary

- Bump remaining doc version stamps from v7.0.x to v7.1.0 across 4 reference pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)