### PR TITLE
Release: homebrew workflow hardening

### DIFF
--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -26,9 +26,12 @@ jobs:
     steps:
       - name: Get version and calculate SHA
         id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
           else
             VERSION="${GITHUB_REF#refs/tags/}"
             VERSION="${VERSION#v}"
@@ -37,7 +40,13 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           TARBALL_URL="https://github.com/Data-Wise/flow-cli/archive/refs/tags/v${VERSION}.tar.gz"
-          SHA256=$(curl -sL "$TARBALL_URL" | shasum -a 256 | cut -d' ' -f1)
+          SHA256=$(curl -sL --retry 3 --retry-delay 2 "$TARBALL_URL" | sha256sum | cut -d' ' -f1)
+
+          # Validate SHA256 is not empty (download failed)
+          if [ -z "$SHA256" ] || [ ${#SHA256} -ne 64 ]; then
+            echo "::error::SHA256 calculation failed. Got: '$SHA256'"
+            exit 1
+          fi
 
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ em <cmd>      # Email management (himalaya)
 
 ### Teaching Subcommands
 
-`teach analyze`, `teach init`, `teach deploy`, `teach doctor`, `teach exam`, `teach macros`, `teach map`, `teach plan`, `teach style`, `teach templates`, `teach prompt`
+`teach analyze`, `teach init`, `teach deploy`, `teach doctor`, `teach exam`, `teach macros`, `teach map`, `teach plan`, `teach style`, `teach templates`, `teach prompt`, `teach cache`, `teach profiles`, `teach migrate`, `teach validate`
 
 - **Doctor (v2):** Two-mode architecture — quick (default, < 3s) and full (`--full`, 11 categories)
   - Quick mode: CLI deps, R + renv, config, git (4 categories)
@@ -175,7 +175,7 @@ em <cmd>      # Email management (himalaya)
 ```
 flow-cli/
 ├── flow.plugin.zsh           # Plugin entry point
-├── lib/                      # Core libraries (69 files)
+├── lib/                      # Core libraries (74 files)
 │   ├── core.zsh              # Colors, logging, utilities
 │   ├── git-helpers.zsh       # Git integration + smart commits
 │   ├── keychain-helpers.zsh  # macOS Keychain secrets
@@ -188,7 +188,7 @@ flow-cli/
 ├── docs/                     # Documentation (MkDocs)
 │   └── internal/             # Internal conventions & contributor templates
 ├── scripts/                  # Standalone validators (check-math.zsh)
-├── tests/                    # 181 test files, 8000+ test functions
+├── tests/                    # 186 test files, 8000+ test functions
 │   └── fixtures/demo-course/ # STAT-101 demo course for E2E
 └── .archive/                 # Archived Node.js CLI
 ```
@@ -255,7 +255,7 @@ Update: `MASTER-DISPATCHER-GUIDE.md`, `QUICK-REFERENCE.md`, `mkdocs.yml`
 
 ## Testing
 
-**181 test files, 8000+ test functions.** Run: `./tests/run-all.sh` (45/45 passing, 1 expected timeout) or individual suites in `tests/`.
+**186 test files, 8000+ test functions.** Run: `./tests/run-all.sh` (45/45 passing, 1 expected timeout) or individual suites in `tests/`.
 
 See `docs/guides/TESTING.md` for patterns, mocks, assertions, TDD workflow.
 


### PR DESCRIPTION
## Summary
- **Fix script injection in homebrew-release workflow:** Move `${{ }}` expressions to `env:` block to prevent code injection via crafted tag names
- **Harden SHA256 calculation:** Add retry logic, validate hash length, use `sha256sum` for Linux compatibility
- **Sync CLAUDE.md:** Update stale file counts and add missing teach subcommands

## Changes
- `.github/workflows/homebrew-release.yml` — security hardening
- `CLAUDE.md` — stale count fixes

## Test plan
- [ ] CI passes
- [ ] Manual dispatch of homebrew-release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)