### PR TITLE
fix: bump FLOW_VERSION to 7.4.0

### DIFF
--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -139,7 +139,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="7.3.0"
+export FLOW_VERSION="7.4.0"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup


### PR DESCRIPTION
## Summary

- FLOW_VERSION in flow.plugin.zsh was not updated during the v7.4.0 release

## Test plan

- [x] `grep FLOW_VERSION flow.plugin.zsh` shows 7.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)