### PR TITLE
fix: resolve 139+ broken anchor links in docs

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -29,7 +29,7 @@ status, log, branch, diff, help
 doc  = document
 cov  = coverage
 cob  = checkout -b (create branch)
-```zsh
+```
 
 ### Files
 
@@ -52,7 +52,7 @@ dash()        # Helper function
 _g_help()           # Help for g
 _v_test_run()       # Internal to v dispatcher
 _c_bold()           # Color helper
-```zsh
+```
 
 ### Aliases
 
@@ -65,7 +65,7 @@ alias reload='source ~/.zshrc'
 # Typo tolerance (redirect to dispatcher)
 alias gti='g'
 alias gis='g'
-```text
+```
 
 ---
 
@@ -99,7 +99,7 @@ alias gis='g'
 ├── .zshrc                      # Main config (ccy function, gem* aliases)
 └── functions/                  # Legacy ADHD helpers
     └── adhd-helpers.zsh        # work, dash, pb, pv, pt
-```bash
+```
 
 **Note (2025-12-25):** Moved from ~/.config/zsh to flow-cli plugin structure. `v-dispatcher.zsh` was removed.
 
@@ -123,7 +123,7 @@ alias gis='g'
 #   <cmd> action2 arg       # Description
 #
 # ══════════════════════════════════════════════════════════════════════════════
-```bash
+```
 
 ---
 
@@ -168,7 +168,7 @@ alias gis='g'
             ;;
     esac
 }
-```bash
+```
 
 ### Help Function Template
 
@@ -196,7 +196,7 @@ ${_C_MAGENTA}💡 TIP${_C_NC}: Unknown commands pass through
   ${_C_DIM}<cmd> anything → <underlying> anything${_C_NC}
 "
 }
-```bash
+```
 
 ---
 
@@ -214,7 +214,7 @@ _C_BLUE='\033[34m'     # Categories, info
 _C_CYAN='\033[36m'     # Commands, actions
 _C_MAGENTA='\033[35m'  # Tips, related info
 _C_RED='\033[31m'      # Errors
-```bash
+```
 
 ### Help Function Color Fallbacks
 
@@ -233,7 +233,7 @@ if [[ -z "$_C_BOLD" ]]; then
     _C_MAGENTA='\033[35m'
     _C_CYAN='\033[36m'
 fi
-```diff
+```
 
 **Rules:**
 - Use `if [[ -z "$_C_BOLD" ]]` guard (NOT `local` scoped defaults)
@@ -247,7 +247,7 @@ fi
 echo -e "${_C_GREEN}Success!${_C_NC}"
 echo -e "${_C_RED}Error:${_C_NC} Something went wrong"
 echo -e "${_C_CYAN}g push${_C_NC}  Push to remote"
-```bash
+```
 
 ---
 
@@ -263,14 +263,14 @@ echo -e "${_C_CYAN}g push${_C_NC}  Push to remote"
 # RIGHT: Single source of truth
 # g-dispatcher:   g status → git status
 # .zshrc:         (no gst alias)
-```bash
+```
 
 **Check before adding:**
 
 ```bash
 grep -rn "alias <name>=" ~/.config/zsh/
 grep -rn "^<name>()" ~/.config/zsh/
-```bash
+```
 
 ### R2: Functions > Aliases
 
@@ -285,7 +285,7 @@ deploy() {
     echo "Deploying to server..."
     ssh server "cd /app && git pull && ./restart.sh"
 }
-```zsh
+```
 
 ### R3: Always Provide Help
 
@@ -306,7 +306,7 @@ mycmd() {
         *) echo "Unknown. Run: mycmd help" ;;
     esac
 }
-```bash
+```
 
 ### R4: Graceful Degradation
 
@@ -320,7 +320,7 @@ if command -v eza &>/dev/null; then
 else
     alias ls='ls -G'
 fi
-```zsh
+```
 
 ### R5: No Blocking Startup
 
@@ -332,7 +332,7 @@ WEATHER=$(curl -s wttr.in/\?format=3)
 weather() {
     curl -s "wttr.in/?format=3"
 }
-```bash
+```
 
 ### R6: Document Changes
 
@@ -361,7 +361,7 @@ shellcheck ~/.config/zsh/functions/*.zsh
 
 # 4. Load test (optional)
 time zsh -ic exit
-```bash
+```
 
 ### Test File Template
 
@@ -391,7 +391,7 @@ test_<function>() {
 
 # Run tests
 test_<function>
-```diff
+```
 
 ---
 

--- a/docs/DOCS-VALIDATION-REPORT-2026-01-24.md
+++ b/docs/DOCS-VALIDATION-REPORT-2026-01-24.md
@@ -84,7 +84,7 @@
 ```text
 WARNING - Doc file 'bugs/BUG-FIX-ccy-alias-missing.md' contains a link
 'lib/dispatchers/cc-dispatcher.zsh#L643', but the target is not found
-```text
+```
 
 **Reason:** Bug fix docs reference actual code files for context. These are internal developer docs, not user-facing.
 
@@ -97,7 +97,7 @@ WARNING - Doc file 'bugs/BUG-FIX-ccy-alias-missing.md' contains a link
 ```text
 WARNING - Doc file 'architecture/DOCTOR-TOKEN-ARCHITECTURE.md' contains
 a link '../reference/MASTER-API-REFERENCE.md#doctor-cache', but target is not found
-```bash
+```
 
 **Reason:** Files moved to `.archive/` during consolidation. Some internal docs still reference old locations.
 
@@ -112,28 +112,28 @@ a link '../reference/MASTER-API-REFERENCE.md#doctor-cache', but target is not fo
 ```bash
 mkdocs build --strict
 # Result: ✅ Success (196 warnings, 0 errors)
-```bash
+```
 
 ### 2. New File Test
 
 ```bash
 ls site/troubleshooting/CLAUDE-CODE-ENVIRONMENT/
 # Result: ✅ Directory exists with index.html
-```bash
+```
 
 ### 3. Content Test
 
 ```bash
 grep "Bug Fix" site/troubleshooting/CLAUDE-CODE-ENVIRONMENT/index.html | wc -l
 # Result: ✅ 5 matches (content present)
-```bash
+```
 
 ### 4. Navigation Test
 
 ```bash
 grep "CLAUDE-CODE-ENVIRONMENT" mkdocs.yml
 # Result: ✅ Entry exists in Help & Quick Reference section
-```bash
+```
 
 ### 5. Link Validation
 

--- a/docs/DOT-DISPATCHER-DOCUMENTATION-SUMMARY.md
+++ b/docs/DOT-DISPATCHER-DOCUMENTATION-SUMMARY.md
@@ -90,7 +90,7 @@
 cd docs/demos
 vhs dot-dispatcher.tape
 # Output: dot-dispatcher.gif
-```yaml
+```
 
 ---
 
@@ -210,7 +210,7 @@ Root:
 ├── README.md                          (UPDATED - added dot to dispatchers)
 ├── CLAUDE.md                          (UPDATED - added v5.0.0 status)
 └── mkdocs.yml                         (UPDATED - added navigation)
-```diff
+```
 
 ---
 

--- a/docs/FEATURE-REQUEST-QUARTO-WORKFLOW-ENHANCEMENTS.md
+++ b/docs/FEATURE-REQUEST-QUARTO-WORKFLOW-ENHANCEMENTS.md
@@ -38,7 +38,7 @@ teach init        # Initialize teaching project
 teach deploy      # Deploy to GitHub Pages
 teach status      # Show semester status
 teach archive     # Archive semester
-```bash
+```
 
 ### Current Limitations
 
@@ -66,7 +66,7 @@ teach init stat-545
 # 2. Adds _freeze/ to .gitignore
 # 3. Documents freeze in CLAUDE.md
 # 4. Adds freeze commands to README.md
-```yaml
+```
 
 **Configuration:**
 
@@ -76,7 +76,7 @@ project:
   type: website
   execute:
     freeze: auto  # Only re-execute changed files
-```bash
+```
 
 **Benefit:** 10-100x faster subsequent renders
 
@@ -95,7 +95,7 @@ teach hooks install
 # 1. .git/hooks/pre-commit (validates & renders changed files)
 # 2. .git/hooks/pre-push (full site render on production)
 # 3. scripts/validate-changes.sh (manual validation)
-```diff
+```
 
 **Pre-commit Hook Behavior:**
 - ✅ YAML frontmatter validation
@@ -114,7 +114,7 @@ teach hooks install
 ```bash
 # Disable rendering in pre-commit if needed
 QUARTO_PRE_COMMIT_RENDER=0 git commit -m "wip"
-```bash
+```
 
 ---
 
@@ -132,7 +132,7 @@ teach validate
 # 2. Renders each one individually
 # 3. Shows pass/fail status
 # 4. Fast (uses freeze cache)
-```text
+```
 
 **Example Output:**
 
@@ -153,7 +153,7 @@ Rendering syllabus/syllabus-final.qmd...
 ════════════════════════════════════════
   Validation failed: 1 file(s)
 ════════════════════════════════════════
-```diff
+```
 
 ---
 
@@ -185,7 +185,7 @@ Rendering syllabus/syllabus-final.qmd...
 - Use `teach deploy` or `./scripts/quick-deploy.sh`
 - Pre-push hook validates full site
 - GitHub Actions deploys to Pages
-```diff
+```
 
 **CLAUDE.md additions:**
 - Quarto Freeze section
@@ -215,7 +215,7 @@ teach check --full
 # Refresh freeze cache
 teach cache refresh
 teach cache clear
-```diff
+```
 
 ---
 
@@ -273,7 +273,7 @@ flow-cli/
 │       ├── _quarto.yml.template
 │       ├── README.md.template
 │       └── CLAUDE.md.template
-```bash
+```
 
 ### Configuration Files
 
@@ -289,7 +289,7 @@ TEACH_VALIDATION_SHOW_OUTPUT=1     # Show render output
 # Hook behavior
 TEACH_HOOK_PRE_COMMIT_RENDER=1     # Default: enabled
 TEACH_HOOK_PRE_PUSH_FULL_SITE=1    # Default: enabled
-```text
+```
 
 ### Error Handling
 
@@ -308,7 +308,7 @@ Running pre-commit checks...
 
 Pre-commit failed: 1 error(s)
 Fix errors or use: git commit --no-verify
-```diff
+```
 
 **Action on error:**
 1. Commit is BLOCKED
@@ -351,7 +351,7 @@ teach cache refresh
 
 # Optional: update configs
 teach upgrade
-```bash
+```
 
 **New projects:**
 
@@ -360,7 +360,7 @@ teach upgrade
 teach init stat-545
 cd stat-545
 quarto preview
-```bash
+```
 
 ### Opt-Out
 
@@ -375,7 +375,7 @@ export TEACH_HOOK_PRE_COMMIT_RENDER=0
 
 # Skip hooks entirely
 git commit --no-verify
-```yaml
+```
 
 ---
 
@@ -461,7 +461,7 @@ CLAUDE.md (with freeze docs)
 Same as before, but:
 - Pre-push hook validates
 - Faster builds with freeze
-```diff
+```
 
 ---
 

--- a/docs/FEATURE-REQUEST-qu-sass-cache-clearing.md
+++ b/docs/FEATURE-REQUEST-qu-sass-cache-clearing.md
@@ -16,7 +16,7 @@ Add a `--clear-cache` (or `--cc`) option to the `qu` dispatcher that clears Quar
 ```bash
 qu render   # Fails with: "NotFound: No such file or directory (os error 2)"
 # User must manually run: rm -rf ~/Library/Caches/quarto/sass/
-```text
+```
 
 **Proposed behavior:**
 
@@ -24,7 +24,7 @@ qu render   # Fails with: "NotFound: No such file or directory (os error 2)"
 qu render --clear-cache   # Clears sass cache first, then renders
 qu --cc                   # Short form, clears cache then runs default workflow
 qu clear-cache            # Standalone command to just clear cache
-```text
+```
 
 ---
 
@@ -37,7 +37,7 @@ Quarto caches compiled SCSS/Sass files at `~/Library/Caches/quarto/sass/` on mac
 ```text
 ERROR: NotFound: No such file or directory (os error 2): lstat
 '/Users/dt/Library/Caches/quarto/sass/0920dd6d7437995b8cdf7429764427b1.css'
-```diff
+```
 
 ### When This Happens
 
@@ -71,7 +71,7 @@ qu --cc                    # Short form for default workflow
 # Standalone cache clearing
 qu clear-cache            # Just clear cache, no render
 qu cc                     # Alias
-```bash
+```
 
 ### Implementation Sketch
 
@@ -94,7 +94,7 @@ _qu_clear_cache() {
         echo "📦 No sass cache to clear"
     fi
 }
-```diff
+```
 
 ---
 

--- a/docs/HOOK-SYSTEM-IMPLEMENTATION.md
+++ b/docs/HOOK-SYSTEM-IMPLEMENTATION.md
@@ -166,7 +166,7 @@ export QUARTO_COMMIT_TIMING=1
 
 # Add validation summary to commits (default: off)
 export QUARTO_COMMIT_SUMMARY=1
-```diff
+```
 
 ## Test Coverage
 
@@ -222,7 +222,7 @@ teach hooks status
 
 # Upgrade hooks (when flow-cli updates)
 teach hooks upgrade
-```bash
+```
 
 ### Daily Workflow
 
@@ -248,7 +248,7 @@ git push origin main
 #   ✓ _site/index.html exists
 #   ✓ Site has 127 files
 #   ✓ Site built 2 hours ago
-```bash
+```
 
 ### Enable Full Rendering
 
@@ -258,7 +258,7 @@ export QUARTO_PRE_COMMIT_RENDER=1
 
 # Or set per-commit
 QUARTO_PRE_COMMIT_RENDER=1 git commit -m "..."
-```bash
+```
 
 ### Parallel Rendering
 
@@ -270,7 +270,7 @@ export QUARTO_MAX_PARALLEL=8
 git add lectures/*.qmd
 git commit -m "feat: add all week 1 lectures"
 # → Renders 5 files in parallel (max 8 jobs)
-```text
+```
 
 ## Architecture
 
@@ -327,7 +327,7 @@ Pre-Push Hook:
 │    │  └─ Block _freeze/ in commits      │
 │    └─ If draft/feature/dev: skip        │
 └─────────────────────────────────────────┘
-```bash
+```
 
 ### Version Management
 
@@ -335,7 +335,7 @@ Hooks use semantic versioning (X.Y.Z) embedded in the file:
 
 ```bash
 # Version: 1.0.0
-```diff
+```
 
 Version comparison logic:
 - `1.0.0 == 1.0.0` → Up to date
@@ -353,7 +353,7 @@ teach hooks install      # Install all hooks
 teach hooks upgrade      # Upgrade to latest version
 teach hooks status       # Show hook status
 teach hooks uninstall    # Remove flow-managed hooks
-```bash
+```
 
 ### teach-dispatcher Integration
 
@@ -366,7 +366,7 @@ if [[ -z "$_FLOW_HOOK_INSTALLER_LOADED" ]]; then
     [[ -f "$hook_installer_path" ]] && source "$hook_installer_path"
     typeset -g _FLOW_HOOK_INSTALLER_LOADED=1
 fi
-```zsh
+```
 
 Then add hook commands to the dispatcher case statement:
 
@@ -386,7 +386,7 @@ teach() {
     # ... other commands
   esac
 }
-```diff
+```
 
 ## Performance
 
@@ -420,7 +420,7 @@ teach hooks status
 
 # Reinstall if needed
 teach hooks install --force
-```bash
+```
 
 #### 2. "yq not found" warning
 
@@ -430,7 +430,7 @@ brew install yq
 
 # Or skip YAML validation (not recommended)
 # Hook will continue with warnings
-```bash
+```
 
 #### 3. "quarto not found" warning
 
@@ -439,7 +439,7 @@ brew install yq
 brew install quarto
 
 # Or the hook will skip syntax validation
-```bash
+```
 
 #### 4. Commit blocked by _freeze/
 
@@ -449,7 +449,7 @@ git restore --staged _freeze/
 
 # Add to .gitignore if needed
 echo "_freeze/" >> .gitignore
-```bash
+```
 
 #### 5. Pre-push blocked: "_site/ not found"
 
@@ -459,7 +459,7 @@ quarto render
 
 # Then push again
 git push
-```text
+```
 
 ### Debug Mode
 

--- a/docs/LINT-FEATURE-SUMMARY.md
+++ b/docs/LINT-FEATURE-SUMMARY.md
@@ -21,7 +21,7 @@ teach validate --lint
 
 # Quick checks only
 teach validate --quick-checks
-```diff
+```
 
 ---
 

--- a/docs/PHASE4-SUMMARY.md
+++ b/docs/PHASE4-SUMMARY.md
@@ -29,7 +29,7 @@ Location: Lines 249-332
   📝 Dotfiles: 🟡 Modified (3 files pending) · 12 files tracked
   📝 Dotfiles: 🔴 Behind (5 commits) · 12 files tracked
   📝 Dotfiles: 🔵 Ahead (2 commits) · 12 files tracked
-```diff
+```
 
 **Implementation Details:**
 - Icon selection based on sync status
@@ -67,7 +67,7 @@ _dash_dotfiles() {
     echo ""
   fi
 }
-```bash
+```
 
 ### 3. Updated `dash()` Function Call Order
 
@@ -85,7 +85,7 @@ _dash_dotfiles    # <-- NEW
 _dash_quick_wins
 _dash_quick_access
 _dash_recent_wins
-```diff
+```
 
 **Rationale:** Dotfile status appears after active session info but before task lists, providing system health context without disrupting workflow focus.
 
@@ -154,7 +154,7 @@ _dash_recent_wins
   └─ ⚪    examify           Planning stage
 
   ...
-```zsh
+```
 
 ## Testing
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -22,7 +22,7 @@ g push              # Git: push to remote
 qu preview          # Quarto: preview document
 mcp status          # MCP: server status
 obs daily           # Obsidian: daily note
-```diff
+```
 
 **Rules:**
 
@@ -56,7 +56,7 @@ g                   # No args → status (most common)
 g help              # Forgot command? Help is there
 r test              # Run tests (R package)
 qu preview          # Preview Quarto doc
-```text
+```
 
 ### 3. Modular Architecture
 
@@ -74,7 +74,7 @@ qu preview          # Preview Quarto doc
     ├── work.zsh            # Session management
     ├── dash.zsh            # Dashboard
     └── adhd.zsh            # ADHD helpers
-```diff
+```
 
 **Rules:**
 
@@ -122,7 +122,7 @@ Every dispatcher MUST have:
 
 📋 ALL COMMANDS:
   [grouped by category]
-```bash
+```
 
 ### 6. Graceful Degradation
 
@@ -133,7 +133,7 @@ if command -v eza &>/dev/null; then
 else
     alias ls='ls -G'
 fi
-```bash
+```
 
 ---
 
@@ -154,7 +154,7 @@ alias xyzzy='complex-internal-function'
 
 # ❌ Blocking operations at startup
 $(curl -s api.example.com/motd)  # Don't do this in .zshrc
-```bash
+```
 
 ### Do This Instead
 
@@ -173,7 +173,7 @@ deploy() {
 
 # ✅ Lazy loading
 motd() { curl -s api.example.com/motd; }  # Only runs when called
-```text
+```
 
 ---
 
@@ -207,7 +207,7 @@ DEPRECATED (2025-12-25):
 ├── v       Use 'flow' command directly
 ├── cc      Use 'ccy' function in .zshrc
 └── gm      Use 'gem*' aliases in .zshrc
-```bash
+```
 
 ---
 

--- a/docs/REFERENCE-CONSOLIDATION-PLAN.md
+++ b/docs/REFERENCE-CONSOLIDATION-PLAN.md
@@ -59,7 +59,7 @@ docs/
     ├── MASTER-DISPATCHER-GUIDE.md    # All 12 dispatchers (beginner → advanced)
     ├── MASTER-API-REFERENCE.md       # Complete API docs (all libraries)
     └── MASTER-ARCHITECTURE.md        # System architecture & design
-```diff
+```
 
 ### Archive Old Files (59 files)
 
@@ -111,7 +111,7 @@ Move to `docs/reference/.archive/` with README explaining consolidation.
 - [Teaching Workflow](../guides/TEACHING-WORKFLOW-V3-GUIDE.md)
 - [ADHD Features](../guides/DOPAMINE-FEATURES-GUIDE.md)
 - [Project Switching](../tutorials/02-multiple-projects.md)
-```diff
+```
 
 **Sources:**
 - Current INDEX.md
@@ -160,7 +160,7 @@ teach analyze         # Analyze concepts
 
 ## Plugin Commands (22 plugins)
 ...
-```diff
+```
 
 **Sources:**
 - COMMAND-QUICK-REFERENCE.md
@@ -209,7 +209,7 @@ teach analyze         # Analyze concepts
 
 ## Plugin Workflows
 ...
-```diff
+```
 
 **Sources:**
 - WORKFLOW-QUICK-REFERENCE.md
@@ -253,7 +253,7 @@ teach analyze         # Analyze concepts
 
 ## Known Limitations
 ...
-```diff
+```
 
 **Sources:**
 - getting-started/troubleshooting.md
@@ -326,7 +326,7 @@ teach analyze         # Analyze concepts
 ...
 
 ### Quick Start (Beginners)
-```bash
+```
 g status          # See what's changed
 g push            # Push to remote
 g commit "msg"    # Quick commit
@@ -357,7 +357,7 @@ g commit "msg"    # Quick commit
 
 [Repeat for all 12 dispatchers]
 
-```diff
+```
 
 **Sources:**
 - DISPATCHER-REFERENCE.md (master index)
@@ -415,7 +415,7 @@ g commit "msg"    # Quick commit
 **Parameters:**
 - `$1` - Message to log
 **Example:**
-```bash
+```
 _flow_log_success "Build completed"
 ```diff
 
@@ -473,7 +473,7 @@ _flow_log_success "Build completed"
 - Added: `_analysis_cache_get()`
 ...
 
-```diff
+```
 
 **Sources:**
 - API-COMPLETE.md
@@ -513,7 +513,7 @@ _flow_log_success "Build completed"
 
 ### High-Level Architecture
 
-```mermaid
+```
 [Diagram from ARCHITECTURE-OVERVIEW.md]
 ```zsh
 
@@ -545,7 +545,7 @@ _flow_log_success "Build completed"
 
 #### Design Pattern
 
-```zsh
+```
 x() {
     case "$1" in
         action1) shift; _x_action1 "$@" ;;
@@ -576,19 +576,19 @@ x() {
 
 ### Session Tracking
 
-```mermaid
+```
 [Diagram]
 ```bash
 
 ### Project Detection
 
-```mermaid
+```
 [Diagram]
 ```bash
 
 ### Teaching Workflow
 
-```mermaid
+```
 [Diagram from diagrams/TEACHING-V3-WORKFLOWS.md]
 ```diff
 
@@ -642,7 +642,7 @@ x() {
 
 ...
 
-```diff
+```
 
 **Sources:**
 - ARCHITECTURE-OVERVIEW.md

--- a/docs/TEACHING-SYSTEM-ARCHITECTURE.md
+++ b/docs/TEACHING-SYSTEM-ARCHITECTURE.md
@@ -70,7 +70,7 @@ teach week                # Current week info
 teach archive             # Create semester snapshot
 teach config              # Update settings
 teach exam "Midterm"      # Create exam (placeholder for Scholar integration)
-```diff
+```
 
 **Key Features:**
 
@@ -97,7 +97,7 @@ teach exam "Midterm"      # Create exam (placeholder for Scholar integration)
 ├─────────────────────────────────────────┤
 │  Underlying: Git + GitHub Actions       │
 └─────────────────────────────────────────┘
-```yaml
+```
 
 ---
 
@@ -120,7 +120,7 @@ teach exam "Midterm"      # Create exam (placeholder for Scholar integration)
 /teaching:slides "Topic"      # Create lecture slides
 /teaching:feedback "Work"     # Generate student feedback
 /teaching:demo                # Create demo course environment
-```diff
+```
 
 **Key Features (v2.0.1 - COMPLETE ✅):**
 
@@ -160,7 +160,7 @@ teach exam "Midterm"      # Create exam (placeholder for Scholar integration)
 ├─────────────────────────────────────────┤
 │  Underlying: Claude API + Templates     │
 └─────────────────────────────────────────┘
-```bash
+```
 
 ---
 
@@ -178,7 +178,7 @@ work stat-545
 
 # 3. Deploy
 teach deploy
-```bash
+```
 
 **Result:** Full teaching workflow, no Scholar needed
 
@@ -200,7 +200,7 @@ work stat-545
 
 # 4. Deploy
 teach deploy
-```text
+```
 
 **Result:** flow-cli handles workflow, Scholar handles content generation
 

--- a/docs/TUTORIAL-WORKFLOW-INTEGRATION-OPTIONS.md
+++ b/docs/TUTORIAL-WORKFLOW-INTEGRATION-OPTIONS.md
@@ -29,7 +29,7 @@ You'll use worktrees when:
 - Want to review PR without stashing changes
 
 ## Step 2: Creating Your First Worktree
-```bash
+```
 wt create feature/new-feature
 ```bash
 
@@ -55,7 +55,7 @@ wt create feature/new-feature
 
 [Links to next tutorial]
 
-```diff
+```
 
 ### Characteristics
 
@@ -97,7 +97,7 @@ wt create feature/new-feature
 [Pure concept explanation - no workflows yet]
 
 ## Step 2: Creating Your First Worktree
-```bash
+```
 wt create feature/new-feature
 ```bash
 
@@ -129,7 +129,7 @@ Now that you understand worktrees, here are the most common workflow patterns:
 
 **Example:**
 
-```bash
+```
 # You're on main, want to add a new feature
 wt create feature/user-auth
 cd ~/.git-worktrees/flow-cli/feature-user-auth
@@ -154,7 +154,7 @@ g pr create
 
 **Example:**
 
-```bash
+```
 # You're working on feature in worktree
 # Urgent bug reported!
 
@@ -210,7 +210,7 @@ cd ~/.git-worktrees/flow-cli/feature-user-auth
 
 [Links to next tutorial]
 
-```diff
+```
 
 ### Characteristics
 
@@ -252,7 +252,7 @@ cd ~/.git-worktrees/flow-cli/feature-user-auth
 [Concept]
 
 💡 **Quick Workflow Tip:** Use worktrees for feature isolation
-```bash
+```
 wt create feature/new-feature  # Try it now!
 ```diff
 
@@ -308,7 +308,7 @@ Now that you understand the basics, here are complete workflow patterns:
 
 [Links]
 
-```diff
+```
 
 ### Characteristics
 
@@ -360,7 +360,7 @@ Now that you understand the basics, here are complete workflow patterns:
 
 Flow: Learn → Apply → Learn → Apply (interleaved)
 
-```text
+```
 
 ### Separated (Option 2)
 
@@ -394,7 +394,7 @@ Flow: Learn → Apply → Learn → Apply (interleaved)
 
 Flow: Learn All → Apply All (sequential)
 
-```text
+```
 
 ### Hybrid (Option 3) - RECOMMENDED
 
@@ -434,7 +434,7 @@ Flow: Learn All → Apply All (sequential)
 
 Flow: Learn + Quick Tips → Complete Workflow Patterns
 
-```diff
+```
 
 ---
 
@@ -485,7 +485,7 @@ Flow: Learn + Quick Tips → Complete Workflow Patterns
 
 ### Workflow 3: Feature + Hotfix Parallel
 [Full workflow]
-```diff
+```
 
 ---
 
@@ -512,7 +512,7 @@ Flow: Learn + Quick Tips → Complete Workflow Patterns
 ### Workflow 1: Feature Development
 ### Workflow 2: Bug Fix + Feature Parallel
 ### Workflow 3: PR Review
-```diff
+```
 
 ---
 

--- a/docs/ZSH-DEVELOPMENT-GUIDELINES.md
+++ b/docs/ZSH-DEVELOPMENT-GUIDELINES.md
@@ -49,7 +49,7 @@ my_interactive_picker() {
 # Later in code...
 local dir=$(my_interactive_picker)  # Gets box-drawing chars + messages!
 cd "$dir" && do_something            # FAILS - $dir is garbage
-```bash
+```
 
 ### Correct Pattern: Chain Interactive Functions
 
@@ -66,7 +66,7 @@ my_interactive_picker() {
 
 # Later in code...
 my_interactive_picker && do_something  # Works! Uses side effects
-```bash
+```
 
 ### Alternative: Separate UI from Logic
 
@@ -85,7 +85,7 @@ _get_project_dir() {
 # Later in code...
 local dir=$(_get_project_dir)  # Clean! Only gets the directory
 cd "$dir" && do_something
-```bash
+```
 
 ---
 
@@ -106,13 +106,13 @@ cc() {
         fi
     fi
 }
-```text
+```
 
 **Error:**
 
 ```text
 cc:cd:6: no such file or directory: \n╔════════════════...
-```zsh
+```
 
 **Fix:**
 
@@ -122,7 +122,7 @@ cc() {
         pick && claude  # ✅ Uses side effect (cd)
     fi
 }
-```diff
+```
 
 ### Lint Rules
 
@@ -142,7 +142,7 @@ cc() {
 \$\(pickdev\)
 \$\(pickq\)
 local.*=\$\(pick
-```zsh
+```
 
 ---
 
@@ -164,21 +164,21 @@ alias peek='bat'
 peek() {  # ❌ FAILS - parse error!
     # Advanced peek functionality...
 }
-```text
+```
 
 **Error:**
 
 ```text
 defining function based on alias `peek'
 parse error near `()'
-```bash
+```
 
 **Fix:** Remove the simple alias, let the advanced function take over:
 
 ```zsh
 # In .zshrc
 # Note: peek is now a function in smart-dispatchers.zsh
-```bash
+```
 
 ### Best Practices
 
@@ -230,7 +230,7 @@ my_function() {
 
 # Usage
 result=$(my_function)  # Gets "/path/to/result", sees messages
-```zsh
+```
 
 ```zsh
 # ❌ WRONG
@@ -242,7 +242,7 @@ my_function() {
 
 # Usage
 result=$(my_function)  # Gets "Processing...\nFound 5 files\n/path/to/result"
-```diff
+```
 
 ### When to Print to Stdout
 
@@ -299,7 +299,7 @@ test_interactive_function_side_effects() {
     local after_dir="$PWD"
     assert_not_equal "$before_dir" "$after_dir"
 }
-```diff
+```
 
 ---
 
@@ -335,7 +335,7 @@ echo "Status: processing..." >&2
 # Function before alias definition
 unalias cmd 2>/dev/null
 cmd() { ... }
-```bash
+```
 
 ### Bad Patterns ❌
 

--- a/docs/architecture/DOCTOR-TOKEN-ARCHITECTURE.md
+++ b/docs/architecture/DOCTOR-TOKEN-ARCHITECTURE.md
@@ -56,7 +56,7 @@ graph TB
     CacheClear --> CacheFiles
     TokExpiring --> CacheSet
     CacheSet --> CacheFiles
-```diff
+```
 
 ---
 
@@ -78,7 +78,7 @@ doctor                    # Main entry (existing)
 doctor --dot              # New: Token check only
 doctor --dot=github       # New: Specific token
 doctor --fix-token        # New: Token fixes only
-```text
+```
 
 **Flow:**
 
@@ -88,7 +88,7 @@ User Input → Flag Parser → Mode Selection → Handler
          Verbosity Level Set
                 ↓
          Cache Manager Init
-```bash
+```
 
 ---
 
@@ -124,7 +124,7 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
-```diff
+```
 
 **State Variables:**
 - `dot_check` - Enable token-only mode
@@ -160,7 +160,7 @@ sequenceDiagram
         Doctor->>Cache: _doctor_cache_set("token-github", result)
         Cache->>Filesystem: Write cache file (atomic)
     end
-```text
+```
 
 **Cache Structure:**
 
@@ -171,7 +171,7 @@ sequenceDiagram
         ├── token-github.cache
         ├── token-npm.cache
         └── token-pypi.cache
-```text
+```
 
 **Cache Entry Format:**
 
@@ -187,7 +187,7 @@ sequenceDiagram
   "username": "your-username",
   "metadata": {...}
 }
-```diff
+```
 
 **Concurrency Safety:**
 - Uses `flock` for lock files
@@ -220,7 +220,7 @@ flowchart TD
     ApplyFix --> ClearCache[Clear Cache]
     FixAll --> ClearCache
     ClearCache --> Done[Done]
-```text
+```
 
 **Menu Design Principles:**
 
@@ -251,7 +251,7 @@ flowchart TD
 │  0. Exit without fixing                         │
 │                                                  │
 ╰──────────────────────────────────────────────────╯
-```bash
+```
 
 ---
 
@@ -280,7 +280,7 @@ sequenceDiagram
     end
 
     Doctor->>Doctor: Display status
-```yaml
+```
 
 **Key Functions:**
 
@@ -305,7 +305,7 @@ sequenceDiagram
 _doctor_log_quiet()     # Normal + Verbose
 _doctor_log_verbose()   # Verbose only
 _doctor_log_always()    # All modes
-```text
+```
 
 **Output Control:**
 
@@ -321,7 +321,7 @@ _doctor_log_always()    # All modes
 _doctor_log_quiet "Processing..."        # Normal flow
 _doctor_log_verbose "Cache hit: 45s"     # Debug info
 _doctor_log_always "Error: Failed"       # Critical
-```text
+```
 
 ---
 
@@ -343,7 +343,7 @@ Cache Hit: < 5 min old
 Parse JSON: Extract status
   ↓
 Display: "✓ Token valid (45 days)"
-```text
+```
 
 **Time:** < 100ms
 
@@ -369,7 +369,7 @@ GitHub API: Validate token
 Cache Set: Store result (5 min TTL)
   ↓
 Display: "✓ Token valid (45 days)"
-```text
+```
 
 **Time:** ~2-3 seconds
 
@@ -395,7 +395,7 @@ Cache Clear: _doctor_cache_token_clear("github")
 Win Log: "Security maintenance"
   ↓
 Display: "✅ Token rotated (28s)"
-```text
+```
 
 **Time:** ~30 seconds
 
@@ -427,7 +427,7 @@ Cache Hit Rate (5-minute TTL):
 API Call Reduction: ~85%
 Storage per entry: ~1.5 KB
 Cleanup frequency: Daily (> 1 day old)
-```diff
+```
 
 ---
 
@@ -453,7 +453,7 @@ Cleanup frequency: Daily (> 1 day old)
 ~/.flow/cache/doctor/     # drwx------  (700)
 ├── token-github.cache    # -rw-------  (600)
 └── token-npm.cache       # -rw-------  (600)
-```diff
+```
 
 **Data Sensitivity:**
 - ✅ Stores: Status, expiration, username
@@ -471,7 +471,7 @@ flock -w $DOCTOR_CACHE_LOCK_TIMEOUT 200
 mv "$temp_file" "$cache_file"
 
 # Release lock (automatic)
-```diff
+```
 
 **Guarantees:**
 - No race conditions
@@ -499,7 +499,7 @@ fi
 # Cache set fails → Log but don't block
 _doctor_cache_set "token-github" "$result" || \
     _doctor_log_verbose "Cache write failed"
-```bash
+```
 
 **Impact:** Slower checks (no cache benefit), but functionality preserved
 
@@ -521,7 +521,7 @@ if ! result=$(_tok_expiring 2>&1); then
     _doctor_log_error "Token check failed: $result"
     return 1
 fi
-```diff
+```
 
 ---
 
@@ -607,7 +607,7 @@ graph LR
     F -->|Yes| G[Update]
     F -->|No| H[Rollback]
     H --> D
-```diff
+```
 
 **Features:**
 - Atomic fixes with rollback

--- a/docs/architecture/DOT-SAFETY-ARCHITECTURE.md
+++ b/docs/architecture/DOT-SAFETY-ARCHITECTURE.md
@@ -70,7 +70,7 @@ graph TB
     SizeDisp --> ChezmoiRepo
     Helpers --> ChezmoiRepo
     ChezmoiRepo --> GitRepo
-```text
+```
 
 ### Layer Architecture
 
@@ -109,7 +109,7 @@ graph LR
     L3A --> L1A
     L2B --> L1A
     L1A --> L1B
-```zsh
+```
 
 ---
 
@@ -133,7 +133,7 @@ _flow_get_file_size() {
     stat -f%z "$file" 2>/dev/null || echo 0  # BSD macOS
   fi
 }
-```diff
+```
 
 **Detection Logic:**
 - Try `stat --version` and grep for "GNU"
@@ -153,7 +153,7 @@ _flow_human_size() {
     # Manual fallback: divide by 1024 repeatedly
   fi
 }
-```diff
+```
 
 **Output Examples:**
 - `512` → "512 bytes"
@@ -176,13 +176,13 @@ _flow_timeout() {
     "$@"  # No timeout available, run anyway
   fi
 }
-```zsh
+```
 
 **Usage:**
 
 ```bash
 _flow_timeout 2 find /large/dir -type f  # 2-second timeout
-```text
+```
 
 ---
 
@@ -199,7 +199,7 @@ graph TB
     CheckCache -->|No| ComputeData[Compute Data]
     ComputeData --> UpdateCache[Update Cache + Timestamp]
     UpdateCache --> ReturnFresh[Return Fresh Data]
-```zsh
+```
 
 **Cache Variables:**
 
@@ -209,7 +209,7 @@ typeset -g _DOT_SIZE_CACHE_TIME     # Timestamp (Unix epoch)
 typeset -g _DOT_IGNORE_CACHE        # Cached ignore patterns
 typeset -g _DOT_IGNORE_CACHE_TIME   # Timestamp
 typeset -g _DOT_CACHE_TTL=300       # 5 minutes (configurable)
-```zsh
+```
 
 **Functions:**
 
@@ -225,7 +225,7 @@ _dot_is_cache_valid() {
   local now=$(date +%s)
   (( now - cache_time < ttl ))
 }
-```bash
+```
 
 **Validation Logic:**
 1. Check cache timestamp exists
@@ -255,7 +255,7 @@ sequenceDiagram
         Command->>Cache: _dot_cache_size()
         Command-->>User: Display (3-5s)
     end
-```diff
+```
 
 **Performance Metrics:**
 - **Cache hit:** ~5-8ms (85% of requests)
@@ -305,7 +305,7 @@ flowchart TD
     Confirm --> Decision{User Confirms?}
     Decision -->|Yes| Success[Return 0 - Proceed]
     Decision -->|No| Cancel[Return 1 - Cancel]
-```zsh
+```
 
 **Detection Categories:**
 
@@ -333,7 +333,7 @@ fi
 if [[ "$file" =~ \.git/ ]]; then
   ((git_files++))
 fi
-```text
+```
 
 #### Git Directory Detection (`_dot_check_git_in_path`)
 
@@ -363,7 +363,7 @@ graph TD
     Results --> Return{Found Any?}
     Return -->|Yes| ReturnList[Return git_dirs]
     Return -->|No| ReturnEmpty[Return empty]
-```diff
+```
 
 **Performance Optimization:**
 
@@ -387,7 +387,7 @@ else
     git_dirs+=("$gitdir")
   done < <(_flow_timeout 2 find "$target" -name ".git" -type d -maxdepth 5 2>/dev/null)
 fi
-```bash
+```
 
 #### Auto-Suggestion (`_dot_suggest_ignore_patterns`)
 
@@ -415,7 +415,7 @@ sequenceDiagram
             Suggest->>User: Success: Added *.log
         end
     end
-```diff
+```
 
 **Features:**
 
@@ -448,7 +448,7 @@ _dot_suggest_ignore_patterns() {
     fi
   done
 }
-```text
+```
 
 ---
 
@@ -478,7 +478,7 @@ graph LR
     List --> Read
     Remove --> Delete
     Edit --> OpenEditor
-```zsh
+```
 
 **Cross-Platform Remove:**
 
@@ -495,7 +495,7 @@ dot_ignore_remove() {
 
   _flow_log_success "Removed pattern: $pattern"
 }
-```diff
+```
 
 **Why temp file?**
 - BSD `sed -i` requires extension: `sed -i.bak`
@@ -538,7 +538,7 @@ sequenceDiagram
     SizeCmd->>FileSystem: find .git dirs
     FileSystem-->>SizeCmd: Git count
     SizeCmd-->>User: Warning if > 0
-```text
+```
 
 **Doctor Health Checks:**
 
@@ -581,7 +581,7 @@ flowchart TD
     ExitCode -->|0| Success[All Passed]
     ExitCode -->|1| Warnings[Some Warnings]
     ExitCode -->|2| Errors[Errors Found]
-```text
+```
 
 ---
 
@@ -621,7 +621,7 @@ sequenceDiagram
     Preview-->>DotAdd: Return 0 (success)
     DotAdd->>Chezmoi: chezmoi add ~/.config/nvim
     Chezmoi-->>User: Files added
-```bash
+```
 
 ### Size Analysis Workflow
 
@@ -655,7 +655,7 @@ sequenceDiagram
     alt Git dirs found
         SizeCmd-->>User: ⚠️ Warning message
     end
-```bash
+```
 
 ---
 
@@ -672,7 +672,7 @@ stateDiagram-v2
     Expired --> Valid: Recompute
     Valid --> Empty: Manual Clear
     Expired --> Empty: Manual Clear
-```diff
+```
 
 ### Cache Variables & TTL
 
@@ -732,7 +732,7 @@ flowchart TD
 
     UseNumFmt --> Done[Return Result]
     Manual --> Done
-```text
+```
 
 ---
 
@@ -750,7 +750,7 @@ flowchart TD
 ├── dot_config/
 │   └── nvim/
 └── README.md
-```diff
+```
 
 **Operations:**
 
@@ -772,7 +772,7 @@ git submodule status
 
 # Check remote
 git remote get-url origin
-```zsh
+```
 
 ### 3. Doctor Integration
 
@@ -784,7 +784,7 @@ _dot_doctor_check_chezmoi_health() {
   # 9 health checks
   # Returns status codes for doctor summary
 }
-```diff
+```
 
 **Exit Code Mapping:**
 
@@ -808,7 +808,7 @@ _dot_ignore_commands() {
   )
   _describe 'ignore commands' commands
 }
-```diff
+```
 
 ---
 

--- a/docs/architecture/SCHOLAR-ENHANCEMENT-ARCHITECTURE.md
+++ b/docs/architecture/SCHOLAR-ENHANCEMENT-ARCHITECTURE.md
@@ -77,7 +77,7 @@ graph TB
 
     Wrapper --> Claude
     Claude --> Scholar
-```text
+```
 
 ### Key Principles
 
@@ -101,7 +101,7 @@ graph LR
     Check -->|Yes| Error[Error Message]
     Check -->|No| Parse[_teach_parse_topic_week]
     Parse --> SetGlobals[Set TEACH_TOPIC/TEACH_WEEK]
-```diff
+```
 
 **Components:**
 - `TEACH_CONTENT_FLAGS` - Associative array of 9 content flags
@@ -114,7 +114,7 @@ graph LR
 ```zsh
 TEACH_TOPIC=""        # Explicit topic string
 TEACH_WEEK=""         # Week number
-```text
+```
 
 ### Phase 2: Preset System
 
@@ -132,7 +132,7 @@ graph TB
 
     Resolved --> BuildInstr[_teach_build_content_instructions]
     BuildInstr --> Instructions[Scholar Instructions]
-```diff
+```
 
 **Components:**
 - `TEACH_STYLE_PRESETS` - Map of 4 style presets
@@ -143,7 +143,7 @@ graph TB
 
 ```zsh
 TEACH_CONTENT_RESOLVED=""  # Space-separated content list
-```text
+```
 
 **Resolution Algorithm:**
 
@@ -156,7 +156,7 @@ TEACH_CONTENT_RESOLVED=""  # Space-separated content list
 4. For each negation flag (--no-X):
      Remove X from content_list
 5. Return deduplicated content_list
-```text
+```
 
 ### Phase 3: Lesson Plan Integration
 
@@ -177,7 +177,7 @@ graph TB
     SetPlanVars --> SetTopic[Set TEACH_TOPIC]
     Prompt -->|Yes| SetTopic
     Prompt -->|No| Cancel[Cancel]
-```diff
+```
 
 **Components:**
 - `_teach_load_lesson_plan()` - YAML parsing
@@ -195,7 +195,7 @@ TEACH_PLAN_SUBTOPICS=""       # Pipe-separated
 TEACH_PLAN_KEY_CONCEPTS=""    # Pipe-separated
 TEACH_PLAN_PREREQUISITES=""   # Pipe-separated
 TEACH_RESOLVED_STYLE=""       # Final style
-```text
+```
 
 ### Phase 4: Interactive Mode
 
@@ -214,7 +214,7 @@ graph TB
     CheckStyle -->|Yes| Done[Continue]
 
     StyleWizard --> ReturnStyle[Return Style]
-```diff
+```
 
 **Components:**
 - `_teach_select_style_interactive()` - Style menu (4 options)
@@ -230,7 +230,7 @@ graph TB
 4. If no style → Show style selection menu
 5. User selects style [1-4]
 6. Return selected style
-```text
+```
 
 ### Phase 5: Revision Workflow
 
@@ -260,7 +260,7 @@ graph TB
     Opt4 --> SetVars
     Opt5 --> SetVars
     Opt6 --> SetVars
-```diff
+```
 
 **Components:**
 - `_teach_analyze_file()` - Content type detection (56 lines)
@@ -274,7 +274,7 @@ graph TB
 TEACH_REVISE_MODE="improve"       # Always "improve" for now
 TEACH_REVISE_FILE=""              # File being revised
 TEACH_REVISE_INSTRUCTIONS=""      # User-selected instruction
-```bash
+```
 
 **Content Type Detection:**
 
@@ -289,7 +289,7 @@ title: "*Quiz*" → quiz
 "# Homework" → assignment
 "Course: " → syllabus
 "Criteria|Rubric" → rubric
-```text
+```
 
 ### Phase 6: Context Integration
 
@@ -313,7 +313,7 @@ graph TB
     Skip --> BuildContext
 
     BuildContext --> SetVar[Set TEACH_CONTEXT]
-```text
+```
 
 **Components:**
 - `_teach_build_context()` - Context gathering (40 lines)
@@ -322,7 +322,7 @@ graph TB
 
 ```zsh
 TEACH_CONTEXT=""  # Course context text
-```text
+```
 
 **Context Format:**
 
@@ -338,7 +338,7 @@ Course Materials:
 Project Overview:
 - From: README.md
 - Content: [first 500 chars]
-```text
+```
 
 ---
 
@@ -383,7 +383,7 @@ sequenceDiagram
 
     Wrapper-->>Dispatcher: Success
     Dispatcher-->>User: Content saved
-```text
+```
 
 ### Interactive Mode Flow
 
@@ -417,7 +417,7 @@ sequenceDiagram
     Note over Wrapper: Phase 2: Resolve content
     Wrapper->>Phase2: _teach_resolve_content("computational")
     Phase2-->>Wrapper: TEACH_CONTENT_RESOLVED="explanation examples code practice-problems"
-```text
+```
 
 ### Revision Workflow Flow
 
@@ -450,7 +450,7 @@ sequenceDiagram
     Note over Wrapper: Build Scholar command with revision
     Wrapper->>Scholar: claude run /teaching:slides + revision + diagrams
     Scholar-->>Wrapper: Improved content
-```bash
+```
 
 ---
 
@@ -498,7 +498,7 @@ _teach_scholar_wrapper() {
     local scholar_cmd="claude run /teaching:$subcommand"
     # ... add revision, context, instructions
 }
-```zsh
+```
 
 ### Why This Order?
 
@@ -522,13 +522,13 @@ _teach_scholar_wrapper() {
 ```zsh
 typeset -g TEACH_TOPIC=""        # Explicit topic
 typeset -g TEACH_WEEK=""         # Week number
-```zsh
+```
 
 **Phase 2 Variables:**
 
 ```zsh
 typeset -g TEACH_CONTENT_RESOLVED=""  # Resolved content list
-```zsh
+```
 
 **Phase 3 Variables:**
 
@@ -540,7 +540,7 @@ typeset -g TEACH_PLAN_SUBTOPICS=""       # From lesson plan
 typeset -g TEACH_PLAN_KEY_CONCEPTS=""    # From lesson plan
 typeset -g TEACH_PLAN_PREREQUISITES=""   # From lesson plan
 typeset -g TEACH_RESOLVED_STYLE=""       # Final style
-```zsh
+```
 
 **Phase 5 Variables:**
 
@@ -548,13 +548,13 @@ typeset -g TEACH_RESOLVED_STYLE=""       # Final style
 typeset -g TEACH_REVISE_MODE=""          # Always "improve"
 typeset -g TEACH_REVISE_FILE=""          # File being revised
 typeset -g TEACH_REVISE_INSTRUCTIONS=""  # Revision instruction
-```zsh
+```
 
 **Phase 6 Variables:**
 
 ```zsh
 typeset -g TEACH_CONTEXT=""  # Course context
-```bash
+```
 
 ### State Lifecycle
 
@@ -584,7 +584,7 @@ stateDiagram-v2
         - Interactive wizard
         - Default (none)
     end note
-```text
+```
 
 ---
 
@@ -632,7 +632,7 @@ sequenceDiagram
 
     W->>S: Execute with context + instructions
     S-->>U: Generated slides
-```text
+```
 
 ---
 
@@ -644,7 +644,7 @@ Each phase transforms data in sequence:
 
 ```text
 Input → Validation → Parsing → Interactive → Integration → Resolution → Output
-```bash
+```
 
 ### 2. Composition Pattern
 
@@ -668,7 +668,7 @@ teach slides -i --style computational --context
 
 # + Revision
 teach slides --revise file.qmd --context
-```diff
+```
 
 ### 3. Strategy Pattern
 
@@ -691,7 +691,7 @@ _teach_scholar_wrapper() {
     resolve()       # Phase 2
     execute()       # Final step
 }
-```bash
+```
 
 ### 5. Facade Pattern
 

--- a/docs/architecture/TEACHING-DATES-ARCHITECTURE.md
+++ b/docs/architecture/TEACHING-DATES-ARCHITECTURE.md
@@ -90,7 +90,7 @@ graph TB
     class PARSER,SYNC,COMPUTE logicLayer
     class CONFIG,SCHEMA,VALIDATOR dataLayer
     class QMD,MD,YAML fileLayer
-```diff
+```
 
 ### System Boundaries
 
@@ -145,7 +145,7 @@ graph LR
     style E fill:#f5e1e1
     style H fill:#f5e1e1
     style F fill:#e1f5e1
-```text
+```
 
 ### Data Flow: Config to Files
 
@@ -187,7 +187,7 @@ sequenceDiagram
     end
 
     CMD->>User: Summary: 3 applied, 2 skipped
-```yaml
+```
 
 ### Semester Init Flow
 
@@ -216,7 +216,7 @@ stateDiagram-v2
         - semester_info.end_date
         - semester_info.weeks[]
     end note
-```diff
+```
 
 ---
 
@@ -288,7 +288,7 @@ stateDiagram-v2
    c. Apply if confirmed
    ↓
 6. Show final summary
-```yaml
+```
 
 **Modes:**
 
@@ -342,7 +342,7 @@ semester_info:
       date: string (YYYY-MM-DD)
       time: string (optional)
       location: string (optional)
-```diff
+```
 
 **Validation Rules:**
 - All dates must be ISO format (`YYYY-MM-DD`)
@@ -448,7 +448,7 @@ flowchart TD
     style Success fill:#e1f5e1
     style Apply fill:#f5f5e1
     style Backup fill:#f5f5e1
-```text
+```
 
 ### Date Computation Flow
 
@@ -467,7 +467,7 @@ graph TD
     style A fill:#e1f5e1
     style E fill:#f5e1e1
     style I fill:#e1f5e1
-```bash
+```
 
 ### File Modification Flow
 
@@ -496,7 +496,7 @@ sequenceDiagram
         Parser->>Backup: Restore from .bak
         Parser-->>Sync: ✗ Failed
     end
-```text
+```
 
 ---
 
@@ -551,7 +551,7 @@ graph TB
     class TEACH,INIT,STATUS,DEPLOY,EXAM existing
     class DATES_SYNC,DATES_INIT,DATES_STATUS,DATES_VALIDATE new
     class CONFIG,VALIDATOR,SCHEMA shared
-```diff
+```
 
 ### Integration with Scholar MCP
 
@@ -574,7 +574,7 @@ teach exam "Midterm 1" --week 8
 # - Week 8 start date from semester_info
 # - Existing exams to avoid duplicates
 # - Holiday dates to avoid conflicts
-```text
+```
 
 ### External Tool Dependencies
 
@@ -603,7 +603,7 @@ graph LR
     style SED fill:#f5e1e1
     style FIND fill:#f5e1e1
     style PARSER fill:#e1f5e1
-```diff
+```
 
 **Dependency Management:**
 - `yq` - Required for YAML operations (install: `brew install yq`)
@@ -663,7 +663,7 @@ graph TD
 
     style E fill:#f5e1e1
     style REC1,REC2,REC3,REC4,REC5,REC6,REC7,REC8,REC9,REC10,REC11 fill:#e1f5e1
-```bash
+```
 
 ### Error Recovery Strategies
 
@@ -690,7 +690,7 @@ mv file.qmd.bak file.qmd  # Restore
 
 # If success
 rm file.qmd.bak  # Clean up
-```bash
+```
 
 **Config-Level Rollback:**
 
@@ -701,7 +701,7 @@ git restore .flow/teach-config.yml
 # Or manual rollback
 # Remove semester_info section from config
 # Files retain their current dates (no change)
-```bash
+```
 
 **Sync-Level Rollback:**
 
@@ -714,7 +714,7 @@ git restore .flow/teach-config.yml
 git diff  # Review changes
 git restore <file>  # Undo specific file
 git restore .  # Undo all
-```diff
+```
 
 ---
 
@@ -786,7 +786,7 @@ git restore .  # Undo all
 - Integer types: Week numbers, offsets
 - Enum types: semester, holiday types
 - No shell commands in YAML
-```bash
+```
 
 **2. Input Sanitization:**
 
@@ -800,7 +800,7 @@ fi
 if [[ ! "$week" =~ ^[0-9]+$ ]]; then
     return 1
 fi
-```bash
+```
 
 **3. File Path Validation:**
 
@@ -811,7 +811,7 @@ fi
 
 # No directory traversal
 [[ "$file" == *".."* ]] && return 1
-```bash
+```
 
 **4. Backup Before Modification:**
 
@@ -821,7 +821,7 @@ cp "$file" "${file}.bak"
 
 # Restore on any error
 trap 'mv "${file}.bak" "$file"' ERR
-```diff
+```
 
 ### Permissions
 
@@ -861,7 +861,7 @@ timeline
         Advanced features : Real-time sync
                          : CI/CD integration
                          : Conflict resolution UI
-```text
+```
 
 ### Planned Features
 
@@ -871,7 +871,7 @@ timeline
 
 ```bash
 teach semester new "Spring 2026"
-```diff
+```
 
 **Behavior:**
 1. Calculate date shift (Fall 2025 → Spring 2026)
@@ -897,7 +897,7 @@ weeks:
         topic: "Introduction"
       - date: "2025-01-15"
         topic: "Setup & RStudio"
-```text
+```
 
 **Use Case:** Courses with MWF or TTh schedules
 

--- a/docs/bugs/BUG-FIX-ccy-alias-missing.md
+++ b/docs/bugs/BUG-FIX-ccy-alias-missing.md
@@ -13,7 +13,7 @@ The `flow alias` command didn't show the `ccy` alias (shortcut for `cc yolo`), e
 
 ```text
 fix: ccy is also an alias that flow alias command missed?
-```bash
+```
 
 ### Verification
 
@@ -28,7 +28,7 @@ $ flow alias cc
   ccp → claude -p (print mode)
   ccr → claude -r (resume session)
   # ❌ ccy missing!
-```diff
+```
 
 ## Root Cause
 
@@ -76,7 +76,7 @@ _flow_alias_show_claude() {
 # Total count
 - echo "Total: 28 custom aliases + 8 dispatchers + 226+ git aliases"
 + echo "Total: 29 custom aliases + 8 dispatchers + 226+ git aliases"
-```zsh
+```
 
 ## Verification
 
@@ -103,7 +103,7 @@ $ flow alias cc
 
 Tip: Use cc dispatcher for full Claude workflow
 See also: cc help for all Claude commands
-```bash
+```
 
 ### Automated Test
 

--- a/docs/bugs/BUG-FIX-dot-wc-sanitization.md
+++ b/docs/bugs/BUG-FIX-dot-wc-sanitization.md
@@ -33,7 +33,7 @@ count="${count%%*( )}"    # Remove trailing spaces
 [[ "$count" =~ ^[0-9]+$ ]] || count=0  # Default to 0 if non-numeric
 
 if [[ $count -gt 0 ]]; then  # Safe: count is always numeric
-```diff
+```
 
 ## Changes Made
 
@@ -95,7 +95,7 @@ Added regression tests:
 Tests run:    56
 Tests passed: 56
 Tests failed: 0
-```diff
+```
 
 **New tests added:** 4 (Test Suite 11)
 **Total test count:** 52 → 56
@@ -122,7 +122,7 @@ $ dot status
 │  Last sync: unknown                              │
 │  Tracked files: 0                                 │
 ╰───────────────────────────────────────────────────╯
-```bash
+```
 
 ## Prevention
 
@@ -133,7 +133,7 @@ local count=$(command | wc -l | tr -d ' ')
 count="${count##*( )}"    # Remove leading spaces
 count="${count%%*( )}"    # Remove trailing spaces
 [[ "$count" =~ ^[0-9]+$ ]] || count=0
-```diff
+```
 
 ## Impact
 
@@ -159,7 +159,7 @@ echo "$matched_files"  # Returns: .test-dotfile-for-e2e
 
 # After:
 echo "$HOME/$matched_files"  # Returns: /Users/dt/.test-dotfile-for-e2e
-```bash
+```
 
 ### Verification
 

--- a/docs/bugs/BUG-FIX-help-browser-preview.md
+++ b/docs/bugs/BUG-FIX-help-browser-preview.md
@@ -12,7 +12,7 @@ The `flow help -i` interactive help browser showed "command not found" errors in
 
 ```text
 flow help -i preview pane does not work. it says command not found
-```text
+```
 
 ### Symptom
 
@@ -23,7 +23,7 @@ Command not found: work
 Command not found: dash
 Command not found: finish
 ...
-```bash
+```
 
 ## Root Cause
 
@@ -42,7 +42,7 @@ The fzf `--preview` option runs commands in a **new subshell** that doesn't have
     echo "Command not found: $cmd"           # ← Always hits this
   fi
 '
-```bash
+```
 
 The `type` check failed because commands like `work`, `dash`, `cc`, etc. weren't defined in the subshell.
 
@@ -73,7 +73,7 @@ _flow_show_help_preview() {
   cmd=$(echo {} | awk "{print \$1}" | sed "s/\x1b\[[0-9;]*m//g")
   _flow_show_help_preview "$cmd"
 '
-```text
+```
 
 ## Files Changed
 
@@ -92,7 +92,7 @@ _flow_show_help_preview() {
 
 ```bash
 ./tests/test-help-browser-preview.zsh
-```diff
+```
 
 **Results:** ✅ All 6 tests pass
 
@@ -109,7 +109,7 @@ Run interactive help and confirm preview pane shows help text:
 
 ```bash
 flow help -i
-```text
+```
 
 **Expected:** Preview pane shows formatted help (e.g., "DASH - Project Dashboard")
 **Before fix:** Preview pane showed "Command not found: dash"
@@ -121,7 +121,7 @@ Updated Phase 2 interactive test to explicitly check for this fix:
 
 ```bash
 ./tests/interactive-dog-feeding-phase2.zsh
-```diff
+```
 
 Expected behavior now includes:
 

--- a/docs/commands/alias.md
+++ b/docs/commands/alias.md
@@ -23,7 +23,7 @@ flow alias rm <name>    # Safe removal (backup + comment out)
 flow alias test <name>  # Validate and dry-run
 flow alias edit         # Open .zshrc at alias section
 flow alias help         # Show all commands
-```diff
+```
 
 ---
 
@@ -71,7 +71,7 @@ $ flow alias
   flow alias cc for details
 
 ...
-```yaml
+```
 
 ### View Category Details
 
@@ -86,7 +86,7 @@ $ flow alias cc
 
 Tip: Use cc dispatcher for full Claude workflow
 See also: cc help for all Claude commands
-```bash
+```
 
 ### Common Categories
 
@@ -102,7 +102,7 @@ flow alias r
 
 # Quarto publishing
 flow alias quarto
-```yaml
+```
 
 ---
 
@@ -188,7 +188,7 @@ Most commonly used:
 
 ```bash
 flow alias doctor
-```diff
+```
 
 Scans all aliases and reports:
 
@@ -204,14 +204,14 @@ Scans all aliases and reports:
   Healthy: 42 (93%)
   Shadows: 2 (cat, gem)
   Broken: 1 (oldcmd)
-```text
+```
 
 ### Find - Search Aliases
 
 ```bash
 flow alias find git        # All git-related aliases
 flow alias find --exact gst # Exact match only
-```text
+```
 
 ### Add - Create Alias
 
@@ -219,14 +219,14 @@ flow alias find --exact gst # Exact match only
 
 ```bash
 flow alias add myalias='echo hello'
-```bash
+```
 
 **Interactive mode:**
 
 ```bash
 flow alias add
 # Prompts for name and command with validation
-```diff
+```
 
 **Safety checks:**
 
@@ -238,7 +238,7 @@ flow alias add
 
 ```bash
 flow alias rm myalias
-```text
+```
 
 **What happens:**
 

--- a/docs/commands/capture.md
+++ b/docs/commands/capture.md
@@ -13,7 +13,7 @@ win <text>              # Log an accomplishment
 catch <idea>            # Quick capture to inbox
 crumb <note>            # Leave a breadcrumb
 yay                     # Show recent wins
-```bash
+```
 
 **Quick examples:**
 
@@ -34,7 +34,7 @@ crumb "About to refactor database layer"
 yay                     # Recent wins
 yay --week              # Weekly summary
 inbox                   # View captured ideas
-```diff
+```
 
 ---
 
@@ -59,7 +59,7 @@ inbox                   # View captured ideas
 
 ```bash
 win [options] <text>
-```bash
+```
 
 ### Options
 
@@ -85,7 +85,7 @@ win -f "Fixed login bug"
 # Interactive mode
 win
 # 🎉 What's your win? _
-```text
+```
 
 ### Auto-Detection
 
@@ -107,7 +107,7 @@ If you don't specify a category, `win` automatically detects it from keywords:
   Implemented user authentication
 
   Keep it up! 🚀
-```text
+```
 
 ---
 
@@ -119,14 +119,14 @@ If you don't specify a category, `win` automatically detects it from keywords:
 
 ```bash
 yay [--week|-w]
-```bash
+```
 
 ### Show Recent Wins
 
 ```bash
 # Show last 5 wins
 yay
-```text
+```
 
 Output:
 
@@ -139,14 +139,14 @@ Output:
   🚀 Deployed to staging
 
   Total: 4 wins today | 🔥 3-day streak
-```bash
+```
 
 ### Weekly Summary
 
 ```bash
 # Show this week's wins with stats
 yay --week
-```text
+```
 
 Output:
 
@@ -165,7 +165,7 @@ Output:
   Mon Tue Wed Thu Fri Sat Sun
    ▁   ▃   ██  ▅   ▂
        Activity Graph
-```bash
+```
 
 ---
 
@@ -179,7 +179,7 @@ Output:
 catch [options] <text>
 # or
 c <text>
-```bash
+```
 
 ### Options
 
@@ -205,7 +205,7 @@ catch -t bug "Login redirect fails on Safari"
 # Interactive mode
 catch
 # 💡 Quick capture: _
-```diff
+```
 
 ### Where It Goes
 
@@ -226,7 +226,7 @@ Breadcrumbs help you remember what you were doing and why. Perfect for ADHD when
 crumb <text>
 # or
 b <text>
-```bash
+```
 
 ### Examples
 
@@ -238,7 +238,7 @@ b "Switching to fix urgent bug, will return"
 # Interactive mode
 crumb
 # 🍞 Breadcrumb: _
-```bash
+```
 
 ---
 
@@ -252,7 +252,7 @@ crumb
 trail [project] [limit]
 # or
 t [project] [limit]
-```bash
+```
 
 ### Examples
 
@@ -265,7 +265,7 @@ trail flow-cli
 
 # Limit results
 trail flow-cli 10
-```bash
+```
 
 ---
 
@@ -279,7 +279,7 @@ trail flow-cli 10
 inbox
 # or
 i
-```bash
+```
 
 ---
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -9,7 +9,7 @@ flow config [command] [options]
 flow config show [filter]
 flow config set <key> <value>
 flow config profile load <name>
-```bash
+```
 
 ## Description
 
@@ -112,7 +112,7 @@ flow config profile save work
 
 # Delete a user profile
 flow config profile delete work
-```bash
+```
 
 ## Examples
 
@@ -127,7 +127,7 @@ flow config show timer
 
 # Filter by keyword
 flow config show adhd
-```text
+```
 
 Output:
 
@@ -142,7 +142,7 @@ FLOW-CLI CONFIGURATION
 
   * = modified from default
   Config file: ~/.config/flow/config.zsh
-```bash
+```
 
 ### Get/Set Values
 
@@ -157,7 +157,7 @@ flow config set timer_default 30
 
 # Shorthand syntax
 flow config timer_default=30
-```bash
+```
 
 ### Reset to Defaults
 
@@ -167,7 +167,7 @@ flow config reset timer_default
 
 # Reset everything
 flow config reset --all
-```bash
+```
 
 ### Using Profiles
 
@@ -180,7 +180,7 @@ flow config profile save work
 
 # List available profiles
 flow config profile list
-```text
+```
 
 Output:
 
@@ -195,13 +195,13 @@ CONFIGURATION PROFILES
 
   User Profiles:
     work (saved: 2025-12-26)
-```text
+```
 
 ### Interactive Setup
 
 ```bash
 flow config wizard
-```bash
+```
 
 Launches an interactive wizard that guides you through:
 
@@ -218,7 +218,7 @@ flow config export > my-config.zsh
 
 # Show config file locations
 flow config path
-```text
+```
 
 ## Configuration File
 
@@ -226,7 +226,7 @@ The configuration file is located at:
 
 ```text
 ~/.config/flow/config.zsh
-```bash
+```
 
 Format:
 
@@ -235,7 +235,7 @@ Format:
 FLOW_CONFIG[timer_default]="25"
 FLOW_CONFIG[dopamine_mode]="yes"
 # ...
-```text
+```
 
 ### Profile Storage
 
@@ -243,7 +243,7 @@ User profiles are stored in:
 
 ```text
 ~/.config/flow/profiles/<name>.zsh
-```bash
+```
 
 ## Environment Variables
 

--- a/docs/commands/dash.md
+++ b/docs/commands/dash.md
@@ -15,7 +15,7 @@ dash [option|category]
 dash -i          # Interactive fzf picker
 dash -w          # Watch mode (auto-refresh every 5s)
 dash -a          # Show all projects (flat list)
-```bash
+```
 
 **Quick examples:**
 
@@ -37,7 +37,7 @@ dash -w 10        # Refresh every 10s
 
 # Show all projects (flat list)
 dash -a
-```diff
+```
 
 ---
 
@@ -90,7 +90,7 @@ flowchart LR
 
     style A fill:#4CAF50,stroke:#2E7D32,color:#fff
     style D fill:#2196F3,stroke:#1565C0,color:#fff
-```text
+```
 
 **In plain words:** Input → Scan → Organize → Display
 
@@ -199,7 +199,7 @@ flowchart TD
     style DisplayPaused fill:#FFF9C4,stroke:#F57F17
     style DisplayBlocked fill:#FFCDD2,stroke:#C62828
     style End fill:#4CAF50,stroke:#2E7D32,color:#fff
-```diff
+```
 
 </details>
 
@@ -292,7 +292,7 @@ Auto-refresh the dashboard:
 ```bash
 dash --watch        # Refresh every 5 seconds
 dash --watch 10     # Custom interval (seconds)
-```text
+```
 
 ### Interactive TUI
 
@@ -317,7 +317,7 @@ The dashboard now shows recent wins and streak:
 │ 💻 Implemented auth service              14:20               │
 │ 🔧 Fixed login redirect bug              11:45               │
 └──────────────────────────────────────────────────────────────┘
-```text
+```
 
 See [Dopamine Features Guide](../guides/DOPAMINE-FEATURES-GUIDE.md) for details.
 
@@ -329,7 +329,7 @@ See [Dopamine Features Guide](../guides/DOPAMINE-FEATURES-GUIDE.md) for details.
 
 ```bash
 $ dash
-```text
+```
 
 **Output:**
 
@@ -362,7 +362,7 @@ $ dash
    work <name>         Start working on a project
    status <name>       Update project status
    dash teaching       Filter by category
-```text
+```
 
 ---
 
@@ -370,7 +370,7 @@ $ dash
 
 ```bash
 $ dash teaching
-```text
+```
 
 **Output:**
 
@@ -391,7 +391,7 @@ $ dash teaching
    work <name>         Start working on a project
    status <name>       Update project status
    dash                Show all projects
-```text
+```
 
 ---
 
@@ -399,7 +399,7 @@ $ dash teaching
 
 ```bash
 $ dash dev
-```text
+```
 
 **Output:**
 
@@ -412,7 +412,7 @@ No projects found with .STATUS files
 
 💡 Tip: Create .STATUS files with:
    status <project> --create
-```yaml
+```
 
 ---
 
@@ -444,7 +444,7 @@ quick_win: yes
 # Option 2: Set estimate under 30 minutes
 estimate: 15m
 estimate: 20min
-```text
+```
 
 ### Display
 
@@ -453,7 +453,7 @@ estimate: 20min
   ├─ ⚡ flow-cli      Fix typo in docs          ~15m
   ├─ 🔥 medfit       Update version number     ~10m
   └─ ⏰ stat-440     Post grades               ~20m
-```yaml
+```
 
 ---
 
@@ -478,7 +478,7 @@ deadline: 2025-12-27
 
 # Or via priority
 priority: 1 # Maps to high urgency
-```yaml
+```
 
 ---
 
@@ -517,7 +517,7 @@ packages  → ~/projects/r-packages
 dev       → ~/projects/dev-tools
 quarto    → ~/projects/quarto
 all       → ~/projects (root)
-```text
+```
 
 ### Status Mapping
 
@@ -528,7 +528,7 @@ Active:  active, working, in progress
 Ready:   ready, todo, planned
 Paused:  paused, hold, waiting
 Blocked: blocked
-```diff
+```
 
 ---
 
@@ -568,7 +568,7 @@ The `dash` command follows these ADHD-friendly principles:
 # Create .STATUS file in project directory
 cd ~/projects/my-project
 status . --create
-```bash
+```
 
 ---
 
@@ -581,7 +581,7 @@ status . --create
 ```bash
 # Create project-hub manually
 mkdir -p ~/projects/project-hub
-```bash
+```
 
 ---
 

--- a/docs/commands/dashboard.md
+++ b/docs/commands/dashboard.md
@@ -10,7 +10,7 @@ Complete reference for the `flow dashboard` command - monitor workflow status in
 flow dashboard [options]
 flow dashboard --web [--port <port>] [--interval <ms>]
 flow dashboard --help
-```yaml
+```
 
 ---
 
@@ -36,7 +36,7 @@ Launch interactive terminal interface:
 
 ```bash
 flow dashboard
-```diff
+```
 
 **Features:**
 
@@ -52,7 +52,7 @@ Launch browser-based dashboard:
 
 ```bash
 flow dashboard --web
-```diff
+```
 
 **Features:**
 
@@ -72,7 +72,7 @@ Launch web-based dashboard:
 
 ```bash
 flow dashboard --web
-```text
+```
 
 **What happens:**
 
@@ -91,7 +91,7 @@ Dashboard: http://localhost:3000/dashboard
 
 ✨ Dashboard ready!
 Press Ctrl+C to stop server
-```diff
+```
 
 **Browser displays:**
 
@@ -106,7 +106,7 @@ Specify custom port for web dashboard:
 
 ```bash
 flow dashboard --web --port 8080
-```diff
+```
 
 **Default:** 3000
 
@@ -127,7 +127,7 @@ flow dashboard --web --port 3001 --category teaching
 
 # Terminal 3: Research projects only
 flow dashboard --web --port 3002 --category research
-```text
+```
 
 ### --interval <ms>
 
@@ -135,7 +135,7 @@ Set auto-refresh interval (milliseconds):
 
 ```bash
 flow dashboard --web --interval 2000
-```bash
+```
 
 **Default:** 5000 (5 seconds)
 
@@ -152,7 +152,7 @@ flow dashboard --web --interval 30000
 
 # Very fast (every second) - resource intensive
 flow dashboard --web --interval 1000
-```text
+```
 
 **Recommendations:**
 
@@ -169,7 +169,7 @@ Filter dashboard to specific category:
 
 ```bash
 flow dashboard --web --category teaching
-```diff
+```
 
 **Valid categories:**
 
@@ -186,7 +186,7 @@ flow dashboard --web --category teaching --port 3001
 
 # Research-only dashboard
 flow dashboard --web --category research --port 3002
-```text
+```
 
 ### --help, -h
 
@@ -194,7 +194,7 @@ Show help message:
 
 ```bash
 flow dashboard --help
-```diff
+```
 
 ---
 
@@ -241,7 +241,7 @@ Shows current work session (if active):
 │ Progress:  ████████░░ 85%               │
 │ Task:      Final simulations            │
 ╰─────────────────────────────────────────╯
-```diff
+```
 
 **Web:**
 
@@ -263,7 +263,7 @@ Sessions │████████░░ 4 sessions
 Time     │██████████ 3.5 hours
 Projects │███░░░░░░░ 3 active
 Progress │███████░░░ +15% total
-```diff
+```
 
 **Web:**
 
@@ -285,7 +285,7 @@ All projects with status, priority, progress:
 │ stat-440         │ Active │ P1 │ 60%│ Grade exams │
 │ flow-cli         │ Ready  │ P2 │100%│ Complete!   │
 └──────────────────┴────────┴────┴────┴─────────────┘
-```diff
+```
 
 **Web:**
 
@@ -311,7 +311,7 @@ Summary metrics:
 │ Completed This Week:  3 projects        │
 │ Total Time This Week: 18.5 hours        │
 ╰─────────────────────────────────────────╯
-```bash
+```
 
 ---
 
@@ -325,7 +325,7 @@ flow dashboard
 
 # View, then quit
 # Press 'q' to exit
-```bash
+```
 
 ### Example 2: Background Web Dashboard
 
@@ -339,7 +339,7 @@ flow dashboard --web &
 # Stop dashboard
 fg
 Ctrl+C
-```bash
+```
 
 ### Example 3: Category-Specific Dashboards
 
@@ -356,7 +356,7 @@ flow dashboard --web --port 3001 --category research
 flow dashboard --web --port 3002 --category packages
 
 # Now have dedicated view for each work type
-```bash
+```
 
 ### Example 4: Custom Refresh Rate
 
@@ -366,7 +366,7 @@ flow dashboard --web --interval 1000
 
 # Background monitoring - slow updates
 flow dashboard --web --interval 30000
-```bash
+```
 
 ### Example 5: Integration with Work Session
 
@@ -382,7 +382,7 @@ flow dashboard --web
 # - Active session timer (live countdown)
 # - Project progress
 # - Session duration (updates every second)
-```bash
+```
 
 ### Example 6: Weekly Review
 
@@ -396,7 +396,7 @@ flow dashboard --web
 # 2. Check progress %
 # 3. Update priorities in terminal
 # 4. Screenshot for records
-```yaml
+```
 
 ---
 
@@ -468,7 +468,7 @@ Click column headers to sort:
 
 ```bash
 flow status --json > dashboard-data.json
-```text
+```
 
 ---
 
@@ -490,7 +490,7 @@ Active session stored in: `~/.config/zsh/.worklog`
   },
   "task": "Final simulations"
 }
-```text
+```
 
 ### Project Data
 
@@ -505,7 +505,7 @@ priority: P0
 progress: 85
 next: Final simulations
 updated: 2025-12-24
-```diff
+```
 
 ---
 
@@ -530,7 +530,7 @@ Override default config directory:
 ```bash
 export FLOW_CLI_HOME=~/.flow-cli
 flow dashboard
-```bash
+```
 
 ### PORT
 
@@ -540,7 +540,7 @@ Default port for web dashboard:
 export PORT=8080
 flow dashboard --web
 # Uses port 8080 instead of 3000
-```yaml
+```
 
 ---
 
@@ -579,7 +579,7 @@ flow dashboard --web --host 0.0.0.0
 # Keep it local:
 flow dashboard --web
 # Binds to 127.0.0.1 only
-```diff
+```
 
 ### Accessibility
 
@@ -606,7 +606,7 @@ flow dashboard --web
 
 ```text
 Error: Port 3000 is already in use
-```bash
+```
 
 **Solution:**
 
@@ -616,7 +616,7 @@ flow dashboard --web --port 3001
 
 # Or kill process using port 3000
 lsof -ti:3000 | xargs kill -9
-```bash
+```
 
 ### "Dashboard not opening"
 
@@ -627,7 +627,7 @@ lsof -ti:3000 | xargs kill -9
 ```bash
 flow dashboard --web
 # Manually open: http://localhost:3000/dashboard
-```diff
+```
 
 ### "Data not updating"
 

--- a/docs/commands/do.md
+++ b/docs/commands/do.md
@@ -6,7 +6,7 @@
 
 ```bash
 flow do [options] "<natural language description>"
-```text
+```
 
 ## Description
 
@@ -28,7 +28,7 @@ Commands that could cause data loss are flagged:
 
 ```bash
 flow do "delete all files"
-```text
+```
 
 Output:
 
@@ -38,7 +38,7 @@ Output:
 
 This command could cause data loss.
 Execute anyway? [y/N]:
-```diff
+```
 
 Dangerous patterns detected:
 
@@ -55,7 +55,7 @@ Always preview before executing uncertain commands:
 
 ```bash
 flow do --dry-run "remove all backup files"
-```text
+```
 
 Output:
 
@@ -64,7 +64,7 @@ Output:
 📝 Command: find . -name "*.bak" -delete
 
 ⚠️  DRY RUN - command not executed
-```bash
+```
 
 ## Examples
 
@@ -79,7 +79,7 @@ flow do "show files modified in the last hour"
 
 flow do "count lines in all zsh files"
 # → find . -name "*.zsh" -exec wc -l {} +
-```bash
+```
 
 ### Git Operations
 
@@ -92,7 +92,7 @@ flow do "find who last modified this file"
 
 flow do "show branches merged into main"
 # → git branch --merged main
-```bash
+```
 
 ### System Information
 
@@ -105,7 +105,7 @@ flow do "show running node processes"
 
 flow do "what's using port 3000"
 # → lsof -i :3000
-```bash
+```
 
 ### Project-Specific
 
@@ -123,7 +123,7 @@ flow do "run the tests"
 # In a Quarto project:
 flow do "build the document"
 # → quarto render
-```bash
+```
 
 ## Workflow Tips
 

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -16,7 +16,7 @@ flow doctor                 # Check all dependencies
 flow doctor --fix           # Interactive fix mode
 flow doctor --fix -y        # Auto-install everything
 flow doctor --dot           # Check only DOT tokens
-```bash
+```
 
 **Quick examples:**
 
@@ -41,7 +41,7 @@ flow doctor --fix-token
 
 # Detailed output + connectivity checks
 flow doctor --verbose
-```diff
+```
 
 ---
 
@@ -66,7 +66,7 @@ flowchart LR
 
     style A fill:#4CAF50,stroke:#2E7D32,color:#fff
     style F fill:#2196F3,stroke:#1565C0,color:#fff
-```bash
+```
 
 **In plain words:** Check → Report → (Optional) Fix
 
@@ -89,7 +89,7 @@ flow doctor --ai
 
 # Verbose output
 flow doctor --verbose
-```diff
+```
 
 ---
 
@@ -233,7 +233,7 @@ flow doctor --verbose
 
 ────────────────────────────────────────────────
 ✅ All dependencies OK!
-```text
+```
 
 ### With Missing Dependencies
 
@@ -254,7 +254,7 @@ Quick fix options:
   flow doctor --fix       Interactive install (prompts each)
   flow doctor --fix -y    Auto-install all missing
   brew bundle --file=$FLOW_PLUGIN_DIR/setup/Brewfile
-```text
+```
 
 ---
 
@@ -285,7 +285,7 @@ Install dust? (y/N) n
 
 ────────────────────────────────────────────────
 ✅ Installed 2 tools, skipped 1
-```text
+```
 
 ### Fix Mode with Email (`--fix`)
 
@@ -302,7 +302,7 @@ When email dependencies are missing, the fix menu includes an Email Tools catego
 │  0. Exit without fixing                          │
 │                                                  │
 ╰──────────────────────────────────────────────────╯
-```text
+```
 
 Email fix mode installs missing brew packages (himalaya, glow, w3m, terminal-notifier) and pip packages (email-oauth2-proxy). If no himalaya config is found, it offers a guided setup wizard.
 
@@ -326,7 +326,7 @@ Auto-installing 3 missing tools...
 
 ────────────────────────────────────────────────
 ✅ Installed 3 tools
-```bash
+```
 
 ---
 
@@ -350,7 +350,7 @@ $ flow doctor --verbose
     ✓ IMAP connection OK (1 message fetched)
     ⚠ OAuth2 proxy not running
     ✓ SMTP config present
-```yaml
+```
 
 Connectivity checks have a 5-second timeout per test (15s max total). All failures are shown as warnings, not errors.
 
@@ -381,7 +381,7 @@ Set up OAuth2 proxy for Gmail? (Y/n) y
 
 Testing connectivity...
 ✓ IMAP connection OK
-```text
+```
 
 The wizard auto-detects providers (Gmail, Outlook, Yahoo, iCloud) and configures appropriate IMAP/SMTP settings.
 
@@ -411,7 +411,7 @@ here are my recommendations:
 3. **Your ZSH plugins look good** - All recommended plugins are installed.
 
 Would you like me to run the installation commands? (y/N)
-```bash
+```
 
 ---
 
@@ -425,7 +425,7 @@ brew bundle --file=~/projects/dev-tools/flow-cli/setup/Brewfile
 
 # Then verify
 flow doctor
-```diff
+```
 
 ---
 
@@ -450,7 +450,7 @@ flow doctor
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```bash
+```
 
 ### Issue: ZSH plugin shows as missing
 
@@ -464,7 +464,7 @@ echo "romkatv/powerlevel10k" >> ~/.config/zsh/.zsh_plugins.txt
 
 # Rebuild antidote bundle
 antidote bundle < ~/.config/zsh/.zsh_plugins.txt > ~/.config/zsh/.zsh_plugins.zsh
-```bash
+```
 
 ### Issue: npm packages fail to install
 

--- a/docs/commands/hop.md
+++ b/docs/commands/hop.md
@@ -10,7 +10,7 @@ The `hop` command provides fast project switching, especially powerful when usin
 
 ```bash
 hop [project]
-```bash
+```
 
 **Quick examples:**
 
@@ -24,7 +24,7 @@ hop
 # With tmux (creates/switches session)
 hop my-project
 # ✓ Hopped to: my-project
-```text
+```
 
 ---
 
@@ -32,7 +32,7 @@ hop my-project
 
 ```bash
 hop [project]
-```diff
+```
 
 ## Arguments
 
@@ -67,7 +67,7 @@ hop flow-cli
 
 # Interactive picker (if no project specified)
 hop
-```bash
+```
 
 ### With Tmux
 
@@ -77,7 +77,7 @@ hop flow-cli
 
 # View all tmux sessions
 tmux list-sessions
-```bash
+```
 
 ### Without Tmux
 
@@ -85,7 +85,7 @@ tmux list-sessions
 # Simply changes to project directory
 hop my-project
 # Changed to: my-project (start tmux for session management)
-```text
+```
 
 ---
 
@@ -95,7 +95,7 @@ With tmux:
 
 ```text
 ✓ Hopped to: flow-cli
-```text
+```
 
 Without tmux:
 

--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -9,7 +9,7 @@ flow install [options]
 flow install --profile <name>
 flow install --category <name>
 flow install <tool> [tool...]
-```text
+```
 
 ## Description
 
@@ -44,7 +44,7 @@ flow install <tool> [tool...]
 fzf      - Fuzzy finder (required for pick, dash-tui)
 zoxide   - Smart cd replacement
 bat      - Cat with syntax highlighting
-```text
+```
 
 **developer** (9 tools)
 
@@ -55,19 +55,19 @@ bat      - Cat with syntax highlighting
 + gh     - GitHub CLI
 + delta  - Git diff viewer
 + jq     - JSON processor
-```text
+```
 
 **researcher** (10 tools)
 
 ```text
 + quarto - Scientific publishing
-```text
+```
 
 **writer** (5 tools)
 
 ```text
 fzf, bat, pandoc, quarto
-```text
+```
 
 **full** (13 tools)
 
@@ -75,7 +75,7 @@ fzf, bat, pandoc, quarto
 + dust   - Disk usage analyzer
 + duf    - Disk free viewer
 + btop   - System monitor
-```text
+```
 
 ## Categories
 
@@ -93,7 +93,7 @@ fzf, bat, pandoc, quarto
 
 ```bash
 flow install
-```bash
+```
 
 Launches an interactive menu to select tools.
 
@@ -108,7 +108,7 @@ flow install --profile developer
 
 # Academic workflow
 flow install --profile researcher
-```bash
+```
 
 ### Category-Based
 
@@ -118,21 +118,21 @@ flow install --category git
 
 # Core productivity tools
 flow install --category core
-```bash
+```
 
 ### Individual Tools
 
 ```bash
 # Install specific tools
 flow install fzf bat eza
-```bash
+```
 
 ### Dry Run
 
 ```bash
 # See what would be installed
 flow install --profile developer --dry-run
-```text
+```
 
 Output:
 
@@ -149,7 +149,7 @@ Output:
   • jq
 
 Total: 9 tools
-```text
+```
 
 ### List Available Options
 

--- a/docs/commands/morning.md
+++ b/docs/commands/morning.md
@@ -10,7 +10,7 @@ The `morning` command provides a structured startup routine to reduce decision f
 
 ```bash
 morning [options]
-```diff
+```
 
 ## Options
 
@@ -37,7 +37,7 @@ The full `morning` command displays:
 
 ```bash
 morning
-```text
+```
 
 Output:
 
@@ -64,7 +64,7 @@ Output:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Ready to start? Try: js (just-start) or work <project>
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```bash
+```
 
 ### Quick Mode
 
@@ -72,7 +72,7 @@ Output:
 morning -q
 # or
 am
-```text
+```
 
 Output:
 
@@ -80,7 +80,7 @@ Output:
   📥 3 inbox  │  📂 5 active projects
 
   → js to start working
-```text
+```
 
 ---
 
@@ -92,7 +92,7 @@ Quick daily status showing current session and today's wins:
 
 ```bash
 today
-```text
+```
 
 Output:
 
@@ -107,7 +107,7 @@ Output:
 
   Active Projects:
      🔧 flow-cli        [ 85%] → Documentation enhancement
-```text
+```
 
 ### week
 
@@ -115,7 +115,7 @@ Weekly review helper showing session stats and wins:
 
 ```bash
 week
-```text
+```
 
 Output:
 
@@ -136,7 +136,7 @@ Week of December 27, 2025
      ...
 
   Take a moment to celebrate progress! 🎉
-```diff
+```
 
 ---
 

--- a/docs/commands/pick.md
+++ b/docs/commands/pick.md
@@ -9,7 +9,7 @@
 ```bash
 pick [CATEGORY] [OPTIONS]
 pick [PROJECT-NAME]
-```bash
+```
 
 **Quick examples:**
 
@@ -22,7 +22,7 @@ pick dev
 
 # Jump directly to project
 pick flow
-```diff
+```
 
 ---
 
@@ -85,7 +85,7 @@ The `pick` command provides an interactive, ADHD-friendly way to select and navi
 ```bash
 # Open picker with all projects
 pick
-```text
+```
 
 **Output:**
 
@@ -96,7 +96,7 @@ pick
 🔧 atlas
 📝 product-of-three
 > _
-```bash
+```
 
 ### Intermediate Usage
 
@@ -105,7 +105,7 @@ pick
 ```bash
 # Show only dev-tools projects
 pick dev
-```text
+```
 
 **Output:**
 
@@ -115,7 +115,7 @@ pick dev
 🔧 aiterm
 🔧 nexus-cli
 > _
-```bash
+```
 
 ### Advanced Usage
 
@@ -124,13 +124,13 @@ pick dev
 ```bash
 # Direct jump (no FZF interface)
 pick flow
-```text
+```
 
 **Output:**
 
 ```text
 📁 /Users/dt/projects/dev-tools/flow-cli
-```bash
+```
 
 ---
 
@@ -149,7 +149,7 @@ pick dev
 
 # Evening: Teaching prep
 pick teach
-```bash
+```
 
 ### Pattern 2: Category Aliases
 
@@ -162,7 +162,7 @@ pickdev          # pick dev
 pickq            # pick q
 pickteach        # pick teach
 pickrs           # pick rs
-```bash
+```
 
 ### Pattern 3: Recent Projects Only
 
@@ -173,7 +173,7 @@ pickrs           # pick rs
 pick --recent
 # or
 pick -r
-```bash
+```
 
 ---
 
@@ -187,14 +187,14 @@ pick && cc
 
 # Or use CC dispatcher's built-in pick
 cc pick
-```bash
+```
 
 ### With Work Command
 
 ```bash
 # Pick project, then start work session
 pick && work
-```text
+```
 
 ---
 
@@ -227,7 +227,7 @@ When you run `pick` without arguments and have a recent session (< 24 hours):
 ```bash
 💡 Last: flow-cli (2h ago)
 [Enter] Resume  │  [Space] Browse all  │  Type to search...
-```bash
+```
 
 | Key | Action |
 |-----|--------|
@@ -251,7 +251,7 @@ When you run `pick` without arguments and have a recent session (< 24 hours):
 ```bash
 export FLOW_PROJECTS_ROOT="$HOME/work"
 pick
-```text
+```
 
 ### Project Categories
 
@@ -268,7 +268,7 @@ PROJ_CATEGORIES=(
     "quarto/presentations:q:📊"
     "apps:app:📱"
 )
-```diff
+```
 
 ---
 
@@ -300,7 +300,7 @@ echo $FLOW_PROJECTS_ROOT
 
 # Set in .zshrc
 export FLOW_PROJECTS_ROOT="$HOME/projects"
-```diff
+```
 
 ### Issue 2: Projects missing from list
 
@@ -316,7 +316,7 @@ export FLOW_PROJECTS_ROOT="$HOME/projects"
 # Add .STATUS file to project
 cd missing-project
 echo "status: active" > .STATUS
-```diff
+```
 
 ### Issue 3: Keybindings don't work
 

--- a/docs/commands/plugin.md
+++ b/docs/commands/plugin.md
@@ -9,7 +9,7 @@ flow plugin [command] [options]
 flow plugin list
 flow plugin install <path|gh:user/repo>
 flow plugin create <name>
-```text
+```
 
 ## Description
 
@@ -59,7 +59,7 @@ Plugins can register callbacks for these events:
 
 ```bash
 flow plugin list
-```text
+```
 
 Output:
 
@@ -73,13 +73,13 @@ INSTALLED PLUGINS
   TOTALS
     Installed: 1
     Enabled: 1
-```text
+```
 
 ### Create a Plugin
 
 ```bash
 flow plugin create my-plugin
-```text
+```
 
 Creates:
 
@@ -88,7 +88,7 @@ Creates:
 ├── main.zsh          # Plugin entry point
 ├── plugin.json       # Metadata (optional)
 └── README.md         # Documentation
-```bash
+```
 
 ### Install from GitHub
 
@@ -98,7 +98,7 @@ flow plugin install gh:username/flow-plugin-name
 
 # Install as dev (symlink)
 flow plugin install --dev ~/code/my-plugin
-```bash
+```
 
 ### Enable/Disable
 
@@ -108,13 +108,13 @@ flow plugin disable example
 
 # Re-enable it
 flow plugin enable example
-```text
+```
 
 ### View Hook Registrations
 
 ```bash
 flow plugin hooks
-```text
+```
 
 Output:
 
@@ -130,7 +130,7 @@ REGISTERED HOOKS
   TOTALS
     Events with hooks: 2
     Total callbacks: 2
-```zsh
+```
 
 ## Creating Plugins
 
@@ -146,7 +146,7 @@ _flow_plugin_register "hello" "1.0.0" "Says hello"
 hello() {
     echo "Hello from my plugin!"
 }
-```zsh
+```
 
 ### Plugin with Hooks
 
@@ -159,7 +159,7 @@ _notify_on_finish() {
     osascript -e "display notification \"Finished $project\" with title \"flow-cli\""
 }
 _flow_hook_register "post-finish" "_notify_on_finish"
-```zsh
+```
 
 ### Plugin with Dependencies
 
@@ -171,7 +171,7 @@ _flow_plugin_require_tool "git" || return 1
 _flow_plugin_require_tool "gh" || return 1
 
 # Plugin code here...
-```text
+```
 
 ### Plugin Metadata (plugin.json)
 
@@ -187,7 +187,7 @@ _flow_plugin_require_tool "gh" || return 1
   },
   "hooks": ["post-work", "post-finish"]
 }
-```zsh
+```
 
 ## Plugin API
 
@@ -202,7 +202,7 @@ _flow_plugin_exists "name"
 
 # Get plugin info
 _flow_plugin_info "name"
-```zsh
+```
 
 ### Hooks
 
@@ -212,7 +212,7 @@ _flow_hook_register "event-name" "callback_function"
 
 # Run hooks for an event
 _flow_hook_run "event-name" "$arg1" "$arg2"
-```zsh
+```
 
 ### Dependencies
 
@@ -222,7 +222,7 @@ _flow_plugin_require_tool "tool-name"
 
 # Require flow version
 _flow_plugin_require_version "3.3.0"
-```zsh
+```
 
 ### Logging
 
@@ -232,7 +232,7 @@ _flow_log_success "Operation complete"
 _flow_log_error "Something went wrong"
 _flow_log_warning "Watch out"
 _flow_log_debug "Debug info"
-```text
+```
 
 ## Plugin Registry
 
@@ -240,7 +240,7 @@ Disabled plugins are tracked in:
 
 ```text
 ~/.config/flow/plugin-registry.json
-```text
+```
 
 Format:
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -12,7 +12,7 @@ Complete reference for the `flow status` command - update and query project stat
 flow status [project] [options]
 flow status [project] <status> <priority> <task> <progress>
 flow status --help
-```yaml
+```
 
 ---
 
@@ -37,7 +37,7 @@ Prompts you for each field:
 
 ```bash
 flow status mediationverse
-```text
+```
 
 **Example interaction:**
 
@@ -63,7 +63,7 @@ Progress? [85]
 > 90
 
 ✅ Updated! Press Enter to continue...
-```text
+```
 
 ### Quick Mode
 
@@ -71,13 +71,13 @@ Provide all values at once:
 
 ```bash
 flow status <project> <status> <priority> <task> <progress>
-```text
+```
 
 **Example:**
 
 ```bash
 flow status mediationverse active P0 "Complete sims" 90
-```text
+```
 
 ### Create Mode
 
@@ -85,7 +85,7 @@ Initialize a new `.STATUS` file:
 
 ```bash
 flow status newproject --create
-```text
+```
 
 ### Show Mode
 
@@ -93,7 +93,7 @@ View status without updating:
 
 ```bash
 flow status mediationverse --show
-```bash
+```
 
 ---
 
@@ -110,7 +110,7 @@ flow status mediationverse
 # Update current project
 cd ~/projects/r-packages/active/mediationverse
 flow status .
-```text
+```
 
 ### status
 
@@ -130,7 +130,7 @@ flow status proj active   # Working on it now
 flow status proj paused   # On hold
 flow status proj blocked  # Waiting for review/approval
 flow status proj ready    # Ready when you are
-```text
+```
 
 ### priority
 
@@ -148,7 +148,7 @@ Priority level (one of):
 flow status proj active P0   # Critical priority
 flow status proj active P1   # Important priority
 flow status proj active P2   # Normal priority
-```diff
+```
 
 **Guidelines:**
 
@@ -164,7 +164,7 @@ Next action description (quoted string):
 
 ```bash
 flow status proj active P0 "Run final simulations" 85
-```diff
+```
 
 **Good task descriptions:**
 
@@ -192,7 +192,7 @@ Progress percentage (0-100):
 
 ```bash
 flow status proj active P0 "Task" 75
-```sql
+```
 
 **Progress guidelines:**
 
@@ -222,7 +222,7 @@ Create new `.STATUS` file for project:
 
 ```bash
 flow status newproject --create
-```bash
+```
 
 **What it does:**
 
@@ -245,7 +245,7 @@ progress: 0
 next: Define first task
 updated: 2025-12-24
 category: r-packages
-```text
+```
 
 ### --show
 
@@ -253,7 +253,7 @@ Display status without updating:
 
 ```bash
 flow status mediationverse --show
-```text
+```
 
 **Output:**
 
@@ -269,7 +269,7 @@ Category: r-packages
 Type:     r-package
 
 Location: ~/projects/r-packages/active/mediationverse
-```text
+```
 
 ### --json
 
@@ -277,7 +277,7 @@ Output in JSON format (useful for scripts):
 
 ```bash
 flow status mediationverse --json
-```text
+```
 
 **Output:**
 
@@ -293,7 +293,7 @@ flow status mediationverse --json
   "type": "r-package",
   "location": "~/projects/r-packages/active/mediationverse"
 }
-```text
+```
 
 ### --help, -h
 
@@ -301,7 +301,7 @@ Show help message:
 
 ```bash
 flow status --help
-```bash
+```
 
 ---
 
@@ -313,7 +313,7 @@ flow status --help
 cd ~/projects/research/new-study
 flow status new-study --create
 flow status new-study ready P2 "Literature review" 0
-```bash
+```
 
 ### Example 2: Daily Updates
 
@@ -326,7 +326,7 @@ flow status mediationverse active P0 "Halfway through sims" 85
 
 # End of day: Save state
 flow status mediationverse paused P0 "Resume tomorrow - 2 sims left" 90
-```bash
+```
 
 ### Example 3: Project State Changes
 
@@ -346,7 +346,7 @@ flow status proj active P0 "Got data - final push!" 75
 
 # Complete
 flow status proj ready P2 "Done!" 100
-```bash
+```
 
 ### Example 4: Batch Updates
 
@@ -359,7 +359,7 @@ flow status proj4 ready P2 "Not started" 0
 
 # Verify
 flow dash
-```bash
+```
 
 ### Example 5: Integration with Other Commands
 
@@ -376,7 +376,7 @@ flow status . active P0 "Feature X committed" 95
 # After testing
 npm test
 flow status . active P0 "All tests passing!" 100
-```text
+```
 
 ---
 
@@ -398,7 +398,7 @@ next: Run final simulations
 updated: 2025-12-24
 category: r-packages
 location: ~/projects/r-packages/active/mediationverse
-```diff
+```
 
 **Fields:**
 
@@ -435,7 +435,7 @@ Override default config directory:
 ```bash
 export FLOW_CLI_HOME=~/.flow-cli
 flow status proj --show
-```yaml
+```
 
 ---
 
@@ -468,7 +468,7 @@ Status updates appear in:
 ```bash
 flow dash              # Terminal dashboard
 flow dashboard --web   # Web dashboard
-```bash
+```
 
 Both auto-refresh to show latest status.
 
@@ -479,7 +479,7 @@ Both auto-refresh to show latest status.
 ```bash
 git add .STATUS
 git commit -m "docs: update project status"
-```bash
+```
 
 **Or gitignore it:**
 

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -14,7 +14,7 @@ Synchronize workflow data across all flow-cli components with a single command. 
 flow sync              # Smart sync - see what needs syncing
 flow sync all          # Sync everything
 flow sync --status     # View sync dashboard
-```text
+```
 
 ---
 
@@ -22,7 +22,7 @@ flow sync --status     # View sync dashboard
 
 ```bash
 flow sync [target] [options]
-```bash
+```
 
 ### Targets
 
@@ -66,7 +66,7 @@ flow sync all --dry-run
 
 # Quick local sync (skip git)
 flow sync all --skip-git
-```bash
+```
 
 ### Individual Targets
 
@@ -82,7 +82,7 @@ flow sync goals
 
 # Sync git (fetch, rebase, push)
 flow sync git
-```bash
+```
 
 ### Scripting
 
@@ -92,7 +92,7 @@ flow sync all --quiet
 
 # Check sync status
 flow sync --status
-```diff
+```
 
 ---
 
@@ -145,7 +145,7 @@ iCloud sync for multi-device access (v4.7.0+).
 flow sync remote              # Show sync status
 flow sync remote init         # Set up iCloud sync
 flow sync remote disable      # Revert to local storage
-```diff
+```
 
 **Setup:**
 
@@ -195,7 +195,7 @@ When running `flow sync all`, targets execute in dependency order:
 session → status → wins → goals → git
    ↓         ↓        ↓       ↓      ↓
  (2ms)    (120ms)  (15ms)  (5ms)  (1.2s)
-```diff
+```
 
 - **Session** must run first (captures current state)
 - **Status** updates timestamps before win aggregation
@@ -219,7 +219,7 @@ session → status → wins → goals → git
   [5/5] git... done (pushed 2 commits)
 
 ✓ Sync complete (1.4s)
-```text
+```
 
 ### Quiet Output
 
@@ -235,7 +235,7 @@ With `--quiet`, only errors are shown.
   ...
 
 Run without --dry-run to execute
-```text
+```
 
 ---
 
@@ -256,7 +256,7 @@ Sync state is stored in `$FLOW_DATA_DIR/sync-state.json`:
     "git": "skipped"
   }
 }
-```bash
+```
 
 View with `flow sync --status`.
 
@@ -286,7 +286,7 @@ git rebase --abort
 git add <resolved-files>
 git rebase --continue
 git push
-```text
+```
 
 ---
 
@@ -298,7 +298,7 @@ The `finish` command can optionally sync before ending a session:
 
 ```bash
 finish "Completed feature"  # Commits and optionally syncs
-```text
+```
 
 ### With `dash` Command
 
@@ -307,14 +307,14 @@ The dashboard shows sync status:
 ```bash
 dash          # Shows last sync time
 dash --watch  # Auto-refreshes with sync status
-```bash
+```
 
 ### With CI/CD
 
 ```bash
 # In a pre-push hook
 flow sync all --quiet || exit 1
-```diff
+```
 
 ---
 

--- a/docs/commands/teach-init.md
+++ b/docs/commands/teach-init.md
@@ -18,7 +18,7 @@ teach-init -y "STAT 545"
 
 # Preview migration plan (existing Quarto project)
 teach-init --dry-run "STAT 545"
-```text
+```
 
 ---
 
@@ -26,7 +26,7 @@ teach-init --dry-run "STAT 545"
 
 ```bash
 teach-init [OPTIONS] <course-name>
-```diff
+```
 
 ---
 
@@ -60,7 +60,7 @@ Use `-y` or `--yes` for automation or when you want to accept safe defaults:
 
 ```bash
 teach-init -y "STAT 545"
-```text
+```
 
 **Safe defaults in non-interactive mode:**
 
@@ -85,7 +85,7 @@ Renames your current branch to `production` and creates `draft` for editing.
 ```text
 main → production (students see this)
      └→ draft (you edit here)
-```diff
+```
 
 ### Strategy 2: Parallel Branches
 
@@ -124,7 +124,7 @@ A lightweight git tag is created before migration:
 
 ```text
 spring-2026-pre-migration
-```text
+```
 
 This allows manual recovery if needed.
 
@@ -157,7 +157,7 @@ After successful migration, `teach-init` displays an ADHD-friendly summary box:
 │   2. Make edits, commit as usual                            │
 │   3. ./scripts/quick-deploy.sh                              │
 └─────────────────────────────────────────────────────────────┘
-```bash
+```
 
 ---
 
@@ -170,7 +170,7 @@ mkdir ~/teaching/stat-579
 cd ~/teaching/stat-579
 git init
 teach-init "STAT 579 - Causal Inference"
-```bash
+```
 
 ### Create and Push to GitHub in One Step
 
@@ -180,7 +180,7 @@ teach-init "STAT 545" --github
 
 # With flow-cli (preferred method):
 teach init "STAT 545" --github
-```bash
+```
 
 ### Existing Quarto Course
 
@@ -188,7 +188,7 @@ teach init "STAT 545" --github
 cd ~/teaching/stat-545
 teach-init --dry-run "STAT 545"  # Preview first
 teach-init "STAT 545"             # Execute migration
-```bash
+```
 
 ### With renv (R Package Management)
 
@@ -196,7 +196,7 @@ teach-init "STAT 545"             # Execute migration
 cd ~/teaching/my-r-course
 teach-init "My R Course"
 # Prompts: "Exclude renv/ from git? [Y/n]"
-```bash
+```
 
 ### Non-Interactive (Automation)
 
@@ -209,7 +209,7 @@ teach-init -y "STAT 440"
 # - Auto-exclude renv/
 # - Skip GitHub push
 # - Use suggested semester dates
-```yaml
+```
 
 ---
 
@@ -234,7 +234,7 @@ semester:
 shortcuts:
   quick: stat
   deploy: statd
-```bash
+```
 
 ---
 

--- a/docs/commands/teach.md
+++ b/docs/commands/teach.md
@@ -23,7 +23,7 @@ teach status
 
 # Deploy changes to production
 teach deploy
-```text
+```
 
 ---
 
@@ -56,7 +56,7 @@ flowchart TD
     style D fill:#90EE90
     style M fill:#FFD700
     style N fill:#87CEEB
-```diff
+```
 
 **Key Integration Points:**
 
@@ -93,7 +93,7 @@ sequenceDiagram
     teach->>GitHub: Create PR (draft → main)
     GitHub-->>teach: PR created
     teach-->>User: PR URL
-```text
+```
 
 ---
 
@@ -101,7 +101,7 @@ sequenceDiagram
 
 ```bash
 teach <command> [args]
-```diff
+```
 
 ---
 
@@ -154,7 +154,7 @@ teach init --no-git "TEST 101"
 
 # Preview migration plan without changes
 teach init --dry-run "STAT 545"
-```bash
+```
 
 ### Daily Workflow with Git Integration (v5.12.0)
 
@@ -195,7 +195,7 @@ teach deploy
 #   ✓ No production conflicts
 #
 # Creating PR: draft → main
-```bash
+```
 
 ### Teaching Mode Workflow (v5.12.0)
 
@@ -220,7 +220,7 @@ teach quiz "Chapter 5"
 
 # Deploy all commits at once
 teach deploy
-```bash
+```
 
 ### End of Semester
 
@@ -229,7 +229,7 @@ teach deploy
 teach archive
 
 # This creates a tagged snapshot and prepares for next semester
-```bash
+```
 
 ### Additional Commands
 
@@ -257,7 +257,7 @@ teach backup archive spring-2026
 # Quarto profiles
 teach profiles list
 teach profiles switch draft
-```bash
+```
 
 ### Content Creation Examples (v5.12.0)
 
@@ -279,7 +279,7 @@ teach assignment "Homework 1"
 
 # All commands support --dry-run preview
 teach exam "Topic" --dry-run --verbose
-```diff
+```
 
 ---
 
@@ -325,7 +325,7 @@ teach deploy
 # Creating PR: draft → main
 # → Auto-generated PR body with commit list
 # → Deploy checklist included
-```diff
+```
 
 **Pre-flight checks:**
 - Verifies on `draft` branch
@@ -344,7 +344,7 @@ Archive the current semester before starting a new one.
 ```bash
 teach archive
 # Runs ./scripts/semester-archive.sh
-```diff
+```
 
 ### `teach status`
 
@@ -373,7 +373,7 @@ teach status
 #   2) Stash changes
 #   3) View diff
 #   4) Skip
-```diff
+```
 
 **Git Integration (v5.12.0):**
 - Detects uncommitted teaching content (exams, slides, assignments, etc.)
@@ -393,7 +393,7 @@ teach week
 # 📅 Week 8
 #   Semester started: 2026-01-13
 #   Days elapsed: 52
-```bash
+```
 
 ### `teach migrate-config` (v5.20.0)
 
@@ -411,14 +411,14 @@ teach migrate-config --force
 
 # Don't create backup
 teach migrate-config --no-backup
-```text
+```
 
 **Before Migration:**
 
 ```text
 .flow/
 └── teach-config.yml    # 657 lines (course + 14 weeks embedded)
-```text
+```
 
 **After Migration:**
 
@@ -427,7 +427,7 @@ teach migrate-config --no-backup
 ├── teach-config.yml      # ~50 lines (course meta + reference)
 ├── teach-config.yml.bak  # Backup of original
 └── lesson-plans.yml      # ~600 lines (all weeks extracted)
-```diff
+```
 
 **Flags:**
 - `--dry-run` - Preview changes without modifying files
@@ -440,7 +440,7 @@ teach migrate-config --no-backup
 ```bash
 cp .flow/teach-config.yml.bak .flow/teach-config.yml
 rm .flow/lesson-plans.yml
-```bash
+```
 
 ### `teach templates` (v5.20.0)
 
@@ -467,7 +467,7 @@ teach templates validate lecture.qmd
 teach templates sync --dry-run
 teach templates sync
 teach templates sync --force
-```diff
+```
 
 **Template types:**
 
@@ -492,7 +492,7 @@ Templates use `{{VARIABLE}}` syntax. Auto-filled from config:
 
 ```bash
 teach init "STAT-545" --with-templates
-```bash
+```
 
 **Resolution order:** Project templates override plugin defaults.
 
@@ -519,7 +519,7 @@ teach macros export --format json > macros.json
 
 # Get help
 teach macros help
-```diff
+```
 
 **Primary purpose:** Ensure AI-generated content (via Scholar) uses correct notation like `\E{Y}` instead of `E[Y]`.
 
@@ -568,7 +568,7 @@ scholar:
     export:
       format: "json"
       include_in_prompts: true
-```diff
+```
 
 **Integration with Scholar:**
 
@@ -607,7 +607,7 @@ teach plan delete 3 --force  # skip confirmation
 
 # Overwrite existing week
 teach plan create 3 --topic "Updated Topic" --force
-```yaml
+```
 
 **Subcommands:**
 
@@ -645,7 +645,7 @@ weeks:
     key_concepts:
       - "descriptive-stats"
     prerequisites: []
-```diff
+```
 
 **Features:**
 
@@ -672,7 +672,7 @@ teach plan edit 5
 
 # Generate slides using the plan
 teach slides --week 5
-```bash
+```
 
 **See:** [Tutorial 25](../tutorials/25-lesson-plan-migration.md) for migration + plan management workflow.
 
@@ -689,7 +689,7 @@ teach config --view
 
 # Print to stdout
 teach config --cat
-```text
+```
 
 ### Scholar Content Commands
 
@@ -703,7 +703,7 @@ Generate lecture notes with comprehensive content.
 teach lecture "Introduction to Regression"
 teach lecture --week 5 --topic "Linear Models"
 teach lecture "Hypothesis Testing" --style formal
-```diff
+```
 
 **Flags:**
 - `--week`, `-w` - Week number for organization
@@ -720,7 +720,7 @@ Generate presentation slides.
 teach slides "ANOVA Overview"
 teach slides --week 8 --optimize   # With slide break optimization
 teach slides "Regression" --template revealjs
-```diff
+```
 
 **Flags:**
 - `--week`, `-w` - Week number
@@ -735,7 +735,7 @@ Generate exams with customizable question types.
 teach exam "Midterm 1"
 teach exam "Final" --topics "regression,anova,hypothesis-testing"
 teach exam "Quiz 5" --duration 30 --points 50
-```diff
+```
 
 **Flags:**
 - `--topics` - Comma-separated topic list
@@ -750,7 +750,7 @@ Generate quick quizzes.
 ```bash
 teach quiz "Chapter 5"
 teach quiz --week 3 --questions 10
-```text
+```
 
 #### `teach assignment`
 
@@ -759,7 +759,7 @@ Generate homework assignments.
 ```bash
 teach assignment "Homework 3"
 teach assignment "Lab 5" --due "2026-02-15"
-```text
+```
 
 #### `teach syllabus`
 
@@ -768,7 +768,7 @@ Generate course syllabus.
 ```bash
 teach syllabus
 teach syllabus --template formal
-```text
+```
 
 #### `teach rubric`
 
@@ -777,7 +777,7 @@ Generate grading rubrics.
 ```bash
 teach rubric "Final Project"
 teach rubric "Presentation" --criteria "content,delivery,visuals"
-```text
+```
 
 #### `teach feedback`
 
@@ -785,7 +785,7 @@ Generate student feedback templates.
 
 ```bash
 teach feedback "Assignment 3"
-```text
+```
 
 ### `teach doctor`
 
@@ -799,7 +799,7 @@ teach doctor --verbose    # Detailed: per-package R, full macro list
 teach doctor --brief      # Warnings and failures only
 teach doctor --json       # Machine-readable JSON
 teach doctor --ci         # CI mode: no color, exit 1 on failure
-```text
+```
 
 **Quick mode checks:** Dependencies, R environment + renv, config, git setup
 **Full mode adds:** R packages, Quarto extensions, Scholar, hooks, cache, macros (opt-in), teaching style
@@ -819,7 +819,7 @@ teach validate --render           # Full render validation
 teach validate --watch            # Continuous watch mode
 teach validate --concepts         # Concept graph validation
 teach validate --macros           # LaTeX macro validation
-```text
+```
 
 **Validation layers:**
 1. YAML frontmatter validation
@@ -838,7 +838,7 @@ teach analyze --batch lectures/         # Batch directory
 teach analyze --slide-breaks week-05.qmd  # Slide optimization
 teach analyze --ai                       # Include AI analysis
 teach analyze --report markdown          # Generate report
-```diff
+```
 
 **Analysis features:**
 - Concept extraction from frontmatter
@@ -857,7 +857,7 @@ teach hooks install     # Install teaching hooks
 teach hooks status      # Check hook status
 teach hooks upgrade     # Upgrade to latest
 teach hooks uninstall   # Remove hooks
-```diff
+```
 
 **Installed hooks:**
 - `pre-commit` - Validation before commit
@@ -872,7 +872,7 @@ Manage semester dates and scheduling.
 teach dates             # Show current date info
 teach dates --calendar  # Show semester calendar
 teach dates week 8      # What date is week 8?
-```text
+```
 
 ### `teach profiles`
 
@@ -883,7 +883,7 @@ teach profiles list           # Show available profiles
 teach profiles show draft     # Display profile config
 teach profiles set production # Activate profile
 teach profiles create slides  # Create new profile
-```text
+```
 
 **Built-in profiles:** default, draft, production, slides, print
 
@@ -898,7 +898,7 @@ teach cache clear --lectures    # Clear only lectures
 teach cache clear --old 7       # Clear older than 7 days
 teach cache analyze             # Detailed diagnostics
 teach cache rebuild             # Clear and regenerate
-```sql
+```
 
 ### `teach clean`
 
@@ -909,7 +909,7 @@ teach clean              # Interactive cleanup
 teach clean --all        # Remove all artifacts
 teach clean --output     # Remove _output only
 teach clean --freeze     # Remove _freeze only
-```text
+```
 
 ### `teach backup`
 
@@ -921,7 +921,7 @@ teach backup list                      # List all backups
 teach backup restore week-05.2026-01-20  # Restore backup
 teach backup delete old-backup         # Delete backup
 teach backup archive spring-2026       # Archive semester
-```diff
+```
 
 **Retention policies:**
 - Daily backups: 7 days
@@ -935,7 +935,7 @@ Scholar, and Craft — grouped by workflow phase.
 
 ```bash
 teach map    # Shows the full ecosystem map
-```yaml
+```
 
 **Workflow Phases:**
 

--- a/docs/commands/timer.md
+++ b/docs/commands/timer.md
@@ -10,7 +10,7 @@ The `timer` command provides Pomodoro-style focus timers with visual countdown, 
 
 ```bash
 timer [command] [options]
-```bash
+```
 
 ## Commands
 
@@ -39,7 +39,7 @@ timer 45           # 45 minutes
 
 # 5-minute break
 timer break
-```bash
+```
 
 ### Focus Sessions
 
@@ -51,7 +51,7 @@ timer focus 30 "Finish documentation"
 timer status
 # ⏱️ focus: 23:45 remaining
 #    Finish documentation
-```bash
+```
 
 ### Pomodoro Cycles
 
@@ -64,7 +64,7 @@ timer pomodoro 6 30 5 20
 
 # Shortcut alias
 pom                # Same as: timer pomodoro
-```text
+```
 
 ---
 
@@ -77,7 +77,7 @@ pom                # Same as: timer pomodoro
 Focus session - 25 minutes
 
   ⏱️  23:45 [████████████░░░░░░░░]
-```text
+```
 
 ### Break Timer
 
@@ -86,7 +86,7 @@ Focus session - 25 minutes
 5 minutes - stretch, hydrate, move
 
   ☕ 4:23 remaining
-```text
+```
 
 ### Pomodoro
 
@@ -95,7 +95,7 @@ Focus session - 25 minutes
 4 cycles: 25m focus, 5m break
 
 ━━━ Cycle 1 of 4 ━━━
-```yaml
+```
 
 ---
 
@@ -120,7 +120,7 @@ Timers save state to `$FLOW_DATA_DIR/timer.state`, allowing you to:
 # From any terminal
 timer status
 timer stop
-```bash
+```
 
 ---
 
@@ -140,7 +140,7 @@ timer 45 "Complete feature X"
 
 # When done
 finish "Completed feature X"
-```text
+```
 
 ---
 

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -6,7 +6,7 @@
 
 ```bash
 flow upgrade [target] [options]
-```text
+```
 
 ## Description
 
@@ -36,7 +36,7 @@ flow upgrade [target] [options]
 
 ```bash
 flow upgrade self
-```text
+```
 
 This runs `git pull` in the flow-cli directory and reloads the plugin.
 
@@ -44,7 +44,7 @@ This runs `git pull` in the flow-cli directory and reloads the plugin.
 
 ```bash
 flow upgrade tools
-```bash
+```
 
 Runs `brew update && brew upgrade` for flow-cli recommended tools.
 
@@ -52,7 +52,7 @@ Runs `brew update && brew upgrade` for flow-cli recommended tools.
 
 ```bash
 flow upgrade plugins
-```text
+```
 
 Updates plugins via antidote (if installed).
 
@@ -60,7 +60,7 @@ Updates plugins via antidote (if installed).
 
 ```bash
 flow upgrade all
-```text
+```
 
 Updates flow-cli, Homebrew packages, and ZSH plugins in sequence.
 
@@ -68,7 +68,7 @@ Updates flow-cli, Homebrew packages, and ZSH plugins in sequence.
 
 ```bash
 flow upgrade --check
-```text
+```
 
 Output:
 
@@ -88,13 +88,13 @@ Homebrew:
 
 ZSH Plugins:
   Status: ✅ Up to date
-```text
+```
 
 ### Show Changelog
 
 ```bash
 flow upgrade --changelog
-```text
+```
 
 Shows recent changes from the git log.
 

--- a/docs/contributing/BRANCH-WORKFLOW.md
+++ b/docs/contributing/BRANCH-WORKFLOW.md
@@ -15,7 +15,7 @@ hotfix/*       │        │
     │          │        │
     └── PR ────┘        │
                └── PR ──┘
-```diff
+```
 
 ---
 
@@ -66,7 +66,7 @@ g feature start my-feature
 # 1. Fetches latest dev
 # 2. Creates feature/my-feature from dev
 # 3. Switches to new branch
-```bash
+```
 
 ### During Development
 
@@ -77,7 +77,7 @@ git commit -m "feat: add new capability"
 
 # Keep in sync with dev
 g feature sync
-```bash
+```
 
 ### Finishing Work
 
@@ -89,7 +89,7 @@ g feature finish
 # 1. Pushes branch to origin
 # 2. Creates PR with dev as base
 # 3. Opens PR in browser
-```bash
+```
 
 ### Release Workflow
 
@@ -101,7 +101,7 @@ g release
 # 1. Creates PR: dev → main
 # 2. Includes all merged features
 # 3. Opens PR for maintainer review
-```yaml
+```
 
 ---
 
@@ -125,7 +125,7 @@ Use instead:
   g promote               Create PR: feature → dev
 
 Override: GIT_WORKFLOW_SKIP=1 git push
-```diff
+```
 
 ### Protected Branches
 
@@ -138,7 +138,7 @@ Override: GIT_WORKFLOW_SKIP=1 git push
 ```bash
 # Only when absolutely necessary
 GIT_WORKFLOW_SKIP=1 git push origin main
-```bash
+```
 
 **Logged:** All blocked attempts are logged to `~/.claude/workflow-violations.log`
 
@@ -161,7 +161,7 @@ g feature sync
 
 # Finish
 g feature finish
-```bash
+```
 
 ### 2. Bug Fix
 
@@ -174,7 +174,7 @@ git commit -m "fix: resolve session timeout race condition"
 
 # Finish
 g feature finish
-```bash
+```
 
 ### 3. Documentation
 
@@ -187,7 +187,7 @@ git commit -m "docs: update dispatcher reference"
 
 # Finish
 g feature finish
-```bash
+```
 
 ### 4. Hotfix (Maintainers Only)
 
@@ -203,7 +203,7 @@ git commit -m "fix: patch security vulnerability"
 # PR directly to main
 git push origin hotfix/security-patch
 gh pr create --base main --title "Security patch"
-```diff
+```
 
 ---
 
@@ -242,7 +242,7 @@ gh api repos/Data-Wise/flow-cli/branches/main/protection \
 
 # Or via GitHub web UI:
 # Settings → Branches → Add rule
-```bash
+```
 
 ---
 
@@ -261,14 +261,14 @@ git branch -a | grep -E "main|dev"
 # 3. Test feature workflow
 g feature start test-workflow
 g feature finish
-```bash
+```
 
 ### Monitor Violations
 
 ```bash
 # Check log file
 tail -f ~/.claude/workflow-violations.log
-```bash
+```
 
 ---
 
@@ -283,7 +283,7 @@ g feature sync
 # Or manually:
 git fetch origin
 git merge origin/dev
-```bash
+```
 
 ### Accidentally Committed to main/dev
 
@@ -293,7 +293,7 @@ git checkout main
 git checkout -b feature/rescued-work
 git checkout main
 git reset --hard origin/main
-```zsh
+```
 
 ### Workflow Guard Not Working
 
@@ -306,7 +306,7 @@ source flow.plugin.zsh
 
 # Check function exists
 type _g_check_workflow
-```bash
+```
 
 ---
 
@@ -339,7 +339,7 @@ git pull origin dev
 git add docs/specs/SPEC-feature-name.md
 git commit -m "docs: add feature X implementation plan"
 git push origin dev
-```bash
+```
 
 **Critical Rule:** ❌ **Never start coding during planning phase**
 
@@ -355,7 +355,7 @@ git worktree add ~/.git-worktrees/flow-cli-<feature-name> -b feature/<feature-na
 
 # Verify creation
 git worktree list
-```diff
+```
 
 **Worktree Location Convention:**
 - Standard: `~/.git-worktrees/flow-cli-<feature-name>`
@@ -380,7 +380,7 @@ git worktree add ~/.git-worktrees/flow-cli-cache -b feature/cache dev
 To start implementation, please start a new session:
   cd ~/.git-worktrees/flow-cli-cache
   claude"
-```diff
+```
 
 **Why?** Fresh session ensures:
 - Clean context (no planning session baggage)
@@ -410,7 +410,7 @@ test:      Add/modify tests
 chore:     Maintenance (deps, config)
 perf:      Performance improvement
 style:     Formatting, whitespace
-```bash
+```
 
 **Examples:**
 
@@ -424,7 +424,7 @@ git commit -m "docs: update CLAUDE.md with cache architecture"
 git commit -m "WIP"
 git commit -m "fixes stuff"
 git commit -m "updated files"
-```diff
+```
 
 **Before Each Commit:**
 1. Run tests: `./tests/run-all.sh` or specific test suite
@@ -553,7 +553,7 @@ git worktree list | grep $(pwd)
 
 # Check remote tracking
 git status
-```bash
+```
 
 ### Abort Conditions
 

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -65,7 +65,7 @@ flow-cli/
 ├── completions/              # ZSH completions
 ├── tests/                    # Test suite
 └── docs/                     # Documentation (MkDocs)
-```yaml
+```
 
 ---
 
@@ -109,7 +109,7 @@ We use conventional commits:
 
 ```text
 <type>(<scope>): <description>
-```diff
+```
 
 **Types:**
 
@@ -127,7 +127,7 @@ feat(cc): add worktree integration
 fix(g): handle missing dev branch
 docs(reference): update dispatcher docs
 test(mcp): add validation tests
-```bash
+```
 
 ---
 
@@ -144,7 +144,7 @@ for f in tests/test-*-dispatcher.zsh; do zsh "$f"; done
 
 # Interactive validation (fun!)
 ./tests/interactive-dog-feeding.zsh
-```sql
+```
 
 ### Writing Tests
 
@@ -191,7 +191,7 @@ test_help_shows_usage
 # Summary
 echo "Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
 [[ $TESTS_FAILED -eq 0 ]] && exit 0 || exit 1
-```diff
+```
 
 ### Test Guidelines
 
@@ -247,7 +247,7 @@ Examples:
   mydisp action2 --flag
 EOF
 }
-```sql
+```
 
 **Avoid:**
 
@@ -339,7 +339,7 @@ EOF
 
 ```text
 feature/* → dev → main
-```diff
+```
 
 - Feature branches merge to `dev`
 - `dev` merges to `main` for releases
@@ -388,7 +388,7 @@ git push origin vX.Y.Z
 
 # 3. Create GitHub release (triggers Homebrew update)
 gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes "Release notes"
-```bash
+```
 
 ### Manual Deployment (if needed)
 
@@ -398,7 +398,7 @@ mkdocs gh-deploy --force
 
 # Homebrew (via workflow dispatch)
 gh workflow run homebrew-release.yml -f version=X.Y.Z
-```text
+```
 
 ### CI Files Location
 

--- a/docs/contributing/DOCUMENTATION-STYLE-GUIDE.md
+++ b/docs/contributing/DOCUMENTATION-STYLE-GUIDE.md
@@ -83,7 +83,7 @@ docs/
 └── contributing/          # Contributor guides
     ├── PR-WORKFLOW-GUIDE.md
     └── DOCUMENTATION-STYLE-GUIDE.md (this file)
-```diff
+```
 
 ### File Naming
 
@@ -137,7 +137,7 @@ Example:
 ```bash
 flow status
 ```text
-````diff
+````
 
 **Bad:**
 
@@ -146,7 +146,7 @@ The flow status command, which is obviously one of the most important
 commands in the entire system, provides comprehensive visibility into
 your current workflow state by leveraging our proprietary session
 tracking algorithm.
-```diff
+```
 
 ### Sentence Structure
 
@@ -163,13 +163,13 @@ tracking algorithm.
 
 ```markdown
 The system caches project scans for one hour.
-```text
+```
 
 **Bad (passive voice):**
 
 ```markdown
 Project scans are cached by the system for a duration of one hour.
-```bash
+```
 
 ---
 
@@ -189,7 +189,7 @@ Project scans are cached by the system for a duration of one hour.
 #### H4 - Rarely needed
 
 ##### H5 - Avoid if possible
-```diff
+```
 
 **Best practices:**
 
@@ -206,16 +206,16 @@ Project scans are cached by the system for a duration of one hour.
 ```bash
 flow status
 ```text
-````bash
+````
 
 ```javascript
 const session = new Session('id', 'project', 'task')
-```bash
+```
 
 ```python
 # Python example
 result = process_data()
-```diff
+```
 
 ````diff
 
@@ -235,13 +235,13 @@ result = process_data()
 ✅ See [Testing Guide](../guides/TESTING.md)
 ✅ Read the [Dispatcher Reference](../reference/MASTER-DISPATCHER-GUIDE.md)
 ❌ See [Testing Guide](https://data-wise.github.io/flow-cli/testing/TESTING/)
-````diff
+````
 
 **Use full URLs for external links:**
 
 ```markdown
 ✅ [Clean Architecture Book](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
-```diff
+```
 
 ### Lists
 
@@ -253,7 +253,7 @@ result = process_data()
   - Nested item
   - Another nested item
 - Third item
-```text
+```
 
 **Ordered lists:**
 
@@ -261,14 +261,14 @@ result = process_data()
 1. First step
 2. Second step
 3. Third step
-```diff
+```
 
 **Task lists:**
 
 ```markdown
 - [ ] Todo item
 - [x] Completed item
-```text
+```
 
 ### Tables
 
@@ -279,7 +279,7 @@ result = process_data()
 | ------------- | -------------------- | ------------------- |
 | `flow status` | Show current session | `flow status`       |
 | `flow work`   | Start session        | `flow work project` |
-```text
+```
 
 **Alignment:**
 
@@ -287,7 +287,7 @@ result = process_data()
 | Left aligned | Center aligned | Right aligned |
 | :----------- | :------------: | ------------: |
 | Text         |      Text      |          Text |
-```text
+```
 
 ---
 
@@ -319,7 +319,7 @@ Use this pattern for better results.
 
 !!! danger "Critical"
 Don't do this - it will break things.
-```text
+```
 
 ### Scannable Content
 
@@ -335,7 +335,7 @@ Don't do this - it will break things.
 3. **Run:** `flow status`
 
 **Time:** 5 minutes
-```text
+```
 
 **Bad (wall of text):**
 
@@ -346,7 +346,7 @@ To get started with flow-cli you'll need to first install the
 dependencies using npm install and then run the test suite to
 make sure everything is working properly and finally you can
 run the flow status command to see your first output.
-```diff
+```
 
 ### Visual Elements
 
@@ -396,7 +396,7 @@ flow status
 # Task: Fix bug #123
 # Duration: 0 min
 ```text
-````text
+````
 
 **What this does:**
 
@@ -414,7 +414,7 @@ flow status
 ✅ Include comments
 ✅ Use realistic data
 ✅ Show error cases
-````text
+````
 
 **DON'T:**
 
@@ -423,7 +423,7 @@ flow status
 ❌ Leave output ambiguous
 ❌ Skip error handling
 ❌ Use outdated examples
-```text
+```
 
 ---
 
@@ -441,7 +441,7 @@ graph LR
     C --> D[Use Cases]
     D --> E[Adapters]
 ```diff
-````text
+````
 
 ````diff
 
@@ -456,7 +456,7 @@ graph LR
 **For simple visualizations:**
 
 ```markdown
-````diff
+````
 
 ┌─────────────────────────────────────┐
 │ 📊 Dashboard │
@@ -467,7 +467,7 @@ graph LR
 
 ```text
 
-```diff
+```
 
 ### Screenshots
 
@@ -481,7 +481,7 @@ graph LR
 
 ```markdown
 ![Dashboard Screenshot](../assets/dashboard-example.png)
-```diff
+```
 
 ---
 
@@ -503,7 +503,7 @@ graph LR
 ---
 
 [Content begins...]
-```text
+```
 
 ### Version Information
 
@@ -512,7 +512,7 @@ graph LR
 ```markdown
 **Version:** v2.0.0-beta.1
 **Status:** Production Use Phase
-```text
+```
 
 ### Update Protocol
 
@@ -531,7 +531,7 @@ graph LR
 ```markdown
 !!! warning "Deprecated"
 This feature was removed in v2.0.0. Use [new feature](#) instead.
-```diff
+```
 
 ---
 
@@ -587,7 +587,7 @@ This feature was removed in v2.0.0. Use [new feature](#) instead.
 ```bash
 # Command example
 ```diff
-````diff
+````
 
 **What this does:** [Explanation]
 
@@ -628,7 +628,7 @@ This feature was removed in v2.0.0. Use [new feature](#) instead.
 
 ```bash
 # Minimal example
-````diff
+````
 
 ## All Options
 
@@ -642,13 +642,13 @@ This feature was removed in v2.0.0. Use [new feature](#) instead.
 
 ```bash
 # Command
-```bash
+```
 
 ### Example 2: [Another Use Case]
 
 ```bash
 # Command
-```yaml
+```
 
 ---
 
@@ -668,7 +668,7 @@ This feature was removed in v2.0.0. Use [new feature](#) instead.
 **Bad:**
 ```markdown
 The status command shows your session.
-````yaml
+````
 
 **Good:**
 

--- a/docs/contributing/PR-WORKFLOW-GUIDE.md
+++ b/docs/contributing/PR-WORKFLOW-GUIDE.md
@@ -45,7 +45,7 @@ git commit -m "feat: add new feature"
 # 5. Push and create PR to dev (NOT main)
 git push origin feature/your-feature-name
 gh pr create --base dev --title "Add new feature"
-```text
+```
 
 **Branch Workflow (v4.1.0+):**
 
@@ -54,7 +54,7 @@ feature/* ──► dev ──► main
     │          │        │
     └── PR ────┘        │
                └── PR ──┘
-```diff
+```
 
 - **feature/\*** → **dev**: All development work
 - **dev** → **main**: Releases only
@@ -73,7 +73,7 @@ feature/* ──► dev ──► main
 
 # Search for existing PRs
 # Visit: https://github.com/Data-Wise/flow-cli/pulls
-```diff
+```
 
 ### 2. Read Project Documentation
 
@@ -100,7 +100,7 @@ flow-cli/
 ├── completions/          # ZSH completions
 ├── hooks/                # ZSH hooks
 └── tests/                # Test suite
-```diff
+```
 
 **Key principles:**
 
@@ -121,7 +121,7 @@ zsh tests/run-tests.zsh
 work --help
 dash --help
 r help
-```text
+```
 
 ---
 
@@ -135,7 +135,7 @@ hotfix/*       │        │
     │          │        │
     └── PR ────┘        │
                └── PR ──┘
-```text
+```
 
 **Branch Roles:**
 
@@ -162,7 +162,7 @@ The `g` dispatcher will **block** direct pushes to protected branches:
 g push  # On main or dev
 ✗ Cannot push directly to protected branch: main
 ℹ Use PRs: feature → dev → main
-```bash
+```
 
 ### When to Use Each Branch
 
@@ -172,7 +172,7 @@ g push  # On main or dev
 g feature start my-feature    # Creates from dev
 # ... work on feature ...
 g feature finish              # PR to dev
-```bash
+```
 
 **For urgent production fixes:**
 
@@ -182,7 +182,7 @@ git checkout -b hotfix/critical-bug
 # ... fix bug ...
 git push origin hotfix/critical-bug
 gh pr create --base main      # Hotfix goes directly to main
-```bash
+```
 
 ---
 
@@ -200,7 +200,7 @@ g feature start add-dashboard-widget
 git checkout dev
 git pull origin dev
 git checkout -b feature/add-dashboard-widget
-```bash
+```
 
 **Branch naming convention:**
 
@@ -219,7 +219,7 @@ refactor/simplify-cache-logic
 
 # Hotfixes (branch from main for urgent production fixes)
 hotfix/critical-security-patch
-```bash
+```
 
 **Pattern:** `type/short-description-kebab-case`
 
@@ -254,7 +254,7 @@ hotfix/critical-security-patch
 
 # Run tests
 zsh tests/run-tests.zsh
-```diff
+```
 
 **Test requirements:**
 
@@ -291,7 +291,7 @@ git commit -m "perf: optimize project scanning with caching"
 git commit -m "feat!: change session API signature
 
 BREAKING CHANGE: work command now requires project name"
-```text
+```
 
 **Commit message format:**
 
@@ -301,7 +301,7 @@ BREAKING CHANGE: work command now requires project name"
 [optional body]
 
 [optional footer(s)]
-```diff
+```
 
 **Types:**
 
@@ -329,7 +329,7 @@ gh pr create --base dev --title "Add dashboard auto-refresh" --body "Closes #123
 
 # Or create PR via GitHub web interface
 # ⚠️ IMPORTANT: Change base branch from main to dev
-```text
+```
 
 **PR workflow:**
 
@@ -339,7 +339,7 @@ feature/your-feature → dev (PR #1)
       (After merge)
            ↓
     dev → main (PR #2, releases only)
-```diff
+```
 
 **PR template will guide you through:**
 
@@ -402,7 +402,7 @@ the dispatcher pattern as you suggested. See commit abc123.
 - Fixed variable naming in work.zsh
 - Added edge case test for empty project list
 - Still working on the performance optimization - will update soon
-```bash
+```
 
 **Iterate quickly:**
 
@@ -413,7 +413,7 @@ git commit -m "refactor: address review comments"
 git push origin feature/your-feature-name
 
 # PR automatically updates
-```diff
+```
 
 ### Approval and Merge
 
@@ -446,7 +446,7 @@ git branch -d feature/your-feature-name
 
 # Delete remote branch (usually done automatically by GitHub)
 git push origin --delete feature/your-feature-name
-```bash
+```
 
 ### 2. Update Your Fork
 
@@ -465,7 +465,7 @@ git checkout main
 git fetch upstream
 git merge upstream/main
 git push origin main
-```bash
+```
 
 ### 3. Celebrate
 
@@ -495,7 +495,7 @@ g feature start new-command
 
 # 6. Create PR to dev
 g feature finish
-```bash
+```
 
 ### Scenario 2: Adding a Dispatcher Subcommand
 
@@ -506,7 +506,7 @@ g feature finish
 # 4. Update _<name>_help() function
 # 5. Add tests
 # 6. Update DISPATCHER-REFERENCE.md
-```bash
+```
 
 ### Scenario 3: Fixing a Bug
 
@@ -524,7 +524,7 @@ zsh tests/run-tests.zsh
 # 6. Create PR
 # - Reference issue number: "Fixes #123"
 # - Explain root cause and solution
-```bash
+```
 
 ### Scenario 4: Updating Documentation
 
@@ -543,7 +543,7 @@ mkdocs build --strict
 # 4. Create PR
 # - Explain what was unclear before
 # - Show improvement
-```bash
+```
 
 ---
 
@@ -560,7 +560,7 @@ zsh tests/unit/test-core.zsh
 
 # Check for syntax errors
 zsh -n lib/core.zsh
-```diff
+```
 
 **Common causes:**
 
@@ -586,7 +586,7 @@ g feature sync
 git add .
 git commit -m "resolve merge conflicts with dev"
 git push origin feature/your-feature-name
-```diff
+```
 
 ### CI/CD Checks Failing
 

--- a/docs/demos/tutorials/COMPLETION-SUMMARY.md
+++ b/docs/demos/tutorials/COMPLETION-SUMMARY.md
@@ -42,7 +42,7 @@ agg \
   --theme dracula \       # High contrast theme
   --fps-cap 10 \          # Smooth playback
   input.cast output.gif
-```diff
+```
 
 ### File Sizes
 
@@ -80,7 +80,7 @@ agg \
 
 ```bash
 teach slides "Introduction to Statistics" --style conceptual
-```diff
+```
 
 **Shows:**
 - Topic specification
@@ -104,7 +104,7 @@ teach slides "Introduction to Statistics" --style conceptual
 
 ```bash
 teach quiz "Hypothesis Testing" --style rigorous --technical-depth high
-```diff
+```
 
 **Shows:**
 - Combining style presets with modifiers
@@ -127,7 +127,7 @@ teach quiz "Hypothesis Testing" --style rigorous --technical-depth high
 
 ```bash
 teach lecture --lesson content/lesson-plans/week03.yml
-```diff
+```
 
 **Shows:**
 - Loading structured lesson plan
@@ -153,7 +153,7 @@ teach lecture --lesson content/lesson-plans/week03.yml
 
 ```bash
 teach exam --interactive
-```diff
+```
 
 **Interactive Flow:**
 1. **Topic selection** → "Statistical Inference"
@@ -183,7 +183,7 @@ teach exam --interactive
 
 ```bash
 teach slides --revise slides-v1.md --feedback "Add more practical examples"
-```diff
+```
 
 **Revision Process:**
 1. **Load existing content** (847 words, 12 slides)
@@ -213,7 +213,7 @@ teach slides --revise slides-v1.md --feedback "Add more practical examples"
 
 ```bash
 teach quiz --week 5
-```diff
+```
 
 **Auto-Detection:**
 - Week 5 → Feb 10-14, 2026 (from config)
@@ -243,7 +243,7 @@ teach quiz --week 5
 
 ```bash
 teach assignment "Hypothesis Testing Practice" --with-readings
-```diff
+```
 
 **Context Sources:**
 - `.flow/teach-config.yml` (course settings)
@@ -292,7 +292,7 @@ docs/demos/tutorials/
 ├── STATUS.md                     # Progress tracker
 ├── COMPLETION-SUMMARY.md         # This file
 └── convert-all.sh                # Batch conversion script
-```diff
+```
 
 ---
 
@@ -344,7 +344,7 @@ docs/demos/tutorials/
 ![Demo: Help System](../../demos/tutorials/scholar-01-help.gif)
 
 *Figure 1: Discovering Scholar Enhancement flags with --help*
-```diff
+```
 
 ---
 

--- a/docs/demos/tutorials/TEACHING-V3-GIFS-README.md
+++ b/docs/demos/tutorials/TEACHING-V3-GIFS-README.md
@@ -55,7 +55,7 @@ This directory contains VHS tapes and generated GIF demos for Teaching Workflow 
 # Run the enhanced generation script with validation + optimization
 cd docs/demos/tutorials
 ./generate-teaching-v3-gifs.sh
-```bash
+```
 
 **The script automatically:**
 1. ✅ Validates all VHS tapes before generation
@@ -75,7 +75,7 @@ vhs tutorial-teach-init.tape
 vhs tutorial-teach-deploy.tape
 vhs tutorial-teach-status.tape
 vhs tutorial-scholar-integration.tape
-```text
+```
 
 ### Expected Output
 
@@ -99,7 +99,7 @@ vhs tutorial-scholar-integration.tape
   ✅ tutorial-scholar-integration.gif (288K)
 
 🎉 All GIFs generated successfully!
-```yaml
+```
 
 ---
 
@@ -203,7 +203,7 @@ Set Width 1400
 Set Height 900
 Set TypingSpeed 50ms
 Set PlaybackSpeed 0.8
-```zsh
+```
 
 ### Important Setup Steps
 
@@ -272,7 +272,7 @@ brew install gifsicle
 # Optimize GIFs
 gifsicle -O3 tutorial-teach-doctor.gif -o tutorial-teach-doctor.gif
 gifsicle -O3 tutorial-backup-system.gif -o tutorial-backup-system.gif
-```diff
+```
 
 ---
 
@@ -299,7 +299,7 @@ ps aux | grep vhs
 
 # Monitor log output
 tail -f /path/to/vhs/output.log
-```zsh
+```
 
 ### Commands not found
 
@@ -307,7 +307,7 @@ Make sure flow-cli is sourced:
 
 ```bash
 source ~/projects/dev-tools/flow-cli/flow.plugin.zsh
-```bash
+```
 
 ### Demo course missing
 

--- a/docs/diagrams/ARCHITECTURE-DIAGRAMS.md
+++ b/docs/diagrams/ARCHITECTURE-DIAGRAMS.md
@@ -72,7 +72,7 @@ graph TB
     style Core fill:#e1f5ff
     style Dispatchers fill:#fff3e0
     style Commands fill:#f3e5f5
-```text
+```
 
 ---
 
@@ -100,7 +100,7 @@ graph LR
 
     style Router fill:#4fc3f7
     style Help fill:#ffb74d
-```text
+```
 
 **Example Flow:**
 
@@ -116,7 +116,7 @@ Route to: _g_push origin main
 Execute: git push origin main
     ↓
 Log result with _flow_log_success
-```text
+```
 
 ---
 
@@ -159,7 +159,7 @@ flowchart TD
     style CheckGit fill:#fff9c4
     style ParseGit fill:#c5e1a5
     style Merge fill:#b3e5fc
-```text
+```
 
 **Worktree Structure Detection:**
 
@@ -185,7 +185,7 @@ graph TB
 
     style Flat1 fill:#ffccbc
     style Hier1 fill:#c5cae9
-```text
+```
 
 ---
 
@@ -215,7 +215,7 @@ sequenceDiagram
     Pick-->>User: Show all worktrees (including new)
 
     Note over Cache,Pick: No TTL wait - immediate visibility
-```text
+```
 
 ---
 
@@ -259,7 +259,7 @@ graph TB
     style Config fill:#fff59d
     style Validator fill:#a5d6a7
     style Claude fill:#90caf9
-```text
+```
 
 **Config Ownership Protocol:**
 
@@ -284,7 +284,7 @@ graph LR
     style ScholarPlugin fill:#64b5f6
     style Course fill:#fff59d
     style Scholar fill:#ce93d8
-```yaml
+```
 
 ---
 
@@ -314,7 +314,7 @@ stateDiagram-v2
         Optional git commit
         Session duration logged
     end note
-```sql
+```
 
 ---
 
@@ -365,7 +365,7 @@ flowchart LR
     style Cache fill:#fff9c4
     style Format fill:#c5e1a5
     style FZF fill:#b3e5fc
-```text
+```
 
 ---
 
@@ -413,7 +413,7 @@ graph TD
     style FZF fill:#ff9800
     style Claude fill:#ff9800
     style Atlas fill:#9e9e9e
-```text
+```
 
 ---
 
@@ -443,7 +443,7 @@ graph TB
     style Status fill:#c8e6c9
     style Project fill:#fff9c4
     style UI fill:#b3e5fc
-```text
+```
 
 **Color Palette (ADHD-Friendly):**
 
@@ -456,7 +456,7 @@ Active:   #729C51 (Green)
 Paused:   #E5C07B (Yellow)
 Header:   #9D9CC9 (Soft Purple)
 Accent:   #D19A66 (Soft Orange)
-```text
+```
 
 ---
 
@@ -491,7 +491,7 @@ graph TB
 
     style PluginLoader fill:#4fc3f7
     style PluginAPI fill:#81c784
-```text
+```
 
 ---
 
@@ -525,7 +525,7 @@ graph TD
     style Project fill:#4caf50
     style Global fill:#2196f3
     style Defaults fill:#9e9e9e
-```text
+```
 
 **Priority Order:**
 
@@ -566,7 +566,7 @@ flowchart TD
     style Warning fill:#fff9c4
     style Error fill:#ffcdd2
     style Fatal fill:#ef9a9a
-```diff
+```
 
 **Error Types:**
 
@@ -610,7 +610,7 @@ graph TB
     style Unit fill:#c5e1a5
     style Integration fill:#b3e5fc
     style E2E fill:#f8bbd0
-```text
+```
 
 ---
 

--- a/docs/examples/course-planning/README.md
+++ b/docs/examples/course-planning/README.md
@@ -116,7 +116,7 @@ cp docs/examples/course-planning/intermediate-stats/stat-545-config.yml \
 
 # Edit with your course details
 vim /path/to/your/course/.flow/teach-config.yml
-```diff
+```
 
 ### Step 3: Adapt to Your Context
 
@@ -144,7 +144,7 @@ teach doctor
 
 # If missing dependencies, auto-install
 teach doctor --fix
-```diff
+```
 
 **What this gives you:**
 - Automatic YAML validation on commit
@@ -165,7 +165,7 @@ teach assignment "HW1: Data Exploration"
 
 # Content is automatically backed up
 # lesson-plan.yml is auto-loaded for context
-```diff
+```
 
 **Phase 2 features available:**
 - Parallel rendering (3-10x faster for large courses)

--- a/docs/examples/course-planning/intermediate-stats/README.md
+++ b/docs/examples/course-planning/intermediate-stats/README.md
@@ -100,7 +100,7 @@ This example demonstrates complete 3-stage backward design:
 
 ```text
 HW3 (R/20%) → HW4 (M/25%) → Midterm (R/20%) → Project (M/20%) → Final (M/30%)
-```diff
+```
 
 ---
 

--- a/docs/getting-started/faq-dependencies.md
+++ b/docs/getting-started/faq-dependencies.md
@@ -14,7 +14,7 @@
 │ ↓                                                           │
 │ Pure ZSH (no dependencies)                                  │
 └─────────────────────────────────────────────────────────────┘
-```diff
+```
 
 **You can use flow-cli:**
 - ✅ Without any plugin manager (manual install)
@@ -54,7 +54,7 @@ if [[ -d "$HOME/.oh-my-zsh" ]]; then
 elif [[ -f "$HOME/.antidoterc" ]]; then
     echo "  ✓ antidote (plugin manager)"
 fi
-```text
+```
 
 ---
 
@@ -72,7 +72,7 @@ Great question! These are **two completely different things**:
 └── custom/                      # Your plugins
     └── plugins/
         └── flow-cli/            ← flow-cli installed HERE
-```diff
+```
 
 **Characteristics:**
 - ❌ Large installation (~50MB)
@@ -89,7 +89,7 @@ Great question! These are **two completely different things**:
 │   ├── ohmyzsh/.../git          ← OMZ git plugin
 │   └── ohmyzsh/.../docker       ← OMZ docker plugin
 └── .zsh_plugins.zsh             # Auto-generated cache
-```diff
+```
 
 **NO ~/.oh-my-zsh/ directory!**
 
@@ -109,7 +109,7 @@ Great question! These are **two completely different things**:
 Plugin Manager:  antidote (modern, fast)
 Plugins Used:    18 OMZ plugins + 4 community + flow-cli
 OMZ Directory:   NONE (no ~/.oh-my-zsh/)
-```diff
+```
 
 **You get:**
 - OMZ's excellent plugins (git, docker, clipboard, etc.)
@@ -151,7 +151,7 @@ OMZ Directory:   NONE (no ~/.oh-my-zsh/)
 ohmyzsh/ohmyzsh path:lib         # YOU load this (optional)
 ohmyzsh/ohmyzsh path:plugins/git # YOU load this (optional)
 Data-Wise/flow-cli               # flow-cli (independent)
-```zsh
+```
 
 All three plugins **coexist independently**.
 
@@ -174,7 +174,7 @@ All three plugins **coexist independently**.
 # In flow-cli/lib/dispatchers/g-dispatcher.zsh
 unalias g 2>/dev/null            # Remove OMZ git alias
 g() { ... }                      # Replace with flow-cli dispatcher
-```bash
+```
 
 **Result:** flow-cli's `g` dispatcher wins, OMZ git aliases (ga, gco, etc.) still work.
 
@@ -193,7 +193,7 @@ gco         # git checkout
 gst         # git status
 gp          # git push
 # ... 226+ more aliases
-```text
+```
 
 **flow-cli `g` dispatcher provides:**
 
@@ -202,7 +202,7 @@ g status    # Enhanced status with branch info
 g push      # Token-validated push
 g commit    # Conventional commit wizard
 g feature   # Feature branch workflow
-```text
+```
 
 **Use together:**
 
@@ -210,7 +210,7 @@ g feature   # Feature branch workflow
 gaa                  # Quick add (OMZ)
 g commit             # Interactive commit (flow-cli)
 gp                   # Quick push (OMZ)
-```diff
+```
 
 ---
 
@@ -247,7 +247,7 @@ zinit list                         # Zinit
 # Check specific plugins
 which g                            # Shows if flow-cli dispatcher
 alias | grep "^g"                  # Shows if OMZ git plugin
-```zsh
+```
 
 ---
 
@@ -264,7 +264,7 @@ echo 'source ~/.flow-cli/flow.plugin.zsh' >> ~/.zshrc
 
 # 3. Reload
 source ~/.zshrc
-```zsh
+```
 
 **No plugin manager required!**
 
@@ -278,7 +278,7 @@ source ~/.zshrc
 # Benchmark
 time ( source flow.plugin.zsh )
 # → ~5-8ms (negligible)
-```diff
+```
 
 **Optimizations:**
 - Load guards prevent double-sourcing
@@ -323,7 +323,7 @@ Covers:
    - zinit
    - Oh-My-Zsh
    - Manual install
-```text
+```
 
 ### Plugin Ecosystem (Optional)
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,7 +23,7 @@ zsh --version
 # Check Git (required)
 git --version
 # Expected: any recent version
-```bash
+```
 
 ---
 
@@ -39,7 +39,7 @@ brew tap data-wise/tap
 
 # 2. Install flow-cli
 brew install flow-cli
-```diff
+```
 
 **That's it!** Homebrew manages the installation and keeps flow-cli updated.
 
@@ -55,7 +55,7 @@ For auto-detection of your plugin manager:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Data-Wise/flow-cli/main/install.sh | bash
-```bash
+```
 
 This auto-detects your plugin manager (antidote, zinit, oh-my-zsh) and installs accordingly.
 
@@ -116,7 +116,7 @@ Choose your plugin manager if not using Homebrew:
 ```bash
 source ~/.zshrc
 # Or just restart your terminal
-```diff
+```
 
 ### Checkpoint
 
@@ -133,7 +133,7 @@ Run the built-in doctor command:
 
 ```bash
 flow doctor
-```text
+```
 
 Expected output:
 
@@ -159,7 +159,7 @@ Optional Tools:
   ...
 
 All checks passed!
-```bash
+```
 
 ### Fix Missing Dependencies
 
@@ -171,7 +171,7 @@ flow doctor --fix
 
 # Auto-install all
 flow doctor --fix -y
-```diff
+```
 
 ### Checkpoint
 
@@ -196,7 +196,7 @@ yay
 
 # End session
 finish
-```diff
+```
 
 ### Checkpoint
 
@@ -226,7 +226,7 @@ For the best experience, install these CLI tools:
 ```bash
 # Using Homebrew (macOS)
 brew install fzf eza bat zoxide fd ripgrep
-```bash
+```
 
 **If you installed flow-cli via Homebrew, you likely already have Homebrew installed.**
 
@@ -239,7 +239,7 @@ brew bundle --file=~/.flow-cli/setup/Brewfile
 # Or if installed via Homebrew, download the Brewfile first
 curl -fsSL https://raw.githubusercontent.com/Data-Wise/flow-cli/main/setup/Brewfile -o /tmp/Brewfile
 brew bundle --file=/tmp/Brewfile
-```bash
+```
 
 | Tool | Purpose | Used By |
 |------|---------|---------|
@@ -278,7 +278,7 @@ Flow-cli uses **nvim** as the default editor. If you're new to nvim, we recommen
 ```bash
 nvim --version
 # Expected: v0.9.0 or higher
-```diff
+```
 
 ### Install LazyVim (Optional but Recommended)
 
@@ -307,7 +307,7 @@ rm -rf ~/.config/nvim/.git
 
 # Start nvim and plugins will auto-install
 nvim
-```bash
+```
 
 **Wait for installation:** First launch will install all plugins (~2-3 minutes). Watch the progress at the bottom of the screen.
 
@@ -353,7 +353,7 @@ nvim
 
 # Quit nvim
 # Press: ESC → :q → ENTER
-```bash
+```
 
 ### Learning Nvim
 
@@ -372,7 +372,7 @@ nvim
 ```bash
 # Hands-on practice with checkpoints
 flow nvim-tutorial
-```bash
+```
 
 **Total learning time:** ~70 minutes from zero to productive
 
@@ -390,7 +390,7 @@ source ~/.zshrc
 # Verify
 echo $EDITOR
 # Expected: nvim
-```bash
+```
 
 Now `work`, `mcp edit`, `dots edit`, and other flow-cli commands will use nvim!
 
@@ -403,7 +403,7 @@ Check installation:
 ```bash
 which nvim
 # If empty, nvim is not in PATH
-```bash
+```
 
 **LazyVim plugins not installing:**
 
@@ -412,7 +412,7 @@ Check internet connection and try:
 ```bash
 # Inside nvim, run:
 :Lazy sync
-```text
+```
 
 **No icons showing in Neo-tree:**
 
@@ -424,7 +424,7 @@ Inside nvim, run:
 
 ```bash
 :checkhealth
-```bash
+```
 
 This diagnoses issues with clipboard, Python, Node.js, etc.
 
@@ -451,7 +451,7 @@ brew --prefix flow-cli
 
 # Reinstall if needed
 brew reinstall flow-cli
-```bash
+```
 
 **Homebrew not installed:**
 
@@ -462,7 +462,7 @@ brew reinstall flow-cli
 # Then install flow-cli
 brew tap data-wise/tap
 brew install flow-cli
-```zsh
+```
 
 ### Plugin Manager Issues
 
@@ -473,7 +473,7 @@ Shell hasn't reloaded. Try:
 ```bash
 source ~/.zshrc
 # Or restart your terminal
-```zsh
+```
 
 **"command not found: work"**
 
@@ -487,7 +487,7 @@ ls ~/.oh-my-zsh/custom/plugins/flow-cli/  # OMZ install
 
 # Re-source
 source ~/.zshrc
-```bash
+```
 
 **Plugin Manager Not Detected**
 
@@ -495,7 +495,7 @@ Force a specific method:
 
 ```bash
 INSTALL_METHOD=manual curl -fsSL .../install.sh | bash
-```bash
+```
 
 Options: `antidote`, `zinit`, `omz`, `manual`
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -24,7 +24,7 @@ win "Set up flow-cli"
 
 # 4. End session
 finish
-```bash
+```
 
 ---
 
@@ -37,7 +37,7 @@ work my-project     # 1. Start a focused session
 # ... do your work ...
 win "Did the thing"  # 2. Log your wins
 finish "Done!"       # 3. End and optionally commit
-```bash
+```
 
 **That's it!** Everything else builds on this foundation.
 
@@ -53,7 +53,7 @@ flow --version
 
 # Should show help
 flow help
-```zsh
+```
 
 If commands aren't found, ensure the plugin is sourced in your `.zshrc`:
 
@@ -63,7 +63,7 @@ antidote load data-wise/flow-cli
 
 # Or manual source
 source /path/to/flow-cli/flow.plugin.zsh
-```bash
+```
 
 ---
 
@@ -75,7 +75,7 @@ work my-project
 
 # Or use the interactive picker
 work
-```text
+```
 
 You'll see:
 
@@ -85,7 +85,7 @@ You'll see:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 🟢 Status: active
 🎯 Focus: Implement new feature
-```diff
+```
 
 **What happened:**
 
@@ -104,7 +104,7 @@ As you accomplish things, log them:
 win "Implemented user login"
 win "Fixed that annoying bug"
 win --ship "Deployed to production"
-```text
+```
 
 Output:
 
@@ -113,7 +113,7 @@ Output:
 Implemented user login
 
 Keep it up! 🚀
-```bash
+```
 
 ### Win Categories
 
@@ -141,7 +141,7 @@ yay
 
 # Weekly summary with graph
 yay --week
-```bash
+```
 
 **What you'll see:**
 
@@ -160,7 +160,7 @@ finish "Completed auth feature"
 # You'll be prompted to commit if there are changes
 # Commit 3 change(s)? [y/N] y
 # ✓ Changes committed
-```bash
+```
 
 ---
 
@@ -175,7 +175,7 @@ flow goal set 3
 # Check progress
 flow goal
 # Today: ██████░░░░ 2/3 wins
-```diff
+```
 
 ---
 
@@ -228,7 +228,7 @@ Get help for any dispatcher:
 g help
 r help
 cc help
-```diff
+```
 
 ---
 

--- a/docs/guides/ALIAS-MANAGEMENT-WORKFLOW.md
+++ b/docs/guides/ALIAS-MANAGEMENT-WORKFLOW.md
@@ -25,7 +25,7 @@ The `flow alias` command provides complete alias lifecycle management:
 
 ```bash
 flow alias doctor
-```diff
+```
 
 **Output shows:**
 - Total alias count
@@ -50,7 +50,7 @@ flow alias doctor
 
 ❌ BROKEN TARGETS
   oldcmd → nonexistent_binary
-```bash
+```
 
 ### 2. Find an Alias
 
@@ -61,7 +61,7 @@ flow alias find devtools   # Aliases containing 'devtools'
 
 # Exact match
 flow alias find --exact gst
-```text
+```
 
 ### 3. Create a New Alias
 
@@ -69,7 +69,7 @@ flow alias find --exact gst
 
 ```bash
 flow alias add myalias='echo hello world'
-```bash
+```
 
 **Interactive mode (wizard):**
 
@@ -82,7 +82,7 @@ flow alias add
 # - Not a duplicate
 # - Doesn't shadow system command
 # - Target command exists
-```diff
+```
 
 **Safety checks performed:**
 - Duplicate detection: prevents overwriting existing alias
@@ -94,7 +94,7 @@ flow alias add
 
 ```bash
 flow alias rm myalias
-```bash
+```
 
 **What happens:**
 1. Creates backup of .zshrc (`~/.zshrc.alias-backup`)
@@ -114,7 +114,7 @@ flow alias test gst --dry-run
 
 # Actually run it
 flow alias test gst --exec
-```text
+```
 
 ---
 
@@ -124,7 +124,7 @@ Running `flow doctor` now includes a quick alias health summary:
 
 ```bash
 flow doctor
-```text
+```
 
 **Output includes:**
 
@@ -132,7 +132,7 @@ flow doctor
 ⚡ ALIASES
   45 aliases (2 shadows, 1 broken)
   Run 'flow alias doctor' for details
-```bash
+```
 
 ---
 
@@ -150,7 +150,7 @@ flow alias find cat
 # This is intentional - bat is a better cat with syntax highlighting
 # If you want the real cat:
 command cat file.txt
-```bash
+```
 
 ### Scenario 2: "I think I have duplicate aliases"
 
@@ -162,7 +162,7 @@ flow alias find log
 # glo='git log --oneline'
 # glog='git log --graph'
 # gl='git pull'
-```bash
+```
 
 ### Scenario 3: "My alias stopped working"
 
@@ -174,7 +174,7 @@ flow alias test myalias
 # - Definition
 # - Whether target command exists
 # - Dry-run output
-```bash
+```
 
 ### Scenario 4: "I want to add an alias but not sure if name conflicts"
 
@@ -185,7 +185,7 @@ flow alias add
 # Or check manually first
 flow alias find myname
 which myname
-```diff
+```
 
 ---
 

--- a/docs/guides/BACKUP-SYSTEM-GUIDE.md
+++ b/docs/guides/BACKUP-SYSTEM-GUIDE.md
@@ -91,7 +91,7 @@ Creates a timestamped backup of content.
 teach backup create lectures/week-01    # Auto timestamp
 teach backup create exams/midterm       # Backup exam
 teach backup create .                   # Backup all
-```text
+```
 
 ### teach backup list
 
@@ -101,7 +101,7 @@ Lists all backups for content.
 teach backup list                       # List all
 teach backup list lectures/week-01      # List specific
 teach backup list --recent 5            # Show 5 most recent
-```text
+```
 
 ### teach backup restore
 
@@ -111,7 +111,7 @@ Restores content from a backup.
 teach backup restore lectures.2026-01-20-1430
 teach backup restore lectures.2026-01-20-1430 --force  # Skip confirmation
 teach backup restore lectures.2026-01-20-1430 --dry-run  # Preview only
-```text
+```
 
 ### teach backup delete
 
@@ -120,7 +120,7 @@ Permanently deletes a backup.
 ```bash
 teach backup delete old-backup
 teach backup delete old-backup --force  # Skip confirmation
-```text
+```
 
 ### teach backup archive
 
@@ -129,7 +129,7 @@ Archives semester backups based on retention policies.
 ```bash
 teach backup archive spring-2026
 teach backup archive spring-2026 --compress  # Create .tar.gz
-```text
+```
 
 ---
 
@@ -149,13 +149,13 @@ lectures/
     ├── week-01-intro.2026-01-17-0915/
     ├── week-02-regression.2026-01-18-1045/
     └── week-03-inference.2026-01-18-1345/
-```text
+```
 
 ### Timestamp Format
 
 ```text
 <content-name>.<YYYY-MM-DD-HHMM>/
-```diff
+```
 
 Examples:
 - `midterm.2026-01-18-1430/` - Created Jan 18, 2026 at 2:30 PM
@@ -173,7 +173,7 @@ exams/
     │   └── midterm.qmd
     └── midterm.2026-01-15-1620/    # Last week, initial version
         └── midterm.qmd
-```yaml
+```
 
 ---
 
@@ -197,7 +197,7 @@ backups:
     assessments: archive    # Exams, quizzes keep forever
     lectures: semester      # Lectures deleted at semester end
     syllabi: archive        # Syllabi keep forever
-```yaml
+```
 
 ### Content Type Mapping
 
@@ -221,7 +221,7 @@ backups:
     assessments: archive
     lectures: archive      # Changed from semester
     syllabi: archive
-```yaml
+```
 
 Or be more aggressive:
 
@@ -232,7 +232,7 @@ backups:
     assessments: archive   # Only exams kept
     lectures: semester     # All others deleted
     syllabi: semester      # Changed from archive
-```bash
+```
 
 ---
 
@@ -247,7 +247,7 @@ Most commands automatically create backups:
 teach exam "Midterm"       # Backup created automatically
 teach lecture "Topic"      # Backup created automatically
 teach assignment "HW3"     # Backup created automatically
-```bash
+```
 
 ### Manual Creation
 
@@ -259,7 +259,7 @@ _teach_backup_content lectures/week-05.qmd
 
 # Returns path to backup
 # /path/to/lectures/.backups/week-05.2026-01-18-1430
-```text
+```
 
 ### Backup Confirmation
 
@@ -268,7 +268,7 @@ After creating content, you'll see:
 ```text
 ✓ Content created: lectures/week-05-regression.qmd
 ✓ Backup created: lectures/.backups/week-05-regression.2026-01-18-1430/
-```text
+```
 
 ---
 
@@ -278,7 +278,7 @@ After creating content, you'll see:
 
 ```bash
 teach status
-```text
+```
 
 Output:
 
@@ -291,7 +291,7 @@ Backup Summary:
     • Exams:       3 backups (4.2 MB)
     • Lectures:    5 backups (8.1 MB)
     • Assignments: 4 backups (2.3 MB)
-```bash
+```
 
 ### Via Filesystem
 
@@ -304,7 +304,7 @@ find . -type d -name ".backups" | wc -l
 
 # Find specific content backups
 ls -lht lectures/.backups/
-```bash
+```
 
 ### Advanced: List Function
 
@@ -316,7 +316,7 @@ _teach_list_backups lectures/week-05.qmd
 # lectures/.backups/week-05.2026-01-18-1430
 # lectures/.backups/week-05.2026-01-17-0915
 # lectures/.backups/week-05.2026-01-15-1620
-```bash
+```
 
 ### Check Backup Size
 
@@ -325,7 +325,7 @@ _teach_list_backups lectures/week-05.qmd
 _teach_backup_size lectures/week-05.qmd
 
 # Output: 1.2M
-```bash
+```
 
 ### Count Backups
 
@@ -334,7 +334,7 @@ _teach_backup_size lectures/week-05.qmd
 _teach_count_backups lectures/week-05.qmd
 
 # Output: 3
-```bash
+```
 
 ---
 
@@ -352,7 +352,7 @@ ls -lt lectures/.backups/
 # 3. Copy content back
 cp -R lectures/.backups/week-05.2026-01-17-0915/week-05.qmd \
       lectures/week-05.qmd
-```bash
+```
 
 ### Restore with Backup
 
@@ -366,7 +366,7 @@ cp -R lectures/.backups/week-05.2026-01-17-0915/week-05.qmd \
 
 # 3. Verify
 cat lectures/week-05.qmd | head -20
-```bash
+```
 
 ### Compare Versions
 
@@ -378,7 +378,7 @@ diff lectures/week-05.qmd \
 # Or with better formatting
 diff -u lectures/week-05.qmd \
         lectures/.backups/week-05.2026-01-17-0915/week-05.qmd | less
-```bash
+```
 
 ### Partial Restore
 
@@ -392,7 +392,7 @@ awk '/^## Section 2/,/^## Section 3/' \
     lectures/.backups/week-05.2026-01-17-0915/week-05.qmd > section2.md
 
 # 3. Manually merge into current file
-```bash
+```
 
 ### Using Git (Alternative)
 
@@ -407,7 +407,7 @@ git show <commit-hash>:lectures/week-05.qmd
 
 # Restore from git
 git checkout <commit-hash> -- lectures/week-05.qmd
-```bash
+```
 
 ---
 
@@ -432,7 +432,7 @@ _teach_delete_backup lectures/.backups/week-05.2026-01-15-1620
 # ⚠ This action cannot be undone!
 #
 # Delete this backup? [y/N]
-```text
+```
 
 ### Force Delete (Scripts)
 
@@ -440,7 +440,7 @@ Skip confirmation for automation:
 
 ```bash
 _teach_delete_backup lectures/.backups/week-05.2026-01-15-1620 --force
-```bash
+```
 
 ### Delete All Old Backups
 
@@ -450,7 +450,7 @@ find . -type d -name "*.2025-*" -path "*/.backups/*" -exec rm -rf {} \;
 
 # Delete all backups for specific content
 rm -rf lectures/.backups/week-05.*
-```bash
+```
 
 ### Preview Cleanup
 
@@ -467,7 +467,7 @@ _teach_preview_cleanup lectures/week-05.qmd exam
 #   Policy:    archive
 #
 #   ✓ All 3 backups will be archived
-```text
+```
 
 ---
 
@@ -479,7 +479,7 @@ At end of semester:
 
 ```bash
 teach archive "Spring 2025"
-```text
+```
 
 **Process:**
 
@@ -510,7 +510,7 @@ teach archive "Spring 2025"
     • lecture-week03-backups
     • slides-week01-backups
     • slides-week02-backups
-```text
+```
 
 ### Archive Structure
 
@@ -525,7 +525,7 @@ teach archive "Spring 2025"
     │   └── syllabus-backups/
     └── Fall-2024/
         └── ...
-```bash
+```
 
 ### Archive Queries
 
@@ -541,7 +541,7 @@ du -sh .flow/archives/Spring-2025/
 
 # Total archive size
 du -sh .flow/archives/
-```bash
+```
 
 ### Restore from Archive
 
@@ -549,7 +549,7 @@ du -sh .flow/archives/
 # Copy archived backup back
 cp -R .flow/archives/Spring-2025/exam-midterm-backups/ \
       exams/.backups/
-```yaml
+```
 
 ---
 
@@ -566,14 +566,14 @@ backups:
     lectures: semester
     syllabi: archive
   archive_dir: .flow/archives
-```yaml
+```
 
 ### Disable Backups (Not Recommended)
 
 ```yaml
 backups:
   enabled: false
-```yaml
+```
 
 ⚠️ **Warning:** Disabling backups removes safety net. Use git instead.
 
@@ -582,14 +582,14 @@ backups:
 ```yaml
 backups:
   archive_dir: ../course-archives  # Outside project
-```yaml
+```
 
 Or:
 
 ```yaml
 backups:
   archive_dir: /Volumes/Backup/teaching/archives  # External drive
-```yaml
+```
 
 ### Per-Project Configuration
 
@@ -602,7 +602,7 @@ backups:
     assessments: archive   # Keep only exams
     lectures: semester     # Delete everything else
     syllabi: semester
-```bash
+```
 
 ---
 
@@ -618,7 +618,7 @@ teach status
 # - Last backup timestamp (should be recent)
 # - Total backup count (should grow over semester)
 # - Backup sizes (watch for excessive growth)
-```bash
+```
 
 ### 2. Archive Every Semester
 
@@ -629,7 +629,7 @@ teach archive "Spring 2025"
 # Verify archive
 ls -lh .flow/archives/Spring-2025/
 du -sh .flow/archives/Spring-2025/
-```bash
+```
 
 ### 3. Don't Rely on Backups Alone
 
@@ -643,7 +643,7 @@ teach lecture "Week 6"                # Automatic backup
 # Result:
 # - Git history for large-scale recovery
 # - Backups for quick restoration
-```bash
+```
 
 ### 4. Clean Up Periodically
 
@@ -660,7 +660,7 @@ for backup_dir in */.backups/*; do
       xargs -I {} rm -rf "$backup_dir/{}"
   fi
 done
-```bash
+```
 
 ### 5. Backup Configuration
 
@@ -671,7 +671,7 @@ cp .flow/teach-config.yml .flow/teach-config.yml.backup
 # Or commit to git
 g add .flow/teach-config.yml
 g commit "docs: update backup retention policies"
-```bash
+```
 
 ### 6. Test Restores
 
@@ -687,7 +687,7 @@ echo "test change" >> lectures/test.qmd
 cp lectures/.backups/test.LATEST/test.qmd lectures/test.qmd
 
 # 4. Verify original content restored
-```text
+```
 
 ---
 
@@ -699,20 +699,20 @@ cp lectures/.backups/test.LATEST/test.qmd lectures/test.qmd
 
 ```bash
 yq '.backups.enabled // true' .flow/teach-config.yml
-```text
+```
 
 **Verify Scholar integration:**
 
 ```bash
 teach doctor
-```bash
+```
 
 **Manual backup test:**
 
 ```bash
 _teach_backup_content lectures/test.qmd
 ls -lht lectures/.backups/
-```bash
+```
 
 ### Can't Restore Backup
 
@@ -721,13 +721,13 @@ ls -lht lectures/.backups/
 ```bash
 ls -ld lectures/.backups/
 ls -lh lectures/.backups/week-05.TIMESTAMP/
-```bash
+```
 
 **Fix permissions:**
 
 ```bash
 chmod -R u+rw lectures/.backups/
-```bash
+```
 
 **Verify backup integrity:**
 
@@ -737,7 +737,7 @@ ls -lh lectures/.backups/week-05.TIMESTAMP/
 
 # Check file contents
 cat lectures/.backups/week-05.TIMESTAMP/week-05.qmd | head
-```text
+```
 
 ### Excessive Backup Size
 
@@ -746,13 +746,13 @@ cat lectures/.backups/week-05.TIMESTAMP/week-05.qmd | head
 ```bash
 teach status  # View backup summary
 du -sh */.backups/
-```bash
+```
 
 **Identify large backups:**
 
 ```bash
 du -sh */.backups/* | sort -hr | head -10
-```bash
+```
 
 **Solutions:**
 
@@ -782,14 +782,14 @@ du -sh */.backups/* | sort -hr | head -10
 
 ```bash
 df -h .
-```bash
+```
 
 **Check permissions:**
 
 ```bash
 ls -ld .flow/
 mkdir -p .flow/archives  # Ensure exists
-```bash
+```
 
 **Manual archive:**
 
@@ -799,7 +799,7 @@ mkdir -p .flow/archives/Spring-2025
 
 # Move backups manually
 mv exams/.backups .flow/archives/Spring-2025/exam-backups
-```bash
+```
 
 ### Lost Backup Metadata
 
@@ -807,7 +807,7 @@ mv exams/.backups .flow/archives/Spring-2025/exam-backups
 
 ```bash
 find . -type d -name ".backups"
-```bash
+```
 
 **Reconstruct from timestamps:**
 
@@ -818,7 +818,7 @@ ls -lt lectures/.backups/
 # Rename if needed
 mv lectures/.backups/broken-name \
    lectures/.backups/week-05.$(date +%Y-%m-%d-%H%M)
-```bash
+```
 
 ---
 
@@ -854,7 +854,7 @@ for dir in exams lectures assignments quizzes slides syllabi rubrics; do
     echo "  $dir: $count backups ($size)"
   fi
 done
-```bash
+```
 
 **Automatic cleanup:**
 
@@ -885,7 +885,7 @@ for content_dir in lectures exams assignments; do
     done
   done
 done
-```bash
+```
 
 ### Integration with External Storage
 
@@ -899,7 +899,7 @@ rsync -av --delete .flow/archives/ \
 # Sync to external drive
 rsync -av --delete .flow/archives/ \
       /Volumes/Backup/teaching/archives/
-```bash
+```
 
 **Scheduled backup:**
 
@@ -910,7 +910,7 @@ crontab -e
 # Daily backup to external drive at 11 PM
 0 23 * * * cd ~/teaching/stat-440 && \
   rsync -av .flow/archives/ /Volumes/Backup/
-```bash
+```
 
 ---
 

--- a/docs/guides/CHEZMOI-SAFETY-GUIDE.md
+++ b/docs/guides/CHEZMOI-SAFETY-GUIDE.md
@@ -42,7 +42,7 @@ dots add ~/.config/nvim
 # - Auto-ignore suggestions
 
 # Confirm or cancel the add operation
-```bash
+```
 
 ### Managing Ignore Patterns
 
@@ -56,7 +56,7 @@ dots ignore list
 
 # Edit patterns manually
 dots ignore edit
-```bash
+```
 
 ### Repository Health
 
@@ -66,7 +66,7 @@ dots size
 
 # Full health check
 flow doctor --dot
-```diff
+```
 
 ---
 
@@ -106,7 +106,7 @@ Total size: 301K
 💡 Consider excluding: *.log, *.sqlite, *.db, *.cache
 
 Auto-add ignore patterns? (Y/n):
-```bash
+```
 
 ### 2. Ignore Pattern Management
 
@@ -129,7 +129,7 @@ dots ignore remove "*.tmp"
 
 # Edit manually in $EDITOR
 dots ignore edit
-```diff
+```
 
 **Pattern Syntax:**
 
@@ -144,7 +144,7 @@ dots ignore edit
 
 ```bash
 dots size
-```text
+```
 
 **Output:**
 
@@ -160,7 +160,7 @@ Top 10 largest files:
 
 ⚠️  Found 2 nested git directories
  ℹ Consider adding to .chezmoiignore
-```diff
+```
 
 **Performance Features:**
 
@@ -174,7 +174,7 @@ Top 10 largest files:
 
 ```bash
 flow doctor --dot
-```diff
+```
 
 **9 Health Checks:**
 
@@ -228,7 +228,7 @@ dots add ~/.config/nvim
 
 # Add with automatic ignore suggestion
 dots add ~/.config/obs
-```diff
+```
 
 **Preview Features:**
 
@@ -255,7 +255,7 @@ Add new ignore pattern.
 dots ignore add "*.log"
 dots ignore add "node_modules"
 dots ignore add ".DS_Store"
-```diff
+```
 
 **Features:**
 
@@ -269,7 +269,7 @@ List all ignore patterns with line numbers.
 
 ```bash
 dots ignore list
-```text
+```
 
 **Output:**
 
@@ -278,7 +278,7 @@ dots ignore list
  2  *.sqlite
  3  node_modules
  4  .DS_Store
-```text
+```
 
 #### `dots ignore remove <pattern>` (alias: `rm`)
 
@@ -286,7 +286,7 @@ Remove ignore pattern.
 
 ```bash
 dots ignore remove "*.log"
-```diff
+```
 
 **Features:**
 
@@ -300,7 +300,7 @@ Open `.chezmoiignore` in `$EDITOR`.
 
 ```bash
 dots ignore edit
-```text
+```
 
 **Default Editor:** `$EDITOR` environment variable (fallback: `vim`)
 
@@ -312,7 +312,7 @@ Analyze repository size and identify large files.
 
 ```bash
 dots size
-```diff
+```
 
 **Features:**
 
@@ -336,7 +336,7 @@ Top 10 largest files:
 ...
 
 ⚠️  Found 2 nested git directories
-```bash
+```
 
 ### `flow doctor --dot`
 
@@ -356,7 +356,7 @@ flow doctor --dot --quiet
 
 # Verbose mode (debugging)
 flow doctor --dot --verbose
-```diff
+```
 
 **Exit Codes:**
 
@@ -386,7 +386,7 @@ flow doctor --dot --verbose
 ⚠️  Large files detected:
   - vault.sqlite (200K)
   - large-config.json (100K)
-```bash
+```
 
 **Recommendation:**
 
@@ -394,7 +394,7 @@ flow doctor --dot --verbose
 # Add to ignore patterns
 dots ignore add "*.sqlite"
 dots ignore add "large-config.json"
-```text
+```
 
 ### Generated File Detection
 
@@ -413,7 +413,7 @@ dots ignore add "large-config.json"
 💡 Consider excluding: *.log, *.sqlite, *.db, *.cache
 
 Auto-add ignore patterns? (Y/n):
-```text
+```
 
 **Common Patterns to Exclude:**
 
@@ -424,7 +424,7 @@ dots ignore add "*.db"
 dots ignore add "*.cache"
 dots ignore add "*.tmp"
 dots ignore add "*.swp"
-```text
+```
 
 ### Git Metadata Detection
 
@@ -437,7 +437,7 @@ dots ignore add "*.swp"
 ```text
 ⚠️  1 git metadata files detected
  ℹ These will be skipped (covered by .chezmoiignore)
-```text
+```
 
 **Default Pattern:**
 
@@ -446,7 +446,7 @@ The `.chezmoiignore` file should include:
 ```text
 **/.git
 **/.git/**
-```diff
+```
 
 ### Performance Timeouts
 
@@ -463,7 +463,7 @@ The `.chezmoiignore` file should include:
 ```text
 ⚠️  Large directory detected (>1000 files)
  ℹ This may take a moment to analyze...
-```bash
+```
 
 ---
 
@@ -477,7 +477,7 @@ export _DOT_CACHE_TTL=600
 
 # Disable preview (skip safety checks)
 export DOT_SKIP_PREVIEW=1
-```diff
+```
 
 ### Cache Management
 
@@ -495,7 +495,7 @@ unset _DOT_SIZE_CACHE
 unset _DOT_SIZE_CACHE_TIME
 
 dots size  # Will recalculate
-```text
+```
 
 ### Ignore File Location
 
@@ -529,7 +529,7 @@ build/
 # Git metadata
 **/.git
 **/.git/**
-```bash
+```
 
 ---
 
@@ -546,7 +546,7 @@ build/
 unset _DOT_SIZE_CACHE
 unset _DOT_SIZE_CACHE_TIME
 dots size
-```bash
+```
 
 **Cause:** Stale cache after large file operations.
 
@@ -562,7 +562,7 @@ dots ignore add "node_modules"
 
 # Then add parent without the large subdirectory
 dots add ~/.config/my-app
-```bash
+```
 
 **Alternative:**
 
@@ -570,7 +570,7 @@ dots add ~/.config/my-app
 # Add specific files instead of directory
 dots add ~/.config/my-app/config.yml
 dots add ~/.config/my-app/settings.json
-```bash
+```
 
 ### Ignore Patterns Not Working
 
@@ -588,7 +588,7 @@ dots ignore add "**/*.log"  # Recursive matching
 
 # Force re-apply
 chezmoi re-add
-```bash
+```
 
 ### Performance Issues with Size Command
 
@@ -603,7 +603,7 @@ echo "Current time: $(date +%s)"
 
 # Verbose mode for debugging
 flow doctor --dot --verbose
-```bash
+```
 
 **Solution:**
 
@@ -614,7 +614,7 @@ export _DOT_CACHE_TTL=1800  # 30 minutes
 # Or analyze only top-level
 cd ~/.local/share/chezmoi
 du -sh .  # Quick size check
-```bash
+```
 
 ### Cross-Platform Compatibility Issues
 
@@ -629,7 +629,7 @@ stat --version 2>/dev/null | grep -q GNU && echo "GNU" || echo "BSD"
 # Test helper function
 source lib/core.zsh
 _flow_get_file_size ~/.zshrc
-```bash
+```
 
 **Solution:**
 
@@ -641,7 +641,7 @@ brew install coreutils
 
 # Use gstat instead of stat
 alias stat=gstat
-```diff
+```
 
 ### Doctor Check Fails
 
@@ -720,14 +720,14 @@ alias stat=gstat
 ```bash
 # Weekly or before major changes
 flow doctor --dot
-```bash
+```
 
 ### 2. Use Preview Before Add
 
 ```bash
 # Always preview, especially for directories
 dots add ~/.config/new-app
-```bash
+```
 
 ### 3. Maintain Ignore Patterns
 
@@ -740,14 +740,14 @@ dots ignore add "*.log"
 dots ignore add "*.sqlite"
 dots ignore add "node_modules"
 dots ignore add ".DS_Store"
-```bash
+```
 
 ### 4. Monitor Repository Size
 
 ```bash
 # Check monthly or after bulk adds
 dots size
-```bash
+```
 
 ### 5. Clean Up Large Files
 
@@ -756,7 +756,7 @@ dots size
 dots size  # Identify culprits
 dots ignore add "large-file.db"
 chezmoi remove large-file.db
-```bash
+```
 
 ---
 
@@ -767,7 +767,7 @@ chezmoi remove large-file.db
 ```bash
 # In ~/.zshrc or session
 export _DOT_CACHE_TTL=1800  # 30 minutes
-```bash
+```
 
 ### Batch Ignore Operations
 
@@ -777,7 +777,7 @@ patterns=("*.log" "*.sqlite" "*.db" "*.cache")
 for pattern in "${patterns[@]}"; do
   dots ignore add "$pattern"
 done
-```bash
+```
 
 ### Integration with Scripts
 
@@ -792,7 +792,7 @@ else
   echo "❌ Add cancelled"
   exit 1
 fi
-```bash
+```
 
 ### CI/CD Integration
 

--- a/docs/guides/CONFIG-MANAGEMENT-WORKFLOW.md
+++ b/docs/guides/CONFIG-MANAGEMENT-WORKFLOW.md
@@ -29,7 +29,7 @@ flow config show
 # Filter by keyword
 flow config show timer
 flow config show adhd
-```text
+```
 
 **Output example:**
 
@@ -54,7 +54,7 @@ ADHD Features:
   auto_breadcrumb     yes
   dopamine_mode       yes
   session_timeout     3600
-```bash
+```
 
 ---
 
@@ -71,7 +71,7 @@ flow config set timer_default 30
 
 # Shorthand (key=value)
 flow config timer_default=30
-```bash
+```
 
 ---
 
@@ -82,7 +82,7 @@ flow config timer_default=30
 flow config edit
 
 # Default editor: $EDITOR (vim/nano/etc)
-```bash
+```
 
 **After editing:**
 
@@ -90,7 +90,7 @@ flow config edit
 # Reload configuration?
 # [y/N]: y
 # ✓ Configuration reloaded
-```diff
+```
 
 ---
 
@@ -121,7 +121,7 @@ flow config profile adhd      # Shorthand
 
 # Save current config as custom profile
 flow config profile save my-workflow
-```text
+```
 
 **Example output:**
 
@@ -134,7 +134,7 @@ Built-in Profiles:
 
 Custom Profiles:
   my-workflow (saved 2026-01-10)
-```yaml
+```
 
 ---
 
@@ -148,7 +148,7 @@ show_icons: no
 dopamine_mode: no
 auto_breadcrumb: no
 timer_sound: no
-```text
+```
 
 **Developer Profile:**
 
@@ -158,7 +158,7 @@ debug: yes
 show_icons: yes
 dopamine_mode: yes
 auto_commit: no  # Manual control
-```text
+```
 
 **ADHD Profile:**
 
@@ -169,7 +169,7 @@ timer_default: 25
 timer_break: 5
 session_timeout: 1800  # 30min
 commit_emoji: yes
-```text
+```
 
 **Researcher Profile:**
 
@@ -179,7 +179,7 @@ timer_default: 45
 timer_long_break: 20
 auto_commit: yes
 push_after_finish: yes
-```diff
+```
 
 ---
 
@@ -265,7 +265,7 @@ flow config set projects_root ~/work
 
 # Save configuration
 flow config save
-```bash
+```
 
 ---
 
@@ -282,7 +282,7 @@ flow config set quiet yes
 flow config set auto_commit yes
 flow config set push_after_finish yes
 flow config profile save work
-```bash
+```
 
 **Personal profile:**
 
@@ -292,7 +292,7 @@ flow config profile load adhd
 flow config set dopamine_mode yes
 flow config set timer_default 25
 flow config profile save personal
-```bash
+```
 
 **Switch based on context:**
 
@@ -304,7 +304,7 @@ flow config profile work
 # In personal project
 cd ~/projects/hobby-app
 flow config profile personal
-```bash
+```
 
 ---
 
@@ -319,7 +319,7 @@ flow config export > team-flow-config.sh
 # Team members import
 source team-flow-config.sh
 flow config save
-```bash
+```
 
 **Example export:**
 
@@ -329,7 +329,7 @@ export FLOW_CONFIG_projects_root="$HOME/workspace"
 export FLOW_CONFIG_atlas_enabled="yes"
 export FLOW_CONFIG_auto_commit="yes"
 export FLOW_CONFIG_timer_default="25"
-```bash
+```
 
 ---
 
@@ -348,7 +348,7 @@ flow test
 
 # Exit shell - config reverts to saved
 exit
-```bash
+```
 
 ---
 
@@ -362,7 +362,7 @@ exit
 
 ```bash
 export FLOW_CONFIG_FILE="$HOME/.flow/my-config.sh"
-```bash
+```
 
 ---
 
@@ -388,7 +388,7 @@ FLOW_CONFIG[auto_breadcrumb]="yes"
 # Git
 FLOW_CONFIG[auto_commit]="no"
 FLOW_CONFIG[push_after_finish]="ask"
-```zsh
+```
 
 ---
 
@@ -404,7 +404,7 @@ _flow_config_set "timer_default" "30"
 
 # Reset to default
 _flow_config_reset "timer_default"
-```text
+```
 
 ---
 
@@ -414,7 +414,7 @@ Interactive setup for first-time users:
 
 ```bash
 flow config wizard
-```text
+```
 
 **Wizard flow:**
 
@@ -445,7 +445,7 @@ flow config wizard
 Saved to: ~/.config/flow-cli/config.sh
 
 Reload shell to apply: exec zsh
-```bash
+```
 
 ---
 
@@ -462,7 +462,7 @@ flow config reset --all
 
 # Force reset without confirmation
 flow config reset --all -f
-```bash
+```
 
 ---
 
@@ -477,7 +477,7 @@ cp ~/.config/flow-cli/config.sh \
 cp ~/.config/flow-cli/config.sh.backup \
    ~/.config/flow-cli/config.sh
 flow config reload
-```bash
+```
 
 ---
 
@@ -499,7 +499,7 @@ git commit -am "Update timer default"
 # Restore old version
 git checkout HEAD~1 config.sh
 flow config reload
-```bash
+```
 
 ---
 
@@ -522,7 +522,7 @@ exec zsh
 
 # Or reload without restarting
 flow config reload
-```bash
+```
 
 ---
 
@@ -540,7 +540,7 @@ flow config save
 
 # Verify location
 flow config path
-```bash
+```
 
 ---
 
@@ -561,7 +561,7 @@ flow config set timer_default
 # Boolean: yes/no (not 1/0 or true/false)
 # Number: integers only
 # Enum: specified values only
-```bash
+```
 
 ---
 
@@ -579,7 +579,7 @@ flow config profile list
 
 # Save profile if needed
 flow config profile save my-profile
-```text
+```
 
 ---
 
@@ -592,7 +592,7 @@ flow config profile save my-profile
 ```bash
 flow config set timer_default 30
 flow config save  # Don't forget!
-```text
+```
 
 **2. Use profiles for different contexts**
 
@@ -600,7 +600,7 @@ flow config save  # Don't forget!
 flow config profile save work
 flow config profile save personal
 flow config profile save client-project
-```bash
+```
 
 **3. Document custom settings**
 
@@ -610,7 +610,7 @@ vim ~/.config/flow-cli/config.sh
 
 # Custom timer for deep work
 FLOW_CONFIG[timer_default]="45"  # 45min focus blocks
-```bash
+```
 
 **4. Test changes before saving**
 
@@ -621,7 +621,7 @@ FLOW_QUIET=1 flow dash
 # If good, make permanent
 flow config set quiet yes
 flow config save
-```bash
+```
 
 ---
 
@@ -637,7 +637,7 @@ flow work my-project  # Session running
 # ✅ Good: Edit before/after
 finish
 flow config edit
-```bash
+```
 
 **2. Don't use environment variables for permanent config**
 
@@ -648,7 +648,7 @@ export FLOW_QUIET=1
 # ✅ Good: Use config system
 flow config set quiet yes
 flow config save
-```bash
+```
 
 **3. Don't forget to reload**
 
@@ -660,7 +660,7 @@ flow config set timer_default 30
 # ✅ Good: Reload
 flow config save
 exec zsh
-```bash
+```
 
 ---
 
@@ -677,7 +677,7 @@ export FLOW_TIMER_DEFAULT="25"
 flow config set projects_root "$HOME/projects"
 flow config set timer_default 25
 flow config save
-```bash
+```
 
 ---
 
@@ -695,7 +695,7 @@ flow config save
 # Remove old vars from .zshrc
 vim ~/.zshrc
 # Delete: export FLOW_* lines
-```bash
+```
 
 ---
 

--- a/docs/guides/COURSE-PLANNING-BEST-PRACTICES.md
+++ b/docs/guides/COURSE-PLANNING-BEST-PRACTICES.md
@@ -92,7 +92,7 @@ Traditional course design often follows this pattern:
 
 ```text
 Content Selection → Delivery Planning → Assessment Creation → Outcomes (if any)
-```diff
+```
 
 **Problems with this approach:**
 - **Misalignment:** Assessments don't measure what was taught
@@ -105,7 +105,7 @@ Content Selection → Delivery Planning → Assessment Creation → Outcomes (if
 
 ```text
 Learning Outcomes → Assessment Design → Content Selection → Delivery Planning
-```diff
+```
 
 **Benefits:**
 - ✅ **Alignment:** Every activity supports measurable outcomes
@@ -164,7 +164,7 @@ timeline
     section Post-Semester (Weeks 17-18)
         Week 17 : Student feedback analysis<br/>(teach backup archive)
         Week 18 : Improvement planning<br/>Update outcomes/assessments
-```bash
+```
 
 ### Phase 1: Pre-Semester Design (8-6 weeks before)
 
@@ -186,7 +186,7 @@ vim .flow/teach-config.yml
 
 # Health check
 teach doctor --fix
-```diff
+```
 
 **Deliverables:**
 - `teach-config.yml` with course metadata
@@ -222,7 +222,7 @@ teach assignment "HW3: Data Wrangling" --template markdown
 # Generate assessments
 teach exam "Midterm 1" --scope "Weeks 1-8"
 teach quiz "Week 3 Quiz" --topics "Probability, Distributions"
-```diff
+```
 
 **Deliverables:**
 - `lesson-plan.yml` with 16-week schedule
@@ -254,7 +254,7 @@ teach status
 
 # Verify environment
 teach doctor
-```diff
+```
 
 **Deliverables:**
 - Production website live
@@ -288,7 +288,7 @@ teach status
 
 # Generate assessments
 teach exam "Final Exam" --scope "Weeks 1-16"
-```diff
+```
 
 **Deliverables:**
 - Weekly content published on schedule
@@ -318,7 +318,7 @@ teach backup archive "Spring 2026"
 # Review backups before cleanup
 teach backup list
 teach backup delete --retention semester  # Prompts for confirmation
-```diff
+```
 
 **Deliverables:**
 - Improvement plan document
@@ -368,7 +368,7 @@ graph TD
     D --> D1
     D1 --> E1
     E --> E1
-```yaml
+```
 
 ### Key Configuration File: teach-config.yml
 
@@ -404,7 +404,7 @@ scholar:
     quizzes: 10
     project: 30
     final: 30
-```bash
+```
 
 **How it supports systematic planning:**
 
@@ -427,7 +427,7 @@ teach exam "Midterm 1" --scope "Weeks 1-8" --template typst
 # - Style preferences (tone, notation, examples)
 
 # Output: Exam aligned with course outcomes and style
-```diff
+```
 
 **Benefits:**
 - ✅ Assessments match course difficulty level
@@ -441,7 +441,7 @@ Before each semester, validate your entire teaching environment:
 
 ```bash
 teach doctor
-```diff
+```
 
 **Checks:**
 - ✅ Required dependencies (git, quarto, yq, gh)
@@ -457,7 +457,7 @@ teach doctor --fix
 # Prompts to install missing dependencies
 # Creates missing configuration files
 # Sets up git branches if needed
-```diff
+```
 
 ---
 
@@ -501,7 +501,7 @@ teach exam "Final Exam" --scope "Weeks 1-16"
 
 # Save to exams/ directory
 # Refine during Phase 2, but structure exists
-```diff
+```
 
 ---
 
@@ -556,13 +556,13 @@ Traditional course design is **forward-thinking**:
 
 ```text
 Content → Activities → Assessment → Hope for learning
-```text
+```
 
 Backward design is **outcome-focused**:
 
 ```text
 Learning Goals → Assessment → Activities → Guaranteed learning
-```diff
+```
 
 **Why "backward"?**
 
@@ -588,7 +588,7 @@ graph LR
     style A fill:#e1f5e1
     style B fill:#e1e5f5
     style C fill:#f5e1e1
-```diff
+```
 
 **Stage 1: Identify Desired Results**
 - What should students understand and be able to do?
@@ -649,7 +649,7 @@ Wiggins & McTighe distinguish three levels:
 
 ```text
 Students will be able to [ACTION VERB] [OBJECT] in order to [PURPOSE/CONTEXT].
-```diff
+```
 
 **Examples:**
 
@@ -705,7 +705,7 @@ scholar:
     - "When should we trust data-driven decisions?"
     - "What makes a statistical model 'good enough'?"
     - "How can we communicate uncertainty to non-statisticians?"
-```yaml
+```
 
 Scholar uses these when generating exams and assignments to create conceptual questions that connect to big ideas.
 
@@ -743,7 +743,7 @@ scholar:
     - "Data visualization (ggplot2)"  # Supports LO1
     - "Regression modeling"           # Supports LO2
     - "Statistical communication"     # Supports LO3
-```diff
+```
 
 **Benefits:**
 - ✅ Outcomes documented and version-controlled
@@ -774,7 +774,7 @@ Wiggins & McTighe recommend three types of assessment evidence:
    Academic        Observations
    Prompts         & Self-Assessment
 (Quizzes/Tests)    (Formative)
-```diff
+```
 
 **Performance Tasks (Transfer Evidence)**
 - Complex, authentic challenges
@@ -850,7 +850,7 @@ analyze it. They need recommendations before their board meeting in 3 weeks.
 - Quality of visualizations and diagnostics (25%)
 - Clarity of technical communication (25%)
 - Effectiveness of executive summary (20%)
-```diff
+```
 
 **Why GRASPS works:**
 - Creates authentic context (not just "solve these problems")
@@ -885,7 +885,7 @@ Week 1-2: Formative
 
 Week 3: Summative
 └── Homework #1 (graded) - students are prepared
-```bash
+```
 
 **flow-cli integration:**
 
@@ -895,7 +895,7 @@ teach quiz "Week 3 Practice Quiz" --topics "Probability" --ungraded
 
 # Summative assessment creation
 teach exam "Midterm 1" --scope "Weeks 1-8" --points 100
-```diff
+```
 
 Set `--ungraded` flag for formative assessments, Scholar generates lower-stakes questions with immediate feedback.
 
@@ -942,7 +942,7 @@ assessment_alignment:
       level: "R"
     - assessment: "Project"
       level: "M"
-```diff
+```
 
 Future feature: `teach alignment matrix` will generate visual matrix from config.
 
@@ -1025,7 +1025,7 @@ Wiggins & McTighe provide the WHERETO acronym for planning learning experiences�
 
 **O - Organized:**
 - Progression: Simple regression (Week 4) → Multiple regression (Week 5) → Model selection (Week 6)
-```yaml
+```
 
 **flow-cli implementation: lesson-plan.yml**
 
@@ -1068,7 +1068,7 @@ weeks:
       - "code/week-05-regression.R"
       - "data/housing-prices.csv"
       - "slides/week-05-slides.qmd"
-```diff
+```
 
 **Scholar integration:**
 
@@ -1181,7 +1181,7 @@ graph TD
     style C1 fill:#e1f5e1
     style C3 fill:#e1f5e1
     style C4 fill:#e1e5f5
-```diff
+```
 
 #### Step 2.2: Design Performance Task (Project)
 
@@ -1217,7 +1217,7 @@ research question and provide statistical recommendations.
 - Diagnostics & model evaluation (20%)
 - Technical writing clarity (10%)
 - Executive summary effectiveness (10%)
-```diff
+```
 
 **Alignment with outcomes:**
 - LO1 (Visualize): 25% weight on visualization quality
@@ -1281,7 +1281,7 @@ Each homework targets 1-2 learning outcomes and progressively builds skills:
 HW1 (Intro) → HW2 (Reinforce) → HW3 (Intro) → HW4 (Reinforce) → Project (Master)
    |              |                 |              |                    |
  Visualize     Visualize         Models         Models            All LOs
-```yaml
+```
 
 ---
 
@@ -1425,14 +1425,14 @@ assessment_alignment:
     - assessment: "Project"
       level: "R"
       weight: 15
-```bash
+```
 
 **Future feature:** Generate matrix visualization
 
 ```bash
 teach alignment matrix --output png
 # Creates: docs/alignment-matrix.png
-```text
+```
 
 ---
 
@@ -1467,7 +1467,7 @@ gantt
     Project work         :w14, 2026-04-13, 7d
     Presentations        :w15, 2026-04-20, 7d
     Final exam           :w16, 2026-04-27, 7d
-```diff
+```
 
 **Scaffolding strategy:**
 - **Weeks 1-4:** Build foundational skills (visualize, wrangle)
@@ -1566,7 +1566,7 @@ weeks:
       code: "code/week-05-regression.R"
       data: "data/advertising.csv"
       homework: "homework/hw3-regression.qmd"
-```diff
+```
 
 **Scholar integration:**
 
@@ -1670,7 +1670,7 @@ When you run `teach lecture "Week 5: Simple Regression"`, Scholar:
 - Lecture: "What have we learned? Revisiting essential questions"
 - Assessments: Final exam (30%), Project report due
 
-```diff
+```
 
 **Alignment check:**
 - ✅ Every week builds toward learning outcomes
@@ -1869,7 +1869,7 @@ deployment:
     type: "github-pages"
     branch: "production"
     url: "https://data-wise.github.io/stat-545"
-```yaml
+```
 
 ---
 
@@ -2043,7 +2043,7 @@ weeks:
       assigned_week: 7  # Not yet, Week 5 is too early
       due_week: 10
       alignment: ["LO2: Build models", "LO4: Wrangle data"]
-```yaml
+```
 
 ---
 
@@ -2334,7 +2334,7 @@ assessment_alignment:
     - assessment: "HW1"
       level: "R"
       weight: 15
-```diff
+```
 
 ---
 
@@ -2400,7 +2400,7 @@ teach init --github                # Auto-create GitHub repo
 teach doctor                       # Validate environment
 teach doctor --fix                 # Interactive dependency installer
 teach status                       # Show course overview
-```bash
+```
 
 **Content Creation with Scholar:**
 
@@ -2415,7 +2415,7 @@ teach quiz "Week 3 Quiz" --topics "Probability, Distributions"
 teach assignment "HW3: Data Wrangling" --template markdown
 
 # Template options: markdown, quarto, typst, pdf, docx
-```text
+```
 
 **Deployment:**
 
@@ -2423,7 +2423,7 @@ teach assignment "HW3: Data Wrangling" --template markdown
 teach deploy                       # Preview changes, create PR
 teach deploy --skip-preview        # Deploy without preview
 teach status                       # Check deployment status
-```text
+```
 
 **Backup Management:**
 
@@ -2433,14 +2433,14 @@ teach backup view <timestamp>      # View specific backup
 teach backup restore <timestamp>   # Restore from backup
 teach backup delete --retention semester  # Delete semester backups
 teach backup archive "Spring 2026"        # Archive semester
-```text
+```
 
 **Git Integration:**
 
 ```bash
 teach git status                   # Enhanced git status for teaching projects
 teach git deploy "Add Week 5"      # Commit + push + PR to production
-```yaml
+```
 
 ---
 
@@ -2462,7 +2462,7 @@ scholar:
     tone: "conversational"    # formal / conversational
     notation: "statistical"   # statistical / mathematical / standard
     examples: true            # Include worked examples
-```diff
+```
 
 **Tone options:**
 - `formal` - Academic writing, technical terminology

--- a/docs/guides/DEVELOPER-GUIDE.md
+++ b/docs/guides/DEVELOPER-GUIDE.md
@@ -46,7 +46,7 @@ source flow.plugin.zsh
 
 # Verify installation
 flow --version
-```text
+```
 
 ---
 
@@ -77,7 +77,7 @@ flow-cli/
     ├── reference/           # API reference
     ├── guides/              # How-to guides
     └── tutorials/           # Step-by-step tutorials
-```diff
+```
 
 ### Development Workflow
 
@@ -168,7 +168,7 @@ source lib/core.zsh
 
 _flow_log_success "Task completed"
 root=$(_flow_find_project_root)
-```diff
+```
 
 #### `lib/project-cache.zsh`
 
@@ -189,7 +189,7 @@ _proj_cache_invalidate
 
 # Get cached project list
 projects=$(_proj_scan_projects)
-```diff
+```
 
 #### `lib/config-validator.zsh`
 
@@ -209,7 +209,7 @@ if _teach_validate_config "teach-config.yml"; then
 else
     echo "Invalid"
 fi
-```text
+```
 
 ---
 
@@ -221,7 +221,7 @@ fi
 
 ```bash
 touch lib/dispatchers/my-dispatcher.zsh
-```zsh
+```
 
 **Step 2:** Implement dispatcher
 
@@ -273,14 +273,14 @@ Examples:
   my action2
 EOF
 }
-```zsh
+```
 
 **Step 3:** Register in `flow.plugin.zsh`
 
 ```zsh
 # Add to plugin file
 source "$FLOW_PLUGIN_DIR/lib/dispatchers/my-dispatcher.zsh"
-```zsh
+```
 
 **Step 4:** Add completion
 
@@ -299,7 +299,7 @@ _my() {
 }
 
 _my "$@"
-```zsh
+```
 
 **Step 5:** Add tests
 
@@ -317,7 +317,7 @@ test_my_action1() {
 }
 
 test_my_action1
-```diff
+```
 
 **Step 6:** Update documentation
 
@@ -331,7 +331,7 @@ test_my_action1
 
 ```bash
 touch commands/mycommand.zsh
-```zsh
+```
 
 **Step 2:** Implement command
 
@@ -376,14 +376,14 @@ Examples:
   mycommand --option foo
 EOF
 }
-```zsh
+```
 
 **Step 3:** Source in plugin
 
 ```zsh
 # flow.plugin.zsh
 source "$FLOW_PLUGIN_DIR/commands/mycommand.zsh"
-```zsh
+```
 
 **Step 4:** Add completion**
 
@@ -398,7 +398,7 @@ _mycommand() {
 }
 
 _mycommand "$@"
-```zsh
+```
 
 **Step 5:** Add tests
 
@@ -416,7 +416,7 @@ test_mycommand_basic() {
 }
 
 test_mycommand_basic
-```diff
+```
 
 ---
 
@@ -473,7 +473,7 @@ echo "Passed: $TESTS_PASSED"
 echo "Failed: $TESTS_FAILED"
 
 [[ $TESTS_FAILED -eq 0 ]]
-```bash
+```
 
 ### Assertion Helpers
 
@@ -507,7 +507,7 @@ assert_file_exists() {
         return 1
     }
 }
-```bash
+```
 
 ### Running Tests
 
@@ -515,19 +515,19 @@ assert_file_exists() {
 
 ```bash
 ./tests/run-all.sh
-```text
+```
 
 **Run Specific Test:**
 
 ```bash
 ./tests/test-pick-command.zsh
-```text
+```
 
 **Run with Debug Output:**
 
 ```bash
 FLOW_DEBUG=1 ./tests/test-my-feature.zsh
-```bash
+```
 
 ### Mock Environment
 
@@ -547,7 +547,7 @@ cleanup() {
     rm -rf "$TEST_DIR"
 }
 trap cleanup EXIT
-```diff
+```
 
 ### Test Coverage
 
@@ -597,7 +597,7 @@ if [[ $? -ne 0 ]]; then
     _flow_log_error "Previous command failed"
     return 1
 fi
-```bash
+```
 
 **5. Arrays:**
 
@@ -613,7 +613,7 @@ done
 
 # Length
 echo "${#items[@]}"
-```bash
+```
 
 **6. Associative Arrays:**
 
@@ -632,7 +632,7 @@ echo "${MY_ARRAY[key1]}"
 for key in "${(@k)MY_ARRAY}"; do
     echo "$key = ${MY_ARRAY[$key]}"
 done
-```diff
+```
 
 ### Code Formatting
 
@@ -657,7 +657,7 @@ function_name() {
     # Brief description of function
     local var="value"  # Inline comment
 }
-```bash
+```
 
 ### Color Usage
 
@@ -669,7 +669,7 @@ echo -e "${FLOW_COLORS[success]}✓ Success${FLOW_COLORS[reset]}"
 
 # Bad
 echo -e "\033[32m✓ Success\033[0m"
-```diff
+```
 
 **Available Colors:**
 - `success`, `warning`, `error`, `info`
@@ -708,14 +708,14 @@ echo -e "\033[32m✓ Success\033[0m"
 - `--option` (flag): Description
 
 **Examples:**
-```bash
+```
 command-name foo
 command-name --option bar
 ```text
 
 **See Also:** Related commands
 
-```diff
+```
 
 **API Documentation:**
 ```markdown
@@ -732,11 +732,11 @@ command-name --option bar
 - Exit code: 0 on success, 1 on failure
 
 **Example:**
-```zsh
+```
 result=$(function_name "arg1" "arg2")
 ```text
 
-```diff
+```
 
 ---
 
@@ -771,7 +771,7 @@ git diff
 git add -A
 git commit -m "chore: bump version to v5.10.0"
 git push origin dev
-```bash
+```
 
 **2. Create Release PR:**
 
@@ -782,7 +782,7 @@ gh pr create \
     --head dev \
     --title "Release v5.10.0" \
     --body "$(cat CHANGELOG.md)"
-```bash
+```
 
 **3. After PR Merge:**
 
@@ -794,7 +794,7 @@ git pull origin main
 # Create and push tag
 git tag -a v5.10.0 -m "Release v5.10.0"
 git push origin v5.10.0
-```diff
+```
 
 **4. GitHub Release:**
 - GitHub Actions automatically creates release from tag
@@ -807,7 +807,7 @@ git push origin v5.10.0
 brew update
 brew upgrade flow-cli
 flow --version  # Should show 5.10.0
-```bash
+```
 
 ---
 
@@ -819,19 +819,19 @@ flow --version  # Should show 5.10.0
 
 ```bash
 export FLOW_DEBUG=1
-```bash
+```
 
 **Debug Output:**
 
 ```zsh
 [[ -n "$FLOW_DEBUG" ]] && echo "Debug: $variable"
-```zsh
+```
 
 **Trace Execution:**
 
 ```bash
 zsh -x flow.plugin.zsh
-```zsh
+```
 
 ### Profiling Performance
 
@@ -844,7 +844,7 @@ zmodload zsh/zprof
 source flow.plugin.zsh
 mycommand
 zprof
-```bash
+```
 
 ### Working with Worktrees
 
@@ -860,7 +860,7 @@ git worktree remove ~/.git-worktrees/flow-cli-feature
 
 # Prune deleted worktrees
 git worktree prune
-```zsh
+```
 
 ---
 
@@ -873,7 +873,7 @@ git worktree prune
 
 ```bash
 source flow.plugin.zsh
-```bash
+```
 
 **Issue:** Completion not working
 **Solution:** Rebuild completion cache
@@ -881,14 +881,14 @@ source flow.plugin.zsh
 ```bash
 rm -f ~/.zcompdump
 compinit
-```text
+```
 
 **Issue:** Cache stale
 **Solution:** Invalidate cache
 
 ```zsh
 _proj_cache_invalidate
-```bash
+```
 
 **Issue:** Test failures
 **Solution:** Check for environment differences
@@ -903,7 +903,7 @@ rm -rf ~/.cache/flow-cli
 
 # Run tests
 ./tests/test-feature.zsh
-```diff
+```
 
 ---
 

--- a/docs/guides/DOCTOR-TOKEN-USER-GUIDE.md
+++ b/docs/guides/DOCTOR-TOKEN-USER-GUIDE.md
@@ -37,7 +37,7 @@ The flow doctor token enhancement adds powerful GitHub token management capabili
 $ doctor
 # Checks: shell, tools, integrations, dotfiles (slow)
 # Result: "GitHub token expiring in 5 days"
-```bash
+```
 
 **After Phase 1:**
 
@@ -45,7 +45,7 @@ $ doctor
 $ doctor --dot
 # Checks: GitHub token only (fast)
 # Result: Same info in < 3 seconds
-```text
+```
 
 ---
 
@@ -55,14 +55,14 @@ $ doctor --dot
 
 ```bash
 doctor --dot
-```text
+```
 
 **Output:**
 
 ```text
 🔑 GITHUB TOKEN
 ✓ Token valid (45 days remaining)
-```diff
+```
 
 **What happens:**
 - Checks token expiration status
@@ -75,7 +75,7 @@ doctor --dot
 
 ```bash
 doctor --fix-token
-```text
+```
 
 **Interactive menu appears:**
 
@@ -89,7 +89,7 @@ doctor --fix-token
 ╰──────────────────────────────────────────────────╯
 
 Select [1, 0 to exit]: 1
-```text
+```
 
 **What happens:**
 1. Shows token issues with time estimate
@@ -103,7 +103,7 @@ Select [1, 0 to exit]: 1
 
 ```bash
 doctor --dot --verbose
-```text
+```
 
 **Output:**
 
@@ -115,7 +115,7 @@ doctor --dot --verbose
   Username: your-username
   Token type: fine-grained
   Age: 100 days
-```diff
+```
 
 **What you see:**
 - Cache status (hit or miss)
@@ -136,7 +136,7 @@ doctor --dot
 
 # If expiring soon, fix it
 doctor --fix-token
-```bash
+```
 
 **Time:** < 3 seconds (cached) or ~30 seconds (rotation)
 
@@ -152,7 +152,7 @@ doctor --dot --quiet
 
 # If check fails, exit code 1
 echo $?  # 0 = success, 1 = issues
-```bash
+```
 
 **Use in scripts:**
 
@@ -164,7 +164,7 @@ if ! doctor --dot --quiet; then
 fi
 
 git push
-```bash
+```
 
 ---
 
@@ -182,7 +182,7 @@ if [ $? -eq 0 ]; then
 else
     echo "Token issues"
 fi
-```bash
+```
 
 ---
 
@@ -200,7 +200,7 @@ _doctor_cache_stats
 # Force fresh check (clear cache)
 _doctor_cache_clear "token-github"
 doctor --dot --verbose
-```text
+```
 
 ---
 
@@ -216,7 +216,7 @@ doctor --dot --verbose
 
 ```bash
 doctor --dot
-```diff
+```
 
 **When to use:**
 - Morning health check
@@ -238,7 +238,7 @@ doctor --dot
 
 ```bash
 doctor --dot=github
-```diff
+```
 
 **When to use:**
 - Multi-token environments
@@ -255,7 +255,7 @@ doctor --dot=github
 
 ```bash
 doctor --fix-token
-```diff
+```
 
 **When to use:**
 - Token expiring warning
@@ -280,7 +280,7 @@ doctor --fix-token
 
 ```bash
 doctor --dot --quiet
-```diff
+```
 
 **Output:**
 - Only errors shown
@@ -302,7 +302,7 @@ doctor --dot --quiet
 
 ```bash
 doctor --dot --verbose
-```diff
+```
 
 **Output:**
 - Cache hit/miss status
@@ -323,7 +323,7 @@ doctor --dot --verbose
 
 ```bash
 doctor --dot --quiet
-```text
+```
 
 **Use case:** Scheduled monitoring
 
@@ -334,7 +334,7 @@ doctor --dot --quiet
 ```bash
 _doctor_cache_clear "token-github"
 doctor --dot --verbose
-```text
+```
 
 **Use case:** Force fresh check with debug info
 
@@ -344,7 +344,7 @@ doctor --dot --verbose
 
 ```bash
 doctor --fix-token --yes
-```bash
+```
 
 **Use case:** Non-interactive rotation
 
@@ -373,7 +373,7 @@ doctor --dot  # Second run (fast < 100ms)
 
 # Clear stale cache
 _doctor_cache_clear
-```bash
+```
 
 ---
 
@@ -392,7 +392,7 @@ ls -ld ~/.flow/cache/doctor/
 
 # Verify cache files
 cat ~/.flow/cache/doctor/token-github.cache
-```bash
+```
 
 **Fix:**
 
@@ -403,7 +403,7 @@ _doctor_cache_init
 
 # Check again
 doctor --dot --verbose
-```bash
+```
 
 ---
 
@@ -427,7 +427,7 @@ type _doctor_select_fix_category
 
 # Disable auto-yes
 doctor --fix-token  # Without --yes
-```bash
+```
 
 ---
 
@@ -450,7 +450,7 @@ doctor --dot --verbose
 
 # Verify delegation
 type _tok_expiring
-```bash
+```
 
 ---
 
@@ -469,7 +469,7 @@ doctor --dot --quiet  # Every 5 min = 80% cache hits
 
 # Bad: Infrequent expensive checks
 doctor  # Every hour = 0% cache hits + slow
-```diff
+```
 
 ---
 
@@ -498,7 +498,7 @@ else
     echo "⚠ Token issues - run 'doctor --fix-token'"
     exit 1
 fi
-```bash
+```
 
 ---
 
@@ -509,7 +509,7 @@ fi
 ```bash
 # crontab
 */5 * * * * doctor --dot --quiet || echo "Token issues" | mail -s "Token Alert" you@example.com
-```diff
+```
 
 ---
 
@@ -539,7 +539,7 @@ fi
 
 ```bash
 _doctor_cache_clear && doctor --dot
-```diff
+```
 
 ---
 
@@ -561,7 +561,7 @@ doctor --dot --verbose
 # Output shows:
 # [Cache hit - age: 45s, TTL: 300s]  ← Cache working
 # [Cache miss - validating...]       ← Cache not used
-```diff
+```
 
 ---
 
@@ -594,7 +594,7 @@ else
     echo "Token issues detected"
     exit 1
 fi
-```text
+```
 
 ---
 

--- a/docs/guides/DOPAMINE-FEATURES-GUIDE.md
+++ b/docs/guides/DOPAMINE-FEATURES-GUIDE.md
@@ -44,7 +44,7 @@ dash
 
 # Set a daily goal
 flow goal set 3
-```bash
+```
 
 ---
 
@@ -63,7 +63,7 @@ win --category ship "Deployed v3.5.0 to production"
 
 # Short form
 win "Fixed bug #123"
-```bash
+```
 
 ### Win Categories
 
@@ -93,7 +93,7 @@ yay --today
 
 # Wins by category
 yay --category code
-```text
+```
 
 **Example Output:**
 
@@ -107,7 +107,7 @@ yay --category code
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Total: 3 wins | Streak: 🔥 5 days
-```diff
+```
 
 ---
 
@@ -135,7 +135,7 @@ dash
 
 # Detailed view
 status --extended
-```bash
+```
 
 ### Streak Benefits
 
@@ -163,7 +163,7 @@ flow goal set 5 --project flow-cli
 
 # View current goal and progress
 flow goal
-```text
+```
 
 ### Goal Progress
 
@@ -171,7 +171,7 @@ The goal appears in the dashboard wins section:
 
 ```text
 🎯 Daily Goal: ██████░░░░ 2/3 wins
-```text
+```
 
 ### Per-Project Goals
 
@@ -179,7 +179,7 @@ Add to your project's `.STATUS` file:
 
 ```markdown
 ## daily_goal: 5
-```text
+```
 
 This overrides the global goal when working in that project.
 
@@ -217,7 +217,7 @@ v3.5.0 adds new fields to the `.STATUS` file format:
 ## last_active: 2025-12-26 14:30
 
 ## tags: typescript, api, backend
-```bash
+```
 
 ### New Fields
 
@@ -237,7 +237,7 @@ status --extended
 
 # Or short form
 status -e
-```text
+```
 
 ---
 
@@ -247,7 +247,7 @@ All dopamine features appear in the dashboard:
 
 ```bash
 dash
-```text
+```
 
 **Dashboard Sections:**
 
@@ -267,7 +267,7 @@ dash
 │ 🔧 Fixed login redirect bug              11:45               │
 │ 📝 Updated API documentation             09:30               │
 └──────────────────────────────────────────────────────────────┘
-```bash
+```
 
 ---
 
@@ -280,7 +280,7 @@ The dashboard TUI (Terminal UI) now has keyboard shortcuts:
 dash -i
 # or
 dash --interactive
-```bash
+```
 
 ### Keyboard Shortcuts
 
@@ -303,7 +303,7 @@ dash --watch
 
 # Custom interval
 dash --watch 10
-```bash
+```
 
 ---
 
@@ -319,7 +319,7 @@ win "Fixed the API timeout issue"
 
 # After a code review
 win "Reviewed PR #42"
-```bash
+```
 
 ### 2. Keep Goals Achievable
 
@@ -331,7 +331,7 @@ flow goal set 2
 
 # Increase as you build the habit
 flow goal set 3
-```bash
+```
 
 ### 3. Check Dashboard Daily
 
@@ -343,7 +343,7 @@ dash
 
 # Or use the morning command
 morning
-```bash
+```
 
 ### 4. Use Categories
 
@@ -355,7 +355,7 @@ win "Deployed the new feature"  # → 🚀 ship
 
 # Force category when unclear
 win --category test "Wrote integration tests"
-```bash
+```
 
 ---
 
@@ -369,7 +369,7 @@ echo $FLOW_DATA_DIR/wins.log
 
 # View raw wins file
 cat ~/.local/share/flow/wins.log
-```bash
+```
 
 ### Streak Reset Unexpectedly
 
@@ -378,7 +378,7 @@ Streaks require at least one work session per day:
 ```bash
 # Check worklog for gaps
 cat ~/.local/share/flow/worklog | tail -20
-```bash
+```
 
 ### Goal Not Updating
 

--- a/docs/guides/DOT-WORKFLOW.md
+++ b/docs/guides/DOT-WORKFLOW.md
@@ -26,7 +26,7 @@ dots sync
 
 # Push your changes
 dots push
-```bash
+```
 
 ---
 
@@ -43,14 +43,14 @@ chezmoi init
 
 # Track your first file
 chezmoi add ~/.zshrc
-```bash
+```
 
 ### Optional: Bitwarden (for secrets)
 
 ```bash
 brew install bitwarden-cli
 bw login
-```bash
+```
 
 ---
 
@@ -63,7 +63,7 @@ Edit a dotfile with preview and apply workflow.
 ```bash
 # 1. Edit (opens $EDITOR with source file)
 dots edit .zshrc
-```text
+```
 
 **Output:**
 
@@ -84,7 +84,7 @@ dots edit .zshrc
   n - Keep in staging
 
 Apply? [Y/n/d]
-```bash
+```
 
 **Options:**
 
@@ -107,7 +107,7 @@ dots apply
 
 # Preview first
 dots apply --dry-run
-```bash
+```
 
 ---
 
@@ -119,7 +119,7 @@ Preview changes without applying them.
 dots apply --dry-run
 # or
 dots apply -n
-```text
+```
 
 **Output (no changes):**
 
@@ -127,7 +127,7 @@ dots apply -n
 ℹ DRY-RUN MODE - No changes will be applied
 
 ✓ No pending changes
-```text
+```
 
 **Output (with changes):**
 
@@ -138,7 +138,7 @@ dots apply -n
 [chezmoi verbose diff]
 
 ✓ Dry-run complete - no changes applied
-```diff
+```
 
 ### When to Use
 
@@ -163,7 +163,7 @@ chezmoi add ~/.tmux.conf
 
 # Push to remote
 dots push
-```bash
+```
 
 ### On Other Machines
 
@@ -173,7 +173,7 @@ chezmoi init https://github.com/user/dotfiles.git
 
 # Apply dotfiles
 dots apply
-```bash
+```
 
 ### Daily Sync
 
@@ -189,7 +189,7 @@ dots sync
 
 # Push local changes
 dots push
-```bash
+```
 
 ---
 
@@ -221,7 +221,7 @@ sec list
 
 # Delete when done
 sec delete github-token
-```diff
+```
 
 **Perfect for:**
 - Shell startup scripts (instant, no unlock)
@@ -239,7 +239,7 @@ bw login
 
 # Unlock vault (each shell session)
 sec unlock
-```bash
+```
 
 **Store Secrets:**
 
@@ -261,7 +261,7 @@ sec list
 
 # Retrieve (no echo)
 TOKEN=$(sec github-token)
-```bash
+```
 
 ### Use in Templates
 
@@ -273,7 +273,7 @@ export PATH=$HOME/bin:$PATH
 
 # Secrets from Bitwarden
 export GITHUB_TOKEN="{{ bitwarden "item" "github-token" }}"
-```text
+```
 
 **Apply with secrets:**
 
@@ -281,7 +281,7 @@ export GITHUB_TOKEN="{{ bitwarden "item" "github-token" }}"
 sec unlock
 dots apply --dry-run  # Preview
 dots apply            # Apply
-```bash
+```
 
 ---
 
@@ -298,7 +298,7 @@ tok npm
 
 # PyPI project token
 tok pypi
-```text
+```
 
 **Wizard output:**
 
@@ -317,13 +317,13 @@ Paste your new token: ghp_xxxxxxxxxxxx
 
 ✓ Token validated!
 ✓ Stored as 'github-token' in Bitwarden
-```text
+```
 
 ### Check Token Status
 
 ```bash
 secs
-```text
+```
 
 **Dashboard output:**
 
@@ -335,7 +335,7 @@ secs
 │  🔑 npm-token          Expires: 180 days                      │
 │  ⚠️  pypi-token         Expires: 9 days  ← EXPIRING SOON      │
 ╰───────────────────────────────────────────────────────────────╯
-```bash
+```
 
 ### Rotate Expiring Tokens
 
@@ -345,7 +345,7 @@ tok pypi-token --refresh
 
 # Short form
 tok pypi-token -r
-```text
+```
 
 **Rotation output:**
 
@@ -361,7 +361,7 @@ Paste your new token: pypi-xxxxxxxx
 
 ⚠️  Remember to revoke old token at:
    https://pypi.org/manage/account/token/
-```text
+```
 
 ---
 
@@ -371,7 +371,7 @@ Paste your new token: pypi-xxxxxxxx
 
 ```bash
 sec sync github
-```text
+```
 
 **Output:**
 
@@ -384,13 +384,13 @@ Select secrets to sync:
   [ ] PYPI_TOKEN
 
 ✓ 2 secrets synced to repository
-```text
+```
 
 ### Generate .envrc for direnv
 
 ```bash
 dots env
-```text
+```
 
 **Output:**
 
@@ -404,7 +404,7 @@ dots env
   ─────────────────────────────
 
 💡 Run 'direnv allow' to activate
-```text
+```
 
 ---
 
@@ -414,7 +414,7 @@ dots env
 
 ```bash
 dots edit .gitconfig  # Edit, apply immediately
-```text
+```
 
 ### Safe Batch Changes
 
@@ -424,7 +424,7 @@ dots edit .gitconfig  # Press 'n' to defer
 dots diff             # Review all
 dots apply --dry-run  # Preview
 dots apply            # Apply all
-```bash
+```
 
 ### Emergency Rollback
 
@@ -436,7 +436,7 @@ chezmoi apply --force
 cd ~/.local/share/chezmoi
 git checkout -- .
 dots apply
-```text
+```
 
 ---
 
@@ -447,7 +447,7 @@ dots apply
 ```text
 ✗ File not found in managed dotfiles: .zshrc
 ℹ Use 'chezmoi add <file>' to start tracking a new file
-```text
+```
 
 **Fix:** `chezmoi add ~/.zshrc`
 
@@ -456,7 +456,7 @@ dots apply
 ```text
 ✗ Bitwarden vault is locked
 ℹ Run: sec unlock
-```text
+```
 
 **Fix:** `sec unlock`
 

--- a/docs/guides/DOTFILE-MANAGEMENT.md
+++ b/docs/guides/DOTFILE-MANAGEMENT.md
@@ -37,7 +37,7 @@ brew install bitwarden-cli
 
 # Optional (for pretty secret listings)
 brew install jq
-```bash
+```
 
 ### 2. Initialize Chezmoi
 
@@ -47,14 +47,14 @@ chezmoi init
 
 # Option B: Clone existing dotfiles
 chezmoi init https://github.com/yourusername/dotfiles
-```bash
+```
 
 ### 3. Authenticate Bitwarden
 
 ```bash
 # One-time login
 bw login
-```bash
+```
 
 ### 4. Start Using
 
@@ -67,7 +67,7 @@ dots edit .zshrc
 
 # Unlock secrets
 sec unlock
-```text
+```
 
 ---
 
@@ -118,7 +118,7 @@ flowchart TD
     style D6 fill:#FFD700
     style E6 fill:#FFD700
     style G3 fill:#FF6B6B
-```diff
+```
 
 **Key Components:**
 
@@ -148,7 +148,7 @@ dots edit .zshrc
 # Press: y
 
 # 5. Changes applied to home directory
-```bash
+```
 
 **Time:** < 30 seconds
 **Commands:** 2 (`dots`, `dots edit .zshrc`)
@@ -168,7 +168,7 @@ dots sync
 
 # 4. Apply changes (if needed)
 dots apply
-```bash
+```
 
 **Time:** 10-30 seconds
 **Commands:** 2 (`dots sync`, `dots apply`)
@@ -187,7 +187,7 @@ dots push
 # Type: "Update ZSH aliases"
 
 # 4. Committed and pushed
-```bash
+```
 
 **Time:** 20-40 seconds
 **Commands:** 2-3 (`dots diff`, `dots push`)
@@ -206,7 +206,7 @@ dots edit .gitconfig
 
 # 4. Apply template (automatic)
 # Result: ~/.gitconfig contains actual token
-```text
+```
 
 **Time:** 1-2 minutes
 **Commands:** 2-3 (`sec unlock`, `dots edit`)
@@ -229,7 +229,7 @@ dots edit .gitconfig
 ├── .zshrc                       # Generated from template
 ├── .gitconfig                   # Generated from template
 └── ...
-```bash
+```
 
 ### Naming Convention
 
@@ -250,7 +250,7 @@ chezmoi add ~/.zshrc
 
 # Add as template (for variable substitution)
 chezmoi add --template ~/.gitconfig
-```bash
+```
 
 ### Removing Files
 
@@ -260,7 +260,7 @@ chezmoi forget ~/.old_config
 
 # Remove from chezmoi directory
 rm ~/.local/share/chezmoi/dot_old_config
-```bash
+```
 
 ---
 
@@ -281,7 +281,7 @@ sec unlock
 
 # 4. Verify unlock
 sec list
-```bash
+```
 
 ### Creating Items
 
@@ -299,7 +299,7 @@ bw create item \
 # 3. Name: github-token
 # 4. Password: ghp_...
 # 5. Save
-```text
+```
 
 ### Organizing Items
 
@@ -320,7 +320,7 @@ Work/
 Personal/
 ├── ssh-passphrase
 └── gpg-key
-```sql
+```
 
 ### Item Types
 
@@ -347,7 +347,7 @@ tok npm
 
 # PyPI project token
 tok pypi
-```text
+```
 
 **Example wizard session:**
 
@@ -370,7 +370,7 @@ Paste your new token: ghp_xxxxxxxxxxxx
 
 ✓ Stored as 'github-token' in Bitwarden
   Expires: 2026-04-10 (90 days)
-```bash
+```
 
 ### Session Cache (15-minute)
 
@@ -383,7 +383,7 @@ sec x   # Works without re-prompting
 sec y   # Still works (cached)
 # ... 16 minutes later ...
 sec z   # Prompts to unlock again
-```text
+```
 
 ### Secrets Dashboard
 
@@ -391,7 +391,7 @@ View all tokens with expiration status:
 
 ```bash
 sec dashboard
-```text
+```
 
 **Dashboard output:**
 
@@ -413,7 +413,7 @@ sec dashboard
 │     Scope: project:mypackage                                  │
 │                                                               │
 ╰───────────────────────────────────────────────────────────────╯
-```bash
+```
 
 ### Token Rotation
 
@@ -425,7 +425,7 @@ tok pypi-token --refresh
 
 # Short form
 tok pypi-token -r
-```text
+```
 
 **Rotation output:**
 
@@ -444,7 +444,7 @@ Paste your new token: pypi-xxxxxxxx
 
 ⚠️  Remember to revoke old token at:
    https://pypi.org/manage/account/token/
-```text
+```
 
 ### CI/CD Integration
 
@@ -452,7 +452,7 @@ Paste your new token: pypi-xxxxxxxx
 
 ```bash
 sec sync github
-```text
+```
 
 ```sql
 ℹ Syncing secrets to: Data-Wise/flow-cli
@@ -463,13 +463,13 @@ Select secrets to sync:
   [ ] PYPI_TOKEN
 
 ✓ 2 secrets synced to repository
-```text
+```
 
 **Generate .envrc for direnv:**
 
 ```bash
 dots env
-```text
+```
 
 ```bash
 ✓ Generated .envrc with 3 secrets
@@ -481,7 +481,7 @@ dots env
   ─────────────────────────────
 
 💡 Run 'direnv allow' to activate
-```bash
+```
 
 ---
 
@@ -502,7 +502,7 @@ dots env
 
 [core]
     editor = vim
-```bash
+```
 
 **Apply:**
 
@@ -510,7 +510,7 @@ dots env
 sec unlock
 dots edit .gitconfig
 # Changes applied → ~/.gitconfig has actual token
-```bash
+```
 
 ### Example 2: ZSH with API Keys
 
@@ -524,7 +524,7 @@ export GITHUB_TOKEN="{{ bitwarden "item" "github-token" }}"
 
 # Regular config
 export PATH="$HOME/bin:$PATH"
-```zsh
+```
 
 **Apply:**
 
@@ -532,7 +532,7 @@ export PATH="$HOME/bin:$PATH"
 sec unlock
 dots edit .zshrc
 source ~/.zshrc
-```bash
+```
 
 ### Example 3: Environment File
 
@@ -547,7 +547,7 @@ export OPENAI_API_KEY="{{ bitwarden "item" "openai-key" }}"
 export ANTHROPIC_API_KEY="{{ bitwarden "item" "anthropic-key" }}"
 export GITHUB_TOKEN="{{ bitwarden "item" "github-token" }}"
 export NPM_TOKEN="{{ bitwarden "item" "npm-token" }}"
-```bash
+```
 
 **Apply:**
 
@@ -555,7 +555,7 @@ export NPM_TOKEN="{{ bitwarden "item" "npm-token" }}"
 sec unlock
 chezmoi apply ~/.env.sh
 source ~/.env.sh
-```text
+```
 
 ### Example 4: SSH Config
 
@@ -570,13 +570,13 @@ Host github.com
 Host bitbucket.org
     User git
     IdentityFile ~/.ssh/bitbucket_rsa
-```text
+```
 
 **Apply:**
 
 ```bash
 dots edit .ssh/config
-```text
+```
 
 ---
 
@@ -594,7 +594,7 @@ The `dash` command automatically shows dotfile status:
   📝 Dotfiles: 🟢 Synced (2h ago) · 12 files tracked
 
   ...
-```text
+```
 
 **Status Icons:**
 
@@ -622,7 +622,7 @@ The `flow doctor` command includes dotfile health checks:
   ✓ No uncommitted changes
   ✓ Synced with remote
   ✓ Bitwarden vault unlocked
-```bash
+```
 
 **Run diagnostics:**
 
@@ -632,7 +632,7 @@ dots doctor
 
 # Via flow doctor
 flow doctor
-```diff
+```
 
 ---
 
@@ -652,7 +652,7 @@ chezmoi init
 
 # Option B: Clone existing repo
 chezmoi init https://github.com/yourusername/dotfiles
-```diff
+```
 
 ### "Bitwarden vault is locked"
 
@@ -668,7 +668,7 @@ sec unlock
 
 # Try again
 sec github-token
-```diff
+```
 
 ### "Item not found or access denied"
 
@@ -684,7 +684,7 @@ sec list
 
 # Check item exists
 bw get item github-token
-```diff
+```
 
 ### Changes Not Applied
 
@@ -704,7 +704,7 @@ dots apply
 # For templates, ensure vault unlocked
 sec unlock
 dots apply
-```bash
+```
 
 ### Session Token in History
 
@@ -720,7 +720,7 @@ The `sec unlock` command safely captures tokens without exposing them. History e
 echo $HISTIGNORE
 
 # Should include: *bw unlock*:*bw get*:*BW_SESSION*
-```diff
+```
 
 This is automatically configured when dotfile helpers load.
 
@@ -762,7 +762,7 @@ git log -p | grep -i "token\|password\|secret" | grep -v "bitwarden"
 # 4. Audit applied files (should contain actual secrets, not templates)
 grep "bitwarden" ~/.gitconfig ~/.zshrc 2>/dev/null
 # Should return nothing (templates are processed)
-```bash
+```
 
 ---
 
@@ -780,7 +780,7 @@ dots push
 # Machine B (MacBook): Pull changes
 dots sync
 dots apply
-```bash
+```
 
 ### Conditional Templates
 
@@ -792,7 +792,7 @@ export WORK_MODE=true
 {{ else }}
 export WORK_MODE=false
 {{ end }}
-```bash
+```
 
 ### Custom Fields
 
@@ -801,7 +801,7 @@ Access custom fields in Bitwarden items:
 ```bash
 # In template
 {{ bitwardenFields "item" "api-key" "custom-field-name" }}
-```bash
+```
 
 ### Secret Rotation
 
@@ -813,7 +813,7 @@ tok github-token --refresh
 
 # This opens browser, validates new token, updates Bitwarden
 # and reminds you to revoke the old token
-```bash
+```
 
 **Method 2: Manual Update**
 

--- a/docs/guides/EMAIL-DISPATCHER-GUIDE.md
+++ b/docs/guides/EMAIL-DISPATCHER-GUIDE.md
@@ -23,7 +23,7 @@ em snooze 42 2h       # Snooze for later
 em digest             # AI-grouped daily summary
 em ai gemini          # Switch AI backend at runtime
 em catch 42           # Capture email as task
-```diff
+```
 
 **Philosophy:**
 - **Pure ZSH** - No Node.js runtime, no build step, sub-100ms commands
@@ -91,7 +91,7 @@ compose, triage, or analyze email content.
 
 ```bash
 em doctor
-```yaml
+```
 
 This checks all dependencies and shows your current configuration:
 
@@ -115,7 +115,7 @@ Config:
   Page size:   25
   Folder:      INBOX
   Config file: (none — using env defaults)
-```bash
+```
 
 ## Setup
 
@@ -129,13 +129,13 @@ brew install himalaya
 
 # Option 2: Cargo (cross-platform alternative)
 cargo install himalaya
-```text
+```
 
 Verify installation:
 
 ```bash
 himalaya --version
-```bash
+```
 
 ### 2. Configure himalaya
 
@@ -151,7 +151,7 @@ pip install email-oauth2-proxy
 
 # Configure himalaya with Gmail account
 himalaya account configure gmail
-```sql
+```
 
 **Quick IMAP/SMTP Setup:**
 
@@ -175,7 +175,7 @@ sender.port = 587
 sender.login = "you@example.com"
 sender.auth.type = "password"
 sender.auth.raw = "your-password-here"  # Or use keychain
-```text
+```
 
 > **Security Note:** Use app-specific passwords or OAuth2 for Gmail/Outlook. Store passwords in your system
 > keychain rather than plaintext config files.
@@ -184,7 +184,7 @@ Test your setup:
 
 ```bash
 himalaya envelope list --page-size 5
-```bash
+```
 
 If this works, you're ready to use `em`.
 
@@ -200,7 +200,7 @@ export FLOW_EMAIL_AI="claude"           # claude | gemini | none
 export FLOW_EMAIL_AI_TIMEOUT=30         # AI timeout in seconds
 export FLOW_EMAIL_PAGE_SIZE=25          # Default inbox page size
 export FLOW_EMAIL_FOLDER="INBOX"        # Default folder
-```sql
+```
 
 #### Option B: Config File
 
@@ -211,7 +211,7 @@ FLOW_EMAIL_AI="claude"
 FLOW_EMAIL_AI_TIMEOUT=30
 FLOW_EMAIL_PAGE_SIZE=25
 FLOW_EMAIL_FOLDER="INBOX"
-```yaml
+```
 
 Or for project-specific settings, create `.flow/email.conf` in your project root.
 
@@ -237,7 +237,7 @@ Recent:
   138     Eve Martinez          Office Hours Schedule Change             2026-02-09
 
 Full inbox: em i  Browse: em p  Help: em h
-```diff
+```
 
 **What I see:**
 - Unread count (ADHD dopamine hit when it's zero)
@@ -251,7 +251,7 @@ Full inbox: em i  Browse: em p  Help: em h
 
 ```bash
 $ em pick
-```yaml
+```
 
 This opens an interactive fzf picker:
 
@@ -275,7 +275,7 @@ Enter=read  Ctrl-R=reply  Ctrl-S=summarize  Ctrl-T=catch  Ctrl-F=star  Ctrl-M=mo
 
 ──────────────────────────────────────────────────
   [email content preview...]
-```diff
+```
 
 **Keyboard shortcuts:**
 - `Enter` - Read selected email
@@ -317,7 +317,7 @@ I've reviewed the rubric and here's my assessment...
 # Explicit confirmation (safety feature)
   Send this reply? [y/N] y
 ✅ Reply sent
-```bash
+```
 
 ### 4. Batch Process Remaining (1-2 minutes)
 
@@ -337,7 +337,7 @@ Analyzing 20 emails for actionable messages...
 $ em respond --review
 
 # fzf picker with drafts, edit or send each
-```text
+```
 
 **Total time:** 5 minutes or less. Inbox zero achieved.
 
@@ -351,13 +351,13 @@ The dispatcher accepts convenient shorthand patterns:
 em 42               # Shorthand for: em read 42
 em -n 5             # Shorthand for: em inbox 5
 em                  # Shorthand for: em dash (quick pulse)
-```text
+```
 
 ### Quick Dashboard
 
 ```bash
 em                  # or: em dash
-```text
+```
 
 Shows unread count + latest 10 emails. Perfect for a quick pulse check between tasks.
 
@@ -368,7 +368,7 @@ em inbox            # Default page size (25)
 em inbox 50         # Show 50 emails
 em i                # Shortcut
 em -n 10            # Shorthand for inbox 10
-```text
+```
 
 Output shows structured table with indicators:
 
@@ -377,13 +377,13 @@ Output shows structured table with indicators:
   ───── ── ──────────────────── ──────────────────────────────────────── ──────────
   142   * + Alice Johnson        Re: STAT-101 Exam Grading Question       2026-02-10
   141     Bob Smith             Department Meeting Notes                 2026-02-10
-```text
+```
 
 ### Read Individual Email
 
 ```bash
 em read <ID>        # or: em r <ID>
-```bash
+```
 
 **Smart Rendering Pipeline:**
 
@@ -427,13 +427,13 @@ Hi Prof. Davis,
 
 I have a question about the grading rubric for Problem 3...
 [rendered content with proper formatting]
-```text
+```
 
 ### Force HTML Rendering
 
 ```bash
 em html <ID>
-```text
+```
 
 Explicitly renders HTML emails in the terminal. Useful for HTML-heavy newsletters.
 
@@ -442,7 +442,7 @@ Explicitly renders HTML emails in the terminal. Useful for HTML-heavy newsletter
 ```bash
 em read --md <ID>
 em read -M <ID>       # Short flag
-```diff
+```
 
 Converts the HTML email to clean Markdown via pandoc, with a 7-stage Outlook cleanup pipeline:
 
@@ -485,13 +485,13 @@ $ em read --md 42
 - Submit feedback via the [shared document](https://docs.example.com/proposal)
 
 Let me know if you have questions.
-```text
+```
 
 ### Raw MIME Export
 
 ```bash
 em read --raw <ID>
-```diff
+```
 
 Exports the full `.eml` MIME source. Useful for debugging email formatting, forwarding to other tools, or archiving.
 
@@ -515,7 +515,7 @@ This cleanup runs on all read operations, including the fzf preview in `em pick`
 em unread           # INBOX
 em unread Sent      # Specific folder
 em u                # Shortcut
-```text
+```
 
 ## Composing & Replying
 
@@ -526,7 +526,7 @@ em reply <ID>              # Basic reply
 em reply <ID> --all        # Reply-all
 em reply <ID> --no-ai      # Skip AI draft
 em reply <ID> --batch      # Non-interactive (preview + confirm)
-```bash
+```
 
 **Interactive Flow (Default):**
 
@@ -551,7 +551,7 @@ Generating AI draft...
 
   Send this reply? [y/N] y
 ✅ Reply sent
-```text
+```
 
 **Batch Mode (Non-Interactive):**
 
@@ -574,7 +574,7 @@ Thanks for reaching out. I've reviewed Problem 3...
 
   Send this reply? [y/N] y
 ✅ Reply sent
-```bash
+```
 
 **Reply-All:**
 
@@ -582,7 +582,7 @@ Thanks for reaching out. I've reviewed Problem 3...
 $ em reply 142 --all
 
 # Includes all original recipients (To + Cc)
-```text
+```
 
 > **Safety Note:** Every send requires explicit `[y/N]` confirmation with default set to **No**. Hit Enter = No send.
 
@@ -593,7 +593,7 @@ em send                    # Interactive prompts
 em send alice@example.com  # Pre-fill recipient
 em send alice@example.com "Grant Proposal"  # Pre-fill recipient + subject
 em send --ai alice@example.com "Weekly Report"  # AI draft from subject
-```yaml
+```
 
 **Interactive Flow:**
 
@@ -629,7 +629,7 @@ Just a reminder that I have office hours...
 
   Send this email? [y/N] y
 ✅ Email sent
-```bash
+```
 
 **With AI Draft:**
 
@@ -644,7 +644,7 @@ Generating AI draft from subject...
 
   Send this email? [y/N] y
 ✅ Email sent
-```text
+```
 
 ### Download Attachments
 
@@ -652,7 +652,7 @@ Generating AI draft from subject...
 em attach <ID>              # Download to ~/Downloads
 em attach <ID> /tmp/files   # Download to specific directory
 em a <ID>                   # Shortcut
-```diff
+```
 
 ## AI Features Deep Dive
 
@@ -670,7 +670,7 @@ Configure via environment variable:
 export FLOW_EMAIL_AI="claude"    # Default (claude CLI)
 export FLOW_EMAIL_AI="gemini"    # Google Gemini CLI
 export FLOW_EMAIL_AI="none"      # Disable AI features
-```text
+```
 
 **Backend Selection:**
 
@@ -695,7 +695,7 @@ If the primary backend fails (timeout, not installed, API error), `em` automatic
 
 ```text
 claude → gemini → fail gracefully
-```text
+```
 
 ## AI Backend Switching
 
@@ -709,7 +709,7 @@ em ai gemini          # Switch to Gemini (faster startup)
 em ai claude          # Switch back to Claude
 em ai toggle          # Cycle through available backends
 em ai none            # Disable AI entirely
-```text
+```
 
 ### Status Display
 
@@ -724,7 +724,7 @@ Email AI Backend
   Gemini args: -e none
 
   Switch: em ai claude | em ai gemini | em ai toggle
-```bash
+```
 
 ### Gemini Speed Optimization
 
@@ -737,7 +737,7 @@ export FLOW_EMAIL_GEMINI_EXTRA_ARGS="-e none"
 
 # Custom extensions
 export FLOW_EMAIL_GEMINI_EXTRA_ARGS="-e my_extension"
-```bash
+```
 
 ### When to Use Each Backend
 
@@ -756,14 +756,14 @@ add to your config:
 ```bash
 # In $FLOW_CONFIG_DIR/email.conf or .flow/email.conf
 FLOW_EMAIL_AI=gemini
-```text
+```
 
 ### Classify Email
 
 ```bash
 em classify <ID>
 em cl <ID>             # Shortcut
-```text
+```
 
 Categorizes an email into one of these types:
 
@@ -784,7 +784,7 @@ Categorizes an email into one of these types:
 ```bash
 $ em classify 142
   S student
-```bash
+```
 
 **Use Case:**
 
@@ -796,14 +796,14 @@ if [[ "$category" == "urgent" ]]; then
 else
     em reply 142          # Take time to craft response
 fi
-```text
+```
 
 ### Summarize Email
 
 ```bash
 em summarize <ID>
 em sum <ID>            # Shortcut
-```text
+```
 
 Generates a one-line summary (max 80 characters) focused on: **who wants what and by when**.
 
@@ -812,7 +812,7 @@ Generates a one-line summary (max 80 characters) focused on: **who wants what an
 ```bash
 $ em summarize 142
   Summary: Alice needs clarification on exam Problem 3 grading by Friday
-```bash
+```
 
 **Use Case:**
 
@@ -822,7 +822,7 @@ for id in {140..145}; do
     echo -n "$id: "
     em summarize $id
 done
-```text
+```
 
 ### Batch Draft Generation
 
@@ -833,7 +833,7 @@ em respond --review         # Review/send cached drafts (skip classification)
 em respond --dry-run        # Classify only (see what's actionable, no drafts)
 em respond --folder Sent    # Process specific folder
 em respond --clear          # Clear draft cache
-```text
+```
 
 **How it works:**
 
@@ -858,7 +858,7 @@ Analyzing 20 emails for actionable messages...
 
 3 drafts generated (17 skipped)
   Review: em respond --review
-```bash
+```
 
 **Review Cached Drafts:**
 
@@ -880,7 +880,7 @@ em respond --review — reviewing cached drafts in INBOX
 #   - Loads cached draft into $EDITOR
 #   - Confirm send [y/N]
 #   - Continue to next? [Y/n/q]
-```bash
+```
 
 **Dry Run (Classify Only):**
 
@@ -889,14 +889,14 @@ $ em respond --dry-run
 
 # Shows classification results without generating drafts
 # Useful to preview what's actionable before committing time
-```text
+```
 
 **Clear Draft Cache:**
 
 ```bash
 $ em respond --clear
 ✅ Email cache cleared (2.4M freed)
-```bash
+```
 
 ### Listserv Safety
 
@@ -907,7 +907,7 @@ auto-skipped before AI classification. They appear as:
 
 ```text
   [3/10] graduation@unm.edu        L listserv — skip
-```text
+```
 
 **Layer 2: Warning banner.** If an actionable email was sent to a list-like address, a warning appears
 before drafting:
@@ -915,7 +915,7 @@ before drafting:
 ```text
   ⚠ WARNING: This email was sent to a mailing list
     Replying may go to ALL list members. Review carefully.
-```diff
+```
 
 ### Discard Detection
 
@@ -943,7 +943,7 @@ Configure global timeout:
 
 ```bash
 export FLOW_EMAIL_AI_TIMEOUT=45  # Increase to 45s for all ops
-```text
+```
 
 ### Prompt Customization
 
@@ -960,7 +960,7 @@ it to the `catch` command.
 ```bash
 em catch 42           # Summarize email #42 → pipe to catch
 em catch 99           # Summarize email #99 → pipe to catch
-```bash
+```
 
 ### How It Works
 
@@ -986,7 +986,7 @@ Press **Ctrl-T** in `em pick` to capture the highlighted email as a task — no 
 ```bash
 em pick               # Browse emails
 # Ctrl-T on any email → instant capture
-```text
+```
 
 ## Organize: Star, Move, Thread, Snooze, Digest
 
@@ -999,19 +999,19 @@ Toggle the IMAP `Flagged` flag on an email:
 ```bash
 em star 42              # Toggle star on email #42
 em flag 42              # Alias for em star
-```text
+```
 
 **Output:**
 
 ```text
 ★ Starred #42 — Re: STAT-101 Exam Grading Question
-```text
+```
 
 Run again to unstar:
 
 ```text
 ☆ Unstarred #42 — Re: STAT-101 Exam Grading Question
-```bash
+```
 
 **List all starred emails:**
 
@@ -1027,7 +1027,7 @@ em starred — flagged emails
   140    Carol Davis        Urgent: Grant Proposal Deadline       2026-02-09
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 2 starred emails
-```text
+```
 
 ### Move
 
@@ -1037,14 +1037,14 @@ Move an email to a different folder:
 em move 42 Archive      # Move to Archive (with confirmation)
 em move 42              # fzf folder picker (requires fzf)
 em mv 42 Trash          # Alias
-```text
+```
 
 **With explicit folder:**
 
 ```text
 Move #42 → Archive? [y/N] y
 ✅ Moved #42 to Archive
-```text
+```
 
 **Without folder (fzf picker):**
 
@@ -1057,7 +1057,7 @@ View the conversation thread for an email — finds related messages by `Referen
 ```bash
 em thread 42            # Show thread for email #42
 em th 42                # Alias
-```text
+```
 
 **Output:**
 
@@ -1069,13 +1069,13 @@ em thread — conversation for #42
 → #142   Alice Johnson     Re: STAT-101 Exam Grading...      2026-02-10
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 3 messages in thread
-```text
+```
 
 The `→` arrow marks the message you started from. If the email is standalone (no thread), you'll see:
 
 ```text
 This is a standalone message (no thread found)
-```text
+```
 
 ### Snooze
 
@@ -1088,14 +1088,14 @@ em snooze 42 3w         # Snooze for 3 weeks
 em snooze 42 tomorrow   # Snooze until tomorrow 9:00 AM
 em snooze 42 monday     # Snooze until next Monday 9:00 AM
 em snz 42 2h            # Alias
-```text
+```
 
 **Output:**
 
 ```text
 💤 Snoozed #42 until 2026-02-18 14:30
    Re: STAT-101 Exam Grading Question
-```bash
+```
 
 **Supported time formats:**
 
@@ -1121,7 +1121,7 @@ em snoozed — pending reminders
   99     Budget Proposal                     in 3h          1d
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 2 snoozed emails (1 ready)
-```text
+```
 
 `READY` means the snooze time has passed — time to handle it.
 
@@ -1136,7 +1136,7 @@ em digest               # Today's emails
 em digest --week        # This week's emails
 em digest -n 5          # Limit to 5 emails
 em dg                   # Alias
-```text
+```
 
 **Output (with AI):**
 
@@ -1154,7 +1154,7 @@ Informational:
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 4 emails today (2 unread)
-```text
+```
 
 **Output (without AI):**
 
@@ -1179,7 +1179,7 @@ The `em pick` command provides a powerful fzf-based email browser with live prev
 em pick              # Browse INBOX
 em pick Sent         # Browse Sent folder
 em p                 # Shortcut
-```text
+```
 
 ### Interface Layout
 
@@ -1200,7 +1200,7 @@ Enter=read  Ctrl-R=reply  Ctrl-S=summarize  Ctrl-T=catch  Ctrl-F=star  Ctrl-M=mo
 │
 │──────────────────────────────────────────────────
 │  [First 60 lines of email content...]
-```bash
+```
 
 **Left Panel:** Email list with indicators
 **Right Panel:** Live preview of selected email
@@ -1249,14 +1249,14 @@ Generating AI draft...
 ✅ Reply sent
 
 # Continue browsing or press Esc to exit
-```text
+```
 
 ## Search
 
 ```bash
 em find <query>
 em f <query>           # Shortcut
-```yaml
+```
 
 Searches across email metadata (subject, sender name, sender address). Client-side filtering for speed.
 
@@ -1272,7 +1272,7 @@ Searching: quarterly report
 28    alice@dept.edu       Quarterly Teaching Summary   2026-01-05
 
 3 results
-```diff
+```
 
 **Search Tips:**
 - Searches are case-insensitive
@@ -1286,7 +1286,7 @@ Searching: quarterly report
 
 ```bash
 em folders
-```text
+```
 
 Shows all available mail folders:
 
@@ -1296,7 +1296,7 @@ Sent
 Drafts
 Trash
 Archive
-```bash
+```
 
 ### Delete Emails
 
@@ -1321,7 +1321,7 @@ em delete --pick                 # Tab to select, Enter to confirm
 # PERMANENT delete (purge)
 em delete --purge 42             # Flag as Deleted + EXPUNGE
 em delete --folder Trash --purge # Purge entire Trash
-```text
+```
 
 **Safety levels:**
 
@@ -1330,7 +1330,7 @@ Star/flag emails directly:
 ```bash
 em star 42              # Toggle Flagged flag
 em starred              # List all flagged emails
-```text
+```
 
 Or use the fzf picker (`em pick`) with `Ctrl-F` to toggle star on the selected email.
 
@@ -1340,7 +1340,7 @@ Lower-level flag management is available via `lib/em-himalaya.zsh` adapter:
 _em_hml_flags add <ID> Seen       # Mark as read
 _em_hml_flags add <ID> Flagged    # Mark as flagged
 _em_hml_flags add <ID> Deleted    # Mark as deleted
-```bash
+```
 
 | Mode | Confirmation | Reversible? |
 |------|-------------|-------------|
@@ -1358,7 +1358,7 @@ em mv Archive 10 20 30           # Batch move
 
 # Move from specific source folder
 em move --from Sent Archive 42   # Sent → Archive
-```bash
+```
 
 ### Restore from Trash
 
@@ -1371,7 +1371,7 @@ em restore 42 --to Archive
 
 # Batch restore
 em restore 10 20 30
-```bash
+```
 
 ### Flag / Unflag
 
@@ -1383,14 +1383,14 @@ em fl 42 43                      # Batch (alias: fl)
 # Remove star
 em unflag 42
 em unflag 42 43                  # Batch
-```text
+```
 
 ### Extract Action Items (AI)
 
 ```bash
 em todo 42                       # AI extracts action items
 em td 42 43                      # Batch (alias: td)
-```text
+```
 
 Shows numbered list of action items, captures to `catch`, and optionally adds to macOS Reminders.app.
 
@@ -1399,7 +1399,7 @@ Shows numbered list of action items, captures to `catch`, and optionally adds to
 ```bash
 em event 42                      # AI extracts dates/times/meetings
 em ev 42 43                      # Batch (alias: ev)
-```text
+```
 
 Shows event details (title, date, time, duration, location), captures to `catch`, and optionally adds to macOS Calendar.app.
 
@@ -1416,14 +1416,14 @@ All AI operations are cached with time-to-live (TTL) to avoid redundant API call
   drafts/<hash>.txt             # Generated reply drafts
   schedules/<hash>.json         # Extracted dates/times
   unread/<hash>.txt             # Unread counts
-```bash
+```
 
 Or globally:
 
 ```text
 $FLOW_DATA_DIR/email-cache/
   (same structure)
-```text
+```
 
 ### TTL Values
 
@@ -1442,7 +1442,7 @@ em cache stats         # Show cache size, per-op counts, expired count
 em cache prune         # Remove expired entries only (report count)
 em cache clear         # Clear all cached AI results (report freed space)
 em cache warm [N]      # Pre-warm latest N emails (default: 10, background)
-```text
+```
 
 **Stats Output:**
 
@@ -1455,14 +1455,14 @@ Email Cache
   drafts             5 items    24K
   schedules          8 items    16K
   Location: .flow/email-cache
-```text
+```
 
 **Prune Expired Entries:**
 
 ```bash
 $ em cache prune
 ✅ Pruned 4 expired cache entries
-```text
+```
 
 Prune only removes entries past their TTL — fresh items are untouched.
 
@@ -1471,7 +1471,7 @@ Prune only removes entries past their TTL — fresh items are untouched.
 ```bash
 $ em cache clear
 ✅ Email cache cleared (2.4M freed)
-```bash
+```
 
 **Warm Cache (Background):**
 
@@ -1484,7 +1484,7 @@ $ em cache warm 20
 # - Summarizes each (AI)
 # - Caches results
 # - Does NOT block shell
-```diff
+```
 
 > **Tip:** Run `em cache warm` at the start of your work session to pre-populate summaries for faster browsing.
 
@@ -1504,7 +1504,7 @@ The cache enforces a maximum size to prevent unbounded growth:
 ```bash
 FLOW_EMAIL_CACHE_MAX_MB=50      # Default: 50 MB
 FLOW_EMAIL_CACHE_MAX_MB=0       # Disable size cap
-```diff
+```
 
 When the cache exceeds this limit, the oldest files are evicted first (LRU -- Least Recently Used). Eviction
 runs automatically after every cache write as a non-blocking background process.
@@ -1555,7 +1555,7 @@ FLOW_EMAIL_FOLDER="INBOX"
 
 # Editor
 EDITOR="nvim"
-```diff
+```
 
 ### himalaya Configuration
 
@@ -1602,7 +1602,7 @@ The `em` dispatcher follows a clean 6-layer architecture:
 │ himalaya CLI                             │  IMAP/SMTP backend
 │ (external)                               │  Handles actual email
 └─────────────────────────────────────────┘
-```diff
+```
 
 ### Design Principles
 
@@ -1642,7 +1642,7 @@ The adapter pattern means we could swap backends in the future without changing 
 ```text
 ❌ himalaya not found
 Install: brew install himalaya or cargo install himalaya
-```bash
+```
 
 **Solution:**
 
@@ -1655,7 +1655,7 @@ cargo install himalaya
 
 # Verify
 himalaya --version
-```text
+```
 
 ### "himalaya cannot connect to mailbox"
 
@@ -1664,7 +1664,7 @@ himalaya --version
 ```text
 ❌ himalaya cannot connect to mailbox
 Check config: himalaya account list
-```bash
+```
 
 **Solution:**
 
@@ -1677,7 +1677,7 @@ himalaya envelope list --page-size 1
 
 # Reconfigure if needed
 himalaya account configure
-```diff
+```
 
 **Common causes:**
 - Wrong IMAP credentials
@@ -1691,7 +1691,7 @@ himalaya account configure
 
 ```text
 ⚠️  Classification failed (no AI backend available?)
-```bash
+```
 
 **Solution:**
 
@@ -1708,7 +1708,7 @@ pip install google-generativeai
 
 # Or disable AI entirely
 export FLOW_EMAIL_AI="none"
-```bash
+```
 
 ### HTML emails not rendering properly
 
@@ -1716,7 +1716,7 @@ export FLOW_EMAIL_AI="none"
 
 ```text
 [Raw HTML output with tags visible]
-```bash
+```
 
 **Solution:**
 
@@ -1730,7 +1730,7 @@ brew install pandoc
 
 # Verify
 em doctor
-```text
+```
 
 ### Cache taking up too much space
 
@@ -1738,13 +1738,13 @@ em doctor
 
 ```bash
 em cache stats
-```text
+```
 
 **Clear cache:**
 
 ```bash
 em cache clear
-```zsh
+```
 
 **Reduce cache lifetime (edit `lib/em-cache.zsh`):**
 
@@ -1754,7 +1754,7 @@ typeset -gA _EM_CACHE_TTL=(
     [classifications]=3600 # 1 hour instead of 24
     [drafts]=1800          # 30 min instead of 1 hour
 )
-```bash
+```
 
 ### fzf picker not showing preview
 
@@ -1763,13 +1763,13 @@ typeset -gA _EM_CACHE_TTL=(
 ```bash
 brew install fzf
 brew install jq
-```text
+```
 
 **Check:**
 
 ```bash
 em doctor
-```bash
+```
 
 ### Editor not opening for compose/reply
 
@@ -1777,13 +1777,13 @@ em doctor
 
 ```bash
 echo $EDITOR
-```bash
+```
 
 **Set in ~/.zshrc:**
 
 ```bash
 export EDITOR="nvim"    # or vim, nano, etc.
-```text
+```
 
 ## Safety Design
 
@@ -1795,7 +1795,7 @@ Every send operation requires explicit confirmation:
 
 ```bash
   Send this reply? [y/N]
-```diff
+```
 
 - **Default is No** - Hitting Enter = no send
 - **Must type 'y' or 'Y'** - Any other input cancels
@@ -1808,7 +1808,7 @@ Rejected sends automatically preserve the draft for later:
 ```bash
 # Drafts saved to:
 $FLOW_DATA_DIR/email-drafts/    # Global draft storage
-```yaml
+```
 
 AI-generated drafts are also cached in `.flow/email-cache/drafts/` with a 1-hour TTL. Use
 `em respond --review` to come back to cached drafts.
@@ -1828,7 +1828,7 @@ Subject: Re: STAT-101 Exam Grading Question
 ────────────────────────────────────────────────────────
 
   Send this reply? [y/N]
-```bash
+```
 
 ### 4. Editor Interception
 
@@ -1842,7 +1842,7 @@ em reply 42
 # 3. You edit/review
 # 4. Save and close
 # 5. Only then: confirmation prompt
-```bash
+```
 
 ### 5. Batch Mode Safety
 
@@ -1859,7 +1859,7 @@ $ em respond
 $ em respond --review
 
 # Each draft requires individual confirmation
-```diff
+```
 
 ### 6. No Auto-Reply
 
@@ -1897,7 +1897,7 @@ em pick
 em respond
 
 # Done - inbox triaged
-```bash
+```
 
 ### Reply to Urgent Email
 
@@ -1909,7 +1909,7 @@ em reply 142
 em reply 142 --batch
 
 # Both provide AI draft, both require confirmation
-```bash
+```
 
 ### Review Emails from Specific Person
 
@@ -1924,7 +1924,7 @@ em find "alice"
 # Read and reply
 em read 42
 em reply 42
-```bash
+```
 
 ### Process All Actionable Emails
 
@@ -1936,7 +1936,7 @@ em respond -n 50
 em respond --review
 
 # Or manually review specific drafts via cache
-```bash
+```
 
 ### Weekly Newsletter Cleanup
 

--- a/docs/guides/ENHANCED-HELP-QUICK-START.md
+++ b/docs/guides/ENHANCED-HELP-QUICK-START.md
@@ -33,13 +33,13 @@ focus help      # Focus timer help
 note help       # Notes sync help
 obs help        # Obsidian help
 workflow help   # Workflow logging help
-```text
+```
 
 Or use the short alias:
 
 ```bash
 r h             # Same as r help
-```text
+```
 
 ---
 
@@ -53,7 +53,7 @@ Each help screen now features:
 ╭─────────────────────────────────────────────╮
 │ command - Description                       │
 ╰─────────────────────────────────────────────╯
-```diff
+```
 
 ### 2. Most Common Commands (🔥)
 
@@ -117,7 +117,7 @@ CORE WORKFLOW:
   r test         Run tests (devtools::test)
   r doc          Generate docs (devtools::document)
   ... (20+ more lines)
-```text
+```
 
 **After:**
 
@@ -139,7 +139,7 @@ CORE WORKFLOW:
 📋 CORE WORKFLOW:
   r load             Load package (devtools::load_all)
   ...
-```bash
+```
 
 **Time saved:** From 10 seconds scanning → <3 seconds finding what you need
 
@@ -154,7 +154,7 @@ NO_COLOR=1 r help
 # Or set in your environment
 export NO_COLOR=1
 r help
-```text
+```
 
 ---
 
@@ -166,7 +166,7 @@ r help
 flow help -i              # Interactive fzf picker for all commands
 r help -i                 # Works with any dispatcher
 cc help -i                # Browse Claude Code commands
-```diff
+```
 
 **Features:**
 
@@ -182,7 +182,7 @@ flow alias                # Show all custom aliases (29 total)
 flow alias cc             # Claude Code aliases (ccy, ccp, ccr)
 flow alias git            # Git aliases
 flow alias <category>     # Any category
-```diff
+```
 
 **Categories:** `git`, `cc`, `pick`, `dash`, `work`, `capture`, `mcp`, `quarto`, `r`, `obs`
 

--- a/docs/guides/HELP-SYSTEM-GUIDE.md
+++ b/docs/guides/HELP-SYSTEM-GUIDE.md
@@ -31,7 +31,7 @@ $ teach --help
 $ teach help
 # or
 $ teach -h
-```text
+```
 
 Shows complete dispatcher overview with all command categories.
 
@@ -41,7 +41,7 @@ Shows complete dispatcher overview with all command categories.
 $ teach lecture --help       # Lecture generation help
 $ teach exam -h              # Exam creation help
 $ teach validate help        # Validation help
-```bash
+```
 
 All three formats work: `--help`, `-h`, `help`
 
@@ -53,7 +53,7 @@ cat docs/tutorials/14-teach-dispatcher.md
 
 # Or visit on the website
 open https://Data-Wise.github.io/flow-cli/tutorials/14-teach-dispatcher/
-```text
+```
 
 15-minute walkthrough from setup to deployment.
 
@@ -102,7 +102,7 @@ LEARN MORE
 SEE ALSO:
   teach related-cmd - Description
   teach another-cmd - Description
-```diff
+```
 
 ---
 
@@ -184,7 +184,7 @@ QUICK START
 
   # Custom template
   $ teach lecture "Bayesian Stats" --template quarto
-```text
+```
 
 **Target:** Users who know what they want, just need syntax
 
@@ -199,7 +199,7 @@ OPTIONS
   Output Format:
     --template FORMAT  markdown|quarto|typst|pdf
     --style TONE       formal|casual
-```bash
+```
 
 **Target:** Users exploring available options
 
@@ -216,7 +216,7 @@ EXAMPLES
     $ teach lecture --week 5
     # Auto-loads topic from lesson-plan.yml
     # Includes learning objectives
-```text
+```
 
 **Target:** Users learning workflows
 
@@ -230,7 +230,7 @@ TIPS
 
 LEARN MORE
   📖 docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md#content-creation
-```bash
+```
 
 **Target:** Power users, troubleshooting
 
@@ -250,7 +250,7 @@ ${FLOW_COLORS[success]}    # Success messages (green)
 ${FLOW_COLORS[info]}       # Info messages (blue)
 ${FLOW_COLORS[dim]}        # Secondary text (dark gray)
 ${FLOW_COLORS[reset]}      # Reset to default
-```text
+```
 
 ### Visual Hierarchy Example
 
@@ -267,7 +267,7 @@ ALIASES                                                         ← bold
 
 # Basic usage                                                   ← muted
 $ teach lecture "Linear Regression"                             ← muted
-```diff
+```
 
 ---
 
@@ -314,7 +314,7 @@ Commands support **three help formats**:
 teach lecture --help     # Long flag
 teach lecture -h         # Short flag
 teach lecture help       # Positional argument
-```bash
+```
 
 ### Routing Implementation
 
@@ -330,7 +330,7 @@ lecture|lec)
             ;;
     esac
     ;;
-```text
+```
 
 **Pattern:**
 1. Check if first argument is help flag
@@ -351,7 +351,7 @@ Links to comprehensive guides:
 LEARN MORE
   📖 Full guide: docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md#section
   📖 Quick ref: docs/reference/MASTER-DISPATCHER-GUIDE.md#teach-dispatcher
-```text
+```
 
 ### SEE ALSO Section
 
@@ -361,7 +361,7 @@ Links to related commands:
 SEE ALSO:
   teach quiz - Create quiz questions
   teach rubric - Generate grading rubric
-```text
+```
 
 ### Cross-Reference Network
 
@@ -377,7 +377,7 @@ teach exam
   SEE ALSO:
     • teach quiz    → Shorter assessment format
     • teach rubric  → Create grading rubric
-```bash
+```
 
 ---
 
@@ -403,7 +403,7 @@ EXAMPLES
     --option2 value \
     --option3
   # Complex workflow explanation
-```diff
+```
 
 ### Example Elements
 
@@ -489,7 +489,7 @@ ${FLOW_COLORS[muted]}SEE ALSO:${FLOW_COLORS[reset]}
 
 EOF
 }
-```diff
+```
 
 ### Validation Checklist
 
@@ -524,7 +524,7 @@ for cmd in lecture exam quiz validate deploy doctor; do
     echo "Testing: teach $cmd --help"
     teach $cmd --help > /dev/null || echo "FAIL: $cmd"
 done
-```zsh
+```
 
 ---
 
@@ -553,7 +553,7 @@ teach() {
         # ... other commands
     esac
 }
-```text
+```
 
 ### Box Width Constraints
 
@@ -563,7 +563,7 @@ Box borders are **60 characters wide**:
 ╔════════════════════════════════════════════════════════════╗
 ^                                                          ^
 0                                                         60
-```bash
+```
 
 Title must fit within **58 characters** (60 minus 2 for `║` borders):
 
@@ -572,7 +572,7 @@ Title must fit within **58 characters** (60 minus 2 for `║` borders):
 ║  teach profiles - Manage Quarto Profile Configurations  ║
 ^                                                        ^
 2                                                       60
-```zsh
+```
 
 ### Color Variables
 

--- a/docs/guides/HIMALAYA-SETUP.md
+++ b/docs/guides/HIMALAYA-SETUP.md
@@ -22,7 +22,7 @@ himalaya (CLI email client)
 email-oauth2-proxy (localhost)     <-- Only needed for OAuth2 providers
   IMAP: 127.0.0.1:1993 --> outlook.office365.com:993 (OAuth2/TLS)
   SMTP: 127.0.0.1:1587 --> smtp.office365.com:587  (OAuth2/STARTTLS)
-```yaml
+```
 
 **For app-password providers** (Gmail with app passwords, Fastmail, etc.), you connect himalaya directly — no proxy needed.
 
@@ -60,7 +60,7 @@ Verify:
 
 ```bash
 himalaya --version
-```sql
+```
 
 ---
 
@@ -126,13 +126,13 @@ message.send.backend.encryption.type = "tls"
 message.send.backend.login = "you@example.com"
 message.send.backend.auth.type = "password"
 message.send.backend.auth.cmd = "security find-generic-password -a you@example.com -s himalaya -w"
-```text
+```
 
 Store your app password in macOS Keychain:
 
 ```bash
 security add-generic-password -a you@example.com -s himalaya -w "your-app-password"
-```bash
+```
 
 ### Option B: OAuth2 via Proxy (Microsoft 365, Google Workspace)
 
@@ -142,7 +142,7 @@ For providers requiring OAuth2, use [email-oauth2-proxy](https://github.com/simo
 
 ```bash
 pip install emailproxy
-```bash
+```
 
 **2. Configure the proxy** at `~/.config/email-oauth2-proxy/emailproxy.config`:
 
@@ -173,7 +173,7 @@ client_secret =
 server_address = smtp.office365.com
 server_port = 587
 local_address = 127.0.0.1:1587
-```bash
+```
 
 **3. Configure himalaya** to connect through the proxy (no TLS — proxy handles it):
 
@@ -195,7 +195,7 @@ message.send.backend.encryption.type = "none"
 message.send.backend.login = "you@example.com"
 message.send.backend.auth.type = "password"
 message.send.backend.auth.cmd = "echo you@example.com"
-```html
+```
 
 **4. Set up the proxy as a LaunchAgent** (starts on login):
 
@@ -229,7 +229,7 @@ EOF
 
 # Load it
 launchctl load ~/Library/LaunchAgents/com.emailproxy.plist
-```bash
+```
 
 **5. Initial OAuth2 authentication:**
 
@@ -241,7 +241,7 @@ himalaya envelope list
 tail -f ~/.local/share/email-oauth2-proxy/proxy.log
 # You'll see: "Visit https://microsoft.com/devicelogin and use code XXXXXXXX"
 # Open that URL and enter the code
-```bash
+```
 
 ---
 
@@ -256,7 +256,7 @@ himalaya envelope list
 
 # Check em dispatcher
 em doctor
-```bash
+```
 
 You should see your inbox. If everything works, `em` commands are ready.
 
@@ -275,21 +275,21 @@ tail -20 ~/.local/share/email-oauth2-proxy/proxy.log
 # Trigger re-auth
 himalaya envelope list
 # Follow the device code instructions in the log
-```text
+```
 
 ### Restart the Proxy
 
 ```bash
 launchctl unload ~/Library/LaunchAgents/com.emailproxy.plist
 launchctl load ~/Library/LaunchAgents/com.emailproxy.plist
-```bash
+```
 
 ### Check Proxy Status
 
 ```bash
 ps aux | grep emailproxy | grep -v grep
 tail -20 ~/.local/share/email-oauth2-proxy/proxy.log
-```bash
+```
 
 ### Common Issues
 

--- a/docs/guides/INTELLIGENT-CONTENT-ANALYSIS.md
+++ b/docs/guides/INTELLIGENT-CONTENT-ANALYSIS.md
@@ -57,7 +57,7 @@ concepts:
     - mean
     - variance
 ---
-```bash
+```
 
 ### 2. Run Analysis
 
@@ -73,7 +73,7 @@ teach analyze --report analysis-report.md
 
 # Or use validation integration
 teach validate --concepts
-```bash
+```
 
 ### 3. Check Status
 
@@ -83,7 +83,7 @@ teach status
 
 # View cache statistics
 teach analyze --stats
-```yaml
+```
 
 ---
 
@@ -99,7 +99,7 @@ concepts:
   requires:             # Prerequisites from earlier weeks
     - prerequisite-1
     - prerequisite-2
-```diff
+```
 
 ### Naming Conventions
 
@@ -133,7 +133,7 @@ concepts:
 # Introduction to Regression
 
 Today we'll build on our understanding of correlation...
-```bash
+```
 
 ---
 
@@ -166,7 +166,7 @@ teach analyze --stats
 
 # Help
 teach analyze --help
-```text
+```
 
 **Output:**
 
@@ -180,7 +180,7 @@ Validating prerequisites...
 ✓ All prerequisites satisfied (18 concepts checked)
 
 Concept graph saved to .teach/concepts.json
-```bash
+```
 
 ### teach analyze --interactive
 
@@ -190,7 +190,7 @@ Guided, ADHD-friendly analysis with step-by-step prompts.
 teach analyze --interactive
 # or
 teach analyze -i
-```text
+```
 
 **Interactive Mode Flow:**
 
@@ -221,7 +221,7 @@ teach analyze -i
 │  Review violations? (y/n) > y                                │
 │                                                              │
 └──────────────────────────────────────────────────────────────┘
-```diff
+```
 
 **Features:**
 - Step-by-step scope and mode selection
@@ -246,7 +246,7 @@ teach analyze --report summary.md --summary-only
 
 # Violations only
 teach analyze --report violations.md --violations-only
-```bash
+```
 
 **Markdown Report Structure:**
 
@@ -279,7 +279,7 @@ teach analyze --report violations.md --violations-only
 
 1. Move `correlation` introduction to Week 1
 2. Consider adding prerequisites for orphan concepts
-```text
+```
 
 **JSON Report Structure:**
 
@@ -299,7 +299,7 @@ teach analyze --report violations.md --violations-only
   "violations": [...],
   "recommendations": [...]
 }
-```text
+```
 
 ### teach analyze --stats
 
@@ -307,7 +307,7 @@ View cache statistics and performance metrics.
 
 ```bash
 teach analyze --stats
-```text
+```
 
 **Output:**
 
@@ -329,7 +329,7 @@ Storage:
 
 Last Rebuild: 2h ago
 Next Expiry: 4 entries in 6h
-```bash
+```
 
 ### teach validate --concepts
 
@@ -344,7 +344,7 @@ teach validate --concepts --quiet
 
 # Combined with YAML validation
 teach validate --yaml --concepts
-```bash
+```
 
 ### teach validate --deep
 
@@ -359,7 +359,7 @@ teach validate --yaml --syntax --deep
 
 # Quiet mode for CI
 teach validate --deep --quiet
-```text
+```
 
 **Output:**
 
@@ -376,7 +376,7 @@ Validating prerequisites...
 ✗ 0 concepts: missing prerequisites (errors)
 
 Layer 6 Result: PASS (2 warnings)
-```bash
+```
 
 **Validation Layers:**
 
@@ -399,7 +399,7 @@ teach deploy --check-prereqs
 
 # Dry-run to see what would be blocked
 teach deploy --check-prereqs --dry-run
-```diff
+```
 
 **Behavior:**
 
@@ -423,7 +423,7 @@ Fix these issues before deploying:
   2. Or use --force to override (not recommended)
 
 Run 'teach analyze --interactive' for guided fixes.
-```text
+```
 
 ### teach status
 
@@ -431,7 +431,7 @@ View concept summary in status dashboard.
 
 ```bash
 teach status
-```text
+```
 
 Shows:
 
@@ -441,7 +441,7 @@ Shows:
 ├─────────────────────────────────────────────────┤
 │ 📊 Concepts    │ 18 concepts, 6 weeks (2h ago) │
 └─────────────────────────────────────────────────┘
-```text
+```
 
 ---
 
@@ -483,7 +483,7 @@ Analysis creates `.teach/concepts.json`:
     }
   }
 }
-```diff
+```
 
 ### Use Cases
 
@@ -515,7 +515,7 @@ The caching system accelerates analysis by storing results based on content hash
     ├── lectures/           # Lecture analysis cache
     ├── assignments/        # Assignment analysis cache
     └── exams/              # Exam analysis cache
-```text
+```
 
 ### Cache Index Structure
 
@@ -533,7 +533,7 @@ The caching system accelerates analysis by storing results based on content hash
     }
   }
 }
-```bash
+```
 
 ### Cache Operations
 
@@ -549,7 +549,7 @@ teach cache clean --expired
 
 # Clear all analysis cache
 teach cache clear --analysis
-```text
+```
 
 ### Performance Targets
 
@@ -568,7 +568,7 @@ When a concept is modified, dependent concepts are automatically invalidated:
 correlation (modified)
     └── simple-regression (invalidated)
         └── multiple-regression (invalidated)
-```yaml
+```
 
 ---
 
@@ -603,7 +603,7 @@ concepts:
   #   - concept: calculus
   #     required_for: [optimization, derivatives]
   #     introduced: 'external'
-```text
+```
 
 ### Configuration Options
 
@@ -625,7 +625,7 @@ concepts:
 ✗ ERROR: Missing prerequisite: variance
    Week 2 requires 'variance' but it's never introduced
    Suggestion: Add variance to earlier week
-```text
+```
 
 **Fix:** Add the missing concept to an earlier lecture's `introduces:` list.
 
@@ -637,7 +637,7 @@ concepts:
 ⚠ WARNING: Future prerequisite: correlation
    Week 2 requires 'correlation' but it's introduced in week 4
    Suggestion: Reorder content or move correlation earlier
-```text
+```
 
 **Fix:** Either reorder lectures or adjust the prerequisite declaration.
 
@@ -649,7 +649,7 @@ Concepts with no prerequisites (when `warn_orphans: true`):
 ⚠ WARNING: Orphan concept: probability
    'probability' has no prerequisites
    This may be intentional for foundational concepts
-```yaml
+```
 
 ---
 
@@ -667,7 +667,7 @@ concepts:
     - variance
     - standard-deviation
   requires: []  # No prerequisites for first week
-```yaml
+```
 
 ### 2. Build Incrementally
 
@@ -682,7 +682,7 @@ concepts:
   requires:
     - mean      # From week 1
     - variance  # From week 1
-```yaml
+```
 
 ### 3. Be Explicit
 
@@ -697,7 +697,7 @@ concepts:
     - correlation  # Direct prerequisite
     - variance     # Also needed for regression
     - mean         # Foundation for everything
-```yaml
+```
 
 ### 4. Use Consistent Naming
 
@@ -715,7 +715,7 @@ introduces:
   - Standard_Deviation  # ❌ Mixed case and underscores
   - chi squared         # ❌ Spaces
   - TTest               # ❌ Camel case
-```bash
+```
 
 ### 5. Run Analysis Regularly
 
@@ -730,7 +730,7 @@ teach analyze
 
 # Check status dashboard
 teach status
-```yaml
+```
 
 ---
 
@@ -751,7 +751,7 @@ concepts:          # Add this block
     - mean
   requires: []
 ---
-```bash
+```
 
 ### "yq not found"
 
@@ -765,7 +765,7 @@ brew install yq
 
 # Or verify with teach doctor
 teach doctor --fix
-```bash
+```
 
 ### Concept count mismatch
 
@@ -778,7 +778,7 @@ teach doctor --fix
 cat .teach/concepts.json | jq '.concepts | keys'
 
 # Look for duplicates or variations
-```bash
+```
 
 ### Prerequisites not detected
 
@@ -792,7 +792,7 @@ grep -r "introduces:" lectures/ | sort -u
 grep -r "requires:" lectures/ | sort -u
 
 # Compare for inconsistencies
-```bash
+```
 
 ### Cache not updating (Phase 2)
 
@@ -809,7 +809,7 @@ teach cache clear --analysis
 
 # Check cache stats
 teach analyze --stats
-```bash
+```
 
 ### Report generation fails (Phase 2)
 
@@ -826,7 +826,7 @@ teach analyze --report analysis.md
 
 # Check if concepts.json exists
 ls -la .teach/concepts.json
-```bash
+```
 
 ### Interactive mode not responding (Phase 2)
 
@@ -840,7 +840,7 @@ teach analyze --verbose
 
 # Or ensure you're in a proper terminal
 echo $TERM  # Should show xterm-256color or similar
-```bash
+```
 
 ### Deploy blocked unexpectedly (Phase 2)
 
@@ -857,7 +857,7 @@ teach analyze --interactive
 
 # Or override (not recommended)
 teach deploy --force
-```bash
+```
 
 ---
 
@@ -874,7 +874,7 @@ teach quiz "Week 3 Check" --concepts-from-week 3
 
 # Validate that exam covers prerequisites
 teach validate --exam exams/midterm1.md --concepts
-```diff
+```
 
 ---
 
@@ -988,7 +988,7 @@ teach analyze --ai --costs lectures/week-05-regression.qmd
 
 # View cumulative AI costs
 teach analyze --costs
-```text
+```
 
 ### What AI Analysis Provides
 
@@ -1008,7 +1008,7 @@ AI Analysis Costs:
   This session: $0.03 (2 analyses)
   Total tracked: $0.42 (28 analyses)
   Avg per analysis: $0.015
-```diff
+```
 
 ### Requirements
 
@@ -1030,7 +1030,7 @@ teach analyze --slide-breaks lectures/week-05-regression.qmd
 
 # Detailed preview of all suggested breaks
 teach analyze --preview-breaks lectures/week-05-regression.qmd
-```text
+```
 
 ### How It Works
 
@@ -1066,7 +1066,7 @@ The optimizer uses 4 heuristic rules to detect where slides need breaks:
 ├──────────────────────────────────────────────────────┤
 │ Phase: 4 (slide-optimized)                            │
 └──────────────────────────────────────────────────────┘
-```diff
+```
 
 ### Key Concept Detection
 
@@ -1100,7 +1100,7 @@ teach slides --apply-suggestions lectures/week-05-regression.qmd
 
 # Show key concepts for callout boxes
 teach slides --key-concepts lectures/week-05-regression.qmd
-```diff
+```
 
 ### Caching
 
@@ -1130,7 +1130,7 @@ Examples:
   teach analyze --interactive
 
 Run 'teach analyze --help' for full documentation.
-```text
+```
 
 When a file is not found, alternatives are suggested:
 
@@ -1141,7 +1141,7 @@ Available .qmd files in lectures/:
   lectures/week-01-foundations.qmd
   lectures/week-02-building.qmd
   lectures/week-03-applications.qmd
-```text
+```
 
 ### Extension Validation
 
@@ -1150,7 +1150,7 @@ Non-.qmd files trigger a warning:
 ```text
 Warning: Expected .qmd or .md file, got .txt
 Analysis works best with Quarto (.qmd) files containing YAML frontmatter.
-```text
+```
 
 ### Dependency Checks
 
@@ -1161,7 +1161,7 @@ Warning: jq not installed - some features unavailable
   Install: brew install jq
 Warning: yq not installed - prerequisite checking limited
   Install: brew install yq
-```diff
+```
 
 ---
 

--- a/docs/guides/LINT-GUIDE.md
+++ b/docs/guides/LINT-GUIDE.md
@@ -62,14 +62,14 @@ The lint validator is included in flow-cli v5.24.0+.
 
 ```bash
 teach validate --help | grep lint
-```text
+```
 
 **Expected output:**
 
 ```text
   --lint              Run Quarto-aware lint rules
   --quick-checks      Run fast lint subset only (Phase 1 rules)
-```bash
+```
 
 ### First Lint Run
 
@@ -77,13 +77,13 @@ teach validate --help | grep lint
 
 ```bash
 cd ~/projects/teaching/stat-545
-```text
+```
 
 **2. Run lint on a single file:**
 
 ```bash
 teach validate --lint slides/week-01.qmd
-```text
+```
 
 **3. Interpret results:**
 
@@ -93,19 +93,19 @@ teach validate --lint slides/week-01.qmd
     ✗ Line 45: LINT_CODE_LANG_TAG: Fenced code block without language tag
     ✗ Line 78: LINT_HEADING_HIERARCHY: Heading level skip (h1 -> h3)
   ✗ 2 errors found
-```bash
+```
 
 **4. Fix issues and re-run:**
 
 ```bash
 # After fixing
 teach validate --lint slides/week-01.qmd
-```text
+```
 
 ```text
 → lint-shared (v1.0.0)
   ✓ All files passed
-```diff
+```
 
 ---
 
@@ -123,37 +123,37 @@ teach validate --lint slides/week-01.qmd
 #### ❌ Invalid
 
 ```markdown
-```text
+```
 
 x <- 1 + 1
 mean(x)
 
 ```text
-```text
+```
 
 **Error:**
 
 ```text
 Line 5: LINT_CODE_LANG_TAG: Fenced code block without language tag
-```text
+```
 
 #### ✅ Valid
 
 ```markdown
-```{r}
+```
 x <- 1 + 1
 mean(x)
 ```text
 
-```python
+```
 print("Hello, World!")
 ```text
 
-```text
+```
 This is plain text output
 ```text
 
-```diff
+```
 
 #### Common Language Tags
 
@@ -185,13 +185,13 @@ This note is opened but never closed.
 ## Next Section
 
 Content here...
-```text
+```
 
 **Error:**
 
 ```text
 Line 1: LINT_DIV_BALANCE: Unclosed fenced div (:::)
-```text
+```
 
 #### ✅ Valid
 
@@ -205,7 +205,7 @@ This note is properly closed.
 ::: {.column-margin}
 Margin content
 :::
-```text
+```
 
 #### Common Div Types
 
@@ -215,7 +215,7 @@ Margin content
 ::: {.panel-tabset}      # Tab panels
 ::: {.incremental}       # Slide increments
 ::: {.fragment}          # Reveal.js fragments
-```diff
+```
 
 ---
 
@@ -236,7 +236,7 @@ Margin content
 ::: {.callout-important}   # Yellow, key points
 ::: {.callout-warning}     # Orange, caution
 ::: {.callout-caution}     # Red, danger/critical
-```text
+```
 
 #### ❌ Invalid
 
@@ -248,14 +248,14 @@ This will render as an unstyled div.
 ::: {.callout-danger}
 Not a valid Quarto callout type.
 :::
-```text
+```
 
 **Error:**
 
 ```text
 Line 1: LINT_CALLOUT_VALID: Unknown callout type '.callout-info'
         (valid: note, tip, important, warning, caution)
-```text
+```
 
 #### ✅ Valid
 
@@ -268,7 +268,7 @@ This renders with blue styling.
 ::: {.callout-warning}
 Be careful with this approach.
 :::
-```diff
+```
 
 #### Visual Reference
 
@@ -301,14 +301,14 @@ Be careful with this approach.
 Content here...
 
 ##### Detail (skipped h3 and h4!)
-```text
+```
 
 **Errors:**
 
 ```text
 Line 3: LINT_HEADING_HIERARCHY: Heading level skip (h1 -> h3)
 Line 7: LINT_HEADING_HIERARCHY: Heading level skip (h3 -> h5)
-```bash
+```
 
 #### ✅ Valid
 
@@ -324,7 +324,7 @@ Line 7: LINT_HEADING_HIERARCHY: Heading level skip (h3 -> h5)
 ## Another Section (reset to h2 is fine)
 
 # New Topic (reset to h1 is fine)
-```diff
+```
 
 #### Heading Reset Rules
 
@@ -357,7 +357,7 @@ fi
 EOF
 
 chmod +x .git/hooks/pre-commit
-```bash
+```
 
 **Usage:**
 
@@ -370,7 +370,7 @@ git commit -m "Update slides"
 #   → lint-shared (v1.0.0)
 #     slides/week-01.qmd:
 #       ✗ Line 45: LINT_CODE_LANG_TAG: ...
-```text
+```
 
 **Note:** Lint warnings don't block commits (warn-only mode).
 
@@ -384,19 +384,19 @@ git commit -m "Update slides"
 
 ```bash
 teach validate --lint lectures/*.qmd slides/*.qmd labs/*.qmd
-```text
+```
 
 **Save output:**
 
 ```bash
 teach validate --lint **/*.qmd > lint-report.txt 2>&1
-```bash
+```
 
 **Count issues:**
 
 ```bash
 teach validate --lint **/*.qmd 2>&1 | grep "✗ Line" | wc -l
-```yaml
+```
 
 ---
 
@@ -430,7 +430,7 @@ jobs:
       run: |
         teach validate --lint --quick-checks
       continue-on-error: true  # Don't fail build on warnings
-```bash
+```
 
 ---
 
@@ -448,13 +448,13 @@ while true; do
     teach validate --lint --quiet "$1"
     sleep 5
 done
-```bash
+```
 
 **Usage:**
 
 ```bash
 ./watch-lint.sh slides/week-01.qmd
-```bash
+```
 
 ---
 
@@ -467,7 +467,7 @@ Lint before rendering:
 ```bash
 # Check first
 teach validate --lint slides/week-01.qmd && quarto preview
-```text
+```
 
 ### VS Code
 
@@ -489,7 +489,7 @@ Add task (`.vscode/tasks.json`):
     }
   ]
 }
-```bash
+```
 
 **Run:** Cmd+Shift+P → "Tasks: Run Task" → "Lint Quarto"
 
@@ -510,7 +510,7 @@ cp ~/.local/share/flow-cli/validators/lint-shared.zsh .teach/validators/
 
 # Or if using Homebrew
 cp $(brew --prefix flow-cli)/share/validators/lint-shared.zsh .teach/validators/
-```bash
+```
 
 ---
 
@@ -526,7 +526,7 @@ teach validate file.qmd
 
 # ✅ Correct (runs lint)
 teach validate --lint file.qmd
-```bash
+```
 
 ---
 
@@ -541,20 +541,20 @@ teach validate --lint file.qmd
 ```bash
 # Fix new files only
 teach validate --lint $(git diff --name-only main | grep '\.qmd$')
-```bash
+```
 
 **2. Suppress specific rules:**
 
 ```bash
 # (Phase 2 feature - not yet available)
 teach validate --lint --ignore LINT_HEADING_HIERARCHY file.qmd
-```text
+```
 
 **3. Use quiet mode:**
 
 ```bash
 teach validate --lint --quiet file.qmd
-```bash
+```
 
 ---
 
@@ -565,7 +565,7 @@ teach validate --lint --quiet file.qmd
 ```bash
 # Check file count
 teach validate --lint --stats
-```bash
+```
 
 **Solutions:**
 
@@ -599,7 +599,7 @@ Don't try to fix all legacy files at once:
 ```bash
 # Lint only files changed in current branch
 git diff --name-only main | grep '\.qmd$' | xargs teach validate --lint
-```bash
+```
 
 ### 2. Fix Before Commit
 
@@ -610,7 +610,7 @@ Add to your git workflow:
 git add slides/week-01.qmd
 teach validate --lint slides/week-01.qmd  # Check first
 git commit -m "Update slides"
-```bash
+```
 
 ### 3. Document Exceptions
 
@@ -623,7 +623,7 @@ If you must violate a rule (rare), document why:
 # Main Title
 
 ### Subtitle (intentional skip for visual hierarchy)
-```bash
+```
 
 ### 4. Use Pre-commit Hooks
 

--- a/docs/guides/LINT-MIGRATION-GUIDE.md
+++ b/docs/guides/LINT-MIGRATION-GUIDE.md
@@ -51,7 +51,7 @@ teach validate --lint lectures/week-01-intro.qmd
 
 # 6. (Optional) Run on all lecture files
 teach validate --lint lectures/*.qmd
-```text
+```
 
 **Expected output:**
 
@@ -66,7 +66,7 @@ teach validate --lint lectures/*.qmd
   ✅ DIV_BALANCE: All divs balanced (8 pairs)
   ✅ CALLOUT_VALID: All callouts valid (5 callouts)
   ✅ HEADING_HIERARCHY: Sequential hierarchy (6 headings)
-```text
+```
 
 Or if issues are found:
 
@@ -83,7 +83,7 @@ Or if issues are found:
 
   ❌ DIV_BALANCE: 1 unclosed div
      Line 92: Unclosed div (add closing :::)
-```zsh
+```
 
 ---
 
@@ -104,7 +104,7 @@ npm update -g @data-wise/flow-cli
 cd ~/projects/dev-tools/flow-cli
 git pull origin main
 source flow.plugin.zsh
-```bash
+```
 
 **Verify your environment:**
 
@@ -118,7 +118,7 @@ ls .teach/
 
 # Test lint command
 teach validate --lint --help
-```bash
+```
 
 **No additional setup needed** - lint validators are built into flow-cli.
 
@@ -135,14 +135,14 @@ teach init --with-validators
 # .teach/config.yml          # Course configuration
 # .teach/validators/         # Validator directory (future custom validators)
 # .teach/hooks/              # Git hooks (optional)
-```bash
+```
 
 **Verify setup:**
 
 ```bash
 teach validate --lint lectures/week-01.qmd
 # Should work immediately on any .qmd file
-```bash
+```
 
 ### Troubleshooting Install Issues
 
@@ -158,7 +158,7 @@ which teach
 
 # Solution 3: Reinstall
 brew reinstall flow-cli
-```bash
+```
 
 **Issue:** Version shows v5.23.0 or earlier
 
@@ -169,7 +169,7 @@ brew upgrade --fetch-HEAD flow-cli
 # Or clean install
 brew uninstall flow-cli
 brew install data-wise/tap/flow-cli
-```text
+```
 
 ---
 
@@ -190,7 +190,7 @@ Each rule catches a specific class of errors. Here's what they mean and how to f
 ```qmd
 Here's some R code:
 
-```text
+```
 
 x <- rnorm(100)
 mean(x)
@@ -198,28 +198,28 @@ mean(x)
 ```text
 
 **Problem:** Quarto doesn't know this is R code → no syntax highlighting, no execution.
-```text
+```
 
 ✅ **Good: Tagged code block**
 
 ```qmd
 Here's some R code:
 
-```{r}
+```
 x <- rnorm(100)
 mean(x)
 ```text
 
 **Works:** Quarto recognizes R → highlights syntax, executes code.
 
-```text
+```
 
 ✅ **Alternative: Non-executable text**
 
 ```qmd
 Here's pseudocode:
 
-```{.text}
+```
 FOR i = 1 to 100
   PRINT i
 END
@@ -227,7 +227,7 @@ END
 
 **Works:** Tagged as text → renders as preformatted block.
 
-```text
+```
 
 #### Common Tags
 
@@ -255,7 +255,7 @@ This is important information.
 <!-- Missing closing ::: -->
 
 Next section starts here.
-```text
+```
 
 **Problem:** "Next section" gets swallowed into the callout div.
 
@@ -267,7 +267,7 @@ This is important information.
 :::
 
 Next section starts here.
-```text
+```
 
 ❌ **Bad: Nested divs closed in wrong order**
 
@@ -277,7 +277,7 @@ Next section starts here.
 Nested content
 ::: <!-- Closes column-page, not callout! -->
 :::
-```text
+```
 
 ✅ **Good: Proper nesting**
 
@@ -287,7 +287,7 @@ Nested content
 Nested content
 ::: <!-- Closes callout-tip -->
 ::: <!-- Closes column-page -->
-```text
+```
 
 **Tip:** Match divs like parentheses - inner closes before outer.
 
@@ -318,7 +318,7 @@ Quarto supports exactly 5 callout types:
 <!-- 'info' is not a standard Quarto callout -->
 This won't be styled correctly.
 :::
-```text
+```
 
 ✅ **Good: Valid callout type**
 
@@ -327,7 +327,7 @@ This won't be styled correctly.
 <!-- 'note' is a standard type -->
 This renders with proper styling.
 :::
-```diff
+```
 
 **Common mistakes:**
 
@@ -349,7 +349,7 @@ This renders with proper styling.
 # Week 1: Introduction
 ### Subsection A (skipped ##)
 #### Detail
-```bash
+```
 
 **Problem:** Jump from H1 → H3 breaks document outline.
 
@@ -360,14 +360,14 @@ This renders with proper styling.
 ## Section A
 ### Subsection A
 #### Detail
-```bash
+```
 
 ❌ **Bad: Multiple H1s in same file**
 
 ```qmd
 # Week 1: Introduction
 # Week 2: Foundations (should be ##)
-```bash
+```
 
 **Problem:** Multiple top-level headings fragment document structure.
 
@@ -377,7 +377,7 @@ This renders with proper styling.
 # Week 1 & 2: Foundations
 ## Week 1: Introduction
 ## Week 2: Core Concepts
-```bash
+```
 
 **Tip:** Reserve `#` (H1) for document title, use `##` (H2) for main sections.
 
@@ -403,7 +403,7 @@ grep -n "^\`\`\`$" lectures/*.qmd
 # lectures/week-01.qmd:48:```
 # lectures/week-02.qmd:23:```
 # ...
-```bash
+```
 
 **Fix Strategy A: Bulk tag as R code**
 
@@ -416,7 +416,7 @@ sed -n 's/^```$/```{r}/p' lectures/week-01.qmd
 
 # Apply changes
 sed -i '' 's/^```$/```{r}/' lectures/week-01.qmd
-```bash
+```
 
 **Fix Strategy B: Manual review (recommended)**
 
@@ -427,7 +427,7 @@ teach validate --lint lectures/week-01.qmd
 # Open file, jump to line number
 vim +45 lectures/week-01.qmd
 # Or use your preferred editor
-```diff
+```
 
 Then tag appropriately:
 
@@ -449,14 +449,14 @@ teach validate --lint lectures/week-03.qmd
 # Output:
 # ❌ DIV_BALANCE: 1 unclosed div
 #    Line 92: Unclosed div (add closing :::)
-```bash
+```
 
 **Fix:**
 
 ```bash
 # Open at line 92
 vim +92 lectures/week-03.qmd
-```text
+```
 
 Use your editor's bracket matching (if supported) or manually count:
 
@@ -464,7 +464,7 @@ Use your editor's bracket matching (if supported) or manually count:
 ::: {.callout-note}  # Line 92: Opener
 Content here.
 <!-- Add closing ::: -->
-```bash
+```
 
 **Count trick:**
 
@@ -474,7 +474,7 @@ grep -c "^:::" lectures/week-03.qmd  # Total ::: lines
 grep -c "^::: {" lectures/week-03.qmd  # Openers only
 
 # Should be equal or 2x (if closers are also :::)
-```bash
+```
 
 ### Pattern 3: Custom Callout Types
 
@@ -493,7 +493,7 @@ sed -i '' 's/\.callout-info/.callout-note/g' lectures/*.qmd
 
 # Convert .callout-success → .callout-tip
 sed -i '' 's/\.callout-success/.callout-tip/g' lectures/*.qmd
-```bash
+```
 
 #### Option B: Disable LINT_CALLOUT_VALID (Not Recommended)
 
@@ -503,7 +503,7 @@ If you have custom Quarto extensions that define additional callout types:
 # Skip callout validation for specific files
 teach validate --lint --validators lint-shared lectures/week-custom.qmd
 # (Future: custom validator configs)
-```bash
+```
 
 **Trade-off:** Disabling the rule means you won't catch typos like `.callout-notte`.
 
@@ -519,7 +519,7 @@ teach validate --lint lectures/week-05.qmd
 # Output:
 # ❌ HEADING_HIERARCHY: Skipped heading level
 #    Line 34: H3 follows H1 (expected H2)
-```bash
+```
 
 **Fix:** Restructure headings sequentially:
 
@@ -533,14 +533,14 @@ teach validate --lint lectures/week-05.qmd
 # Week 5: Regression
 ## Model Assumptions
 ## Diagnostics
-```bash
+```
 
 **Mass fix strategy:**
 
 ```bash
 # Downgrade all H3 → H2 (review first!)
 sed -i '' 's/^### /## /' lectures/week-05.qmd
-```bash
+```
 
 ---
 
@@ -559,7 +559,7 @@ teach validate --lint lectures/week-*.qmd
 
 # All .qmd files recursively
 teach validate --lint **/*.qmd
-```bash
+```
 
 ### Quiet Mode (For CI/CD)
 
@@ -569,7 +569,7 @@ teach validate --lint --quiet lectures/week-01.qmd
 
 # Exit code 0 = pass, non-zero = violations found
 echo $?
-```bash
+```
 
 **Use case:** GitHub Actions, pre-commit hooks that need pass/fail only.
 
@@ -580,7 +580,7 @@ echo $?
 teach validate --lint --quick-checks lectures/week-01.qmd
 
 # Alias for: --validators lint-shared
-```bash
+```
 
 **Performance:** ~50% faster on large files, runs core lint rules only.
 
@@ -589,7 +589,7 @@ teach validate --lint --quick-checks lectures/week-01.qmd
 ```bash
 # Coming in v5.25.0: Specify validator plugins
 teach validate --validators lint-shared,lint-slides lectures/slides.qmd
-```diff
+```
 
 **Planned validators:**
 
@@ -641,7 +641,7 @@ chmod +x .teach/hooks/pre-commit
 
 # 4. Link to git hooks
 ln -sf ../../.teach/hooks/pre-commit .git/hooks/pre-commit
-```bash
+```
 
 **Usage:** Violations display as warnings but never block your commit.
 
@@ -682,7 +682,7 @@ jobs:
       - name: Run lint on labs
         run: |
           teach validate --lint labs/*.qmd
-```bash
+```
 
 **Result:** PR checks show pass/fail status, blocking merge if violations found.
 
@@ -698,7 +698,7 @@ teach validate --lint --watch
 # 👀 Watching lectures/*.qmd for changes...
 # 🔄 week-01.qmd changed → running lint...
 # ✅ No violations found
-```bash
+```
 
 **Use case:** Keep lint check running in terminal while editing in IDE.
 
@@ -738,7 +738,7 @@ teach validate --lint lectures/*.qmd labs/*.qmd
 git add -A
 git commit -m "chore: fix all lint violations for v5.24.0"
 git push
-```bash
+```
 
 **Pros:** Done immediately, clean slate going forward.
 
@@ -772,7 +772,7 @@ teach validate --lint lectures/week-05-regression.qmd
 git add lectures/week-05-regression.qmd
 git commit -m "feat(week-05): update regression examples + fix lint"
 git push
-```bash
+```
 
 **Pros:** Low friction, spreads work across semester, no dedicated time block.
 
@@ -803,7 +803,7 @@ git mv lectures/old-* _archive/
 
 # 5. Add .gitignore exception (optional)
 echo "_archive/*.qmd" >> .gitignore
-```text
+```
 
 **Pros:** Focuses effort on content students actually see.
 
@@ -821,14 +821,14 @@ Common issues and solutions during migration.
 
 ```qmd
 Use the `mean()` function to calculate averages.
-```bash
+```
 
 **Diagnosis:**
 
 ```bash
 teach validate --lint lectures/week-01.qmd
 # ❌ CODE_LANG_TAG: Bare code block at line 23
-```bash
+```
 
 **Solution:** The lint rule only checks fenced blocks (3+ backticks). Inline code (1 backtick) is ignored.
 
@@ -837,7 +837,7 @@ teach validate --lint lectures/week-01.qmd
 ```bash
 # Jump to reported line
 vim +23 lectures/week-01.qmd
-```text
+```
 
 **Issue:** Nested divs confuse balance checker
 
@@ -849,14 +849,14 @@ Content
 ::: <!-- Closes fragment -->
 ::: <!-- Closes callout -->
 ::: <!-- Closes column-page -->
-```bash
+```
 
 **Diagnosis:**
 
 ```bash
 teach validate --lint lectures/week-02.qmd
 # ❌ DIV_BALANCE: Unbalanced divs (3 openers, 2 closers)
-```bash
+```
 
 **Solution:** Ensure proper nesting. Inner divs must close before outer divs.
 
@@ -873,7 +873,7 @@ grep -n "^:::" lectures/week-02.qmd
 # 40: :::  # Closes fragment
 # 41: :::  # Closes callout
 # 42: :::  # Closes column-page
-```bash
+```
 
 ### Performance Issues
 
@@ -884,14 +884,14 @@ grep -n "^:::" lectures/week-02.qmd
 ```bash
 time teach validate --lint lectures/week-10-massive.qmd
 # real    0m15.432s  (too slow!)
-```bash
+```
 
 **Solution 1: Use quick checks**
 
 ```bash
 teach validate --lint --quick-checks lectures/week-10-massive.qmd
 # Runs core lint rules only, ~50% faster
-```text
+```
 
 **Solution 2: Split large files**
 
@@ -900,7 +900,7 @@ teach validate --lint --quick-checks lectures/week-10-massive.qmd
 week-10-part1-theory.qmd
 week-10-part2-examples.qmd
 week-10-part3-lab.qmd
-```bash
+```
 
 **Solution 3: Skip lint for specific files (not recommended)**
 
@@ -908,7 +908,7 @@ week-10-part3-lab.qmd
 # Validate YAML/syntax only, skip lint
 teach validate lectures/week-10-massive.qmd
 # (No --lint flag)
-```bash
+```
 
 ### Validator Conflicts
 
@@ -917,7 +917,7 @@ teach validate lectures/week-10-massive.qmd
 ```bash
 teach validate --validators lint-shared,my-custom lectures/week-01.qmd
 # Error: Validator 'my-custom' not found
-```bash
+```
 
 **Diagnosis:**
 
@@ -925,7 +925,7 @@ teach validate --validators lint-shared,my-custom lectures/week-01.qmd
 # Check validator directory
 ls .teach/validators/
 # Expected: lint-shared/ (built-in), my-custom/ (if custom)
-```bash
+```
 
 **Solution:** Custom validators are a future feature (v5.25.0). For now, use built-in validators only:
 
@@ -933,7 +933,7 @@ ls .teach/validators/
 # Correct usage (v5.24.0)
 teach validate --lint lectures/week-01.qmd
 # Uses built-in lint-shared validator
-```bash
+```
 
 ---
 
@@ -963,7 +963,7 @@ teach validate --lint lectures/*.qmd labs/*.qmd
 # - 3 unbalanced divs (copy-paste errors)
 # - 2 invalid callouts (.callout-info → .callout-note)
 # - 0 heading hierarchy issues
-```bash
+```
 
 **Fixes:**
 
@@ -980,7 +980,7 @@ vim +201 labs/lab-07.qmd
 
 # 3. Fixed invalid callouts
 sed -i '' 's/\.callout-info/.callout-note/g' lectures/*.qmd
-```bash
+```
 
 **Outcome:**
 
@@ -991,7 +991,7 @@ teach validate --lint lectures/*.qmd labs/*.qmd
 # Results:
 # ✅ All checks pass (85/85 files)
 # Total time: 52 minutes
-```bash
+```
 
 ### stat-579 Migration (Iowa State University)
 
@@ -1009,7 +1009,7 @@ teach validate --lint lectures/*.qmd labs/*.qmd
 # - Updated week 1-3 lectures → fixed 4 violations
 # - Created new week 4 lab → 0 violations (wrote clean)
 # - Reviewed old exams → skipped (archived content)
-```diff
+```
 
 **Findings:**
 
@@ -1036,7 +1036,7 @@ teach validate lectures/week-01-intro.qmd
 # ❌ Render failed
 #    Error: Div not closed (line 92)
 #    (Spent 15 minutes debugging render error)
-```bash
+```
 
 **After lint adoption:**
 
@@ -1107,7 +1107,7 @@ After completing your migration:
   This course uses flow-cli v5.24.0 lint validation to ensure high-quality materials.
 
   Before committing .qmd files:
-  ```bash
+  ```
   teach validate --lint <file>
   ```
   ````

--- a/docs/guides/MERMAID-DIAGRAMS-QUICK-START.md
+++ b/docs/guides/MERMAID-DIAGRAMS-QUICK-START.md
@@ -126,7 +126,7 @@ flowchart TD
 
     style Start fill:#4CAF50,stroke:#2E7D32,color:#fff
     style End fill:#4CAF50,stroke:#2E7D32,color:#fff
-```text
+```
 
 ---
 
@@ -140,7 +140,7 @@ graph TD
 
     style ResultA fill:#FFC107,stroke:#F57C00,color:#000
     style ResultB fill:#FFC107,stroke:#F57C00,color:#000
-```bash
+```
 
 ---
 
@@ -152,7 +152,7 @@ stateDiagram-v2
     StateA --> StateB : event
     StateB --> StateC : event
     StateC --> [*]
-```text
+```
 
 ---
 
@@ -165,13 +165,13 @@ Decision/Choice:#FFC107 (Yellow)
 Error/Block:    #F44336 (Red)
 Info/Reference: #9C27B0 (Purple)
 Neutral/End:    #757575 (Gray)
-```text
+```
 
 **Usage:**
 
 ```mermaid
 style NodeName fill:#4CAF50,stroke:#2E7D32,color:#fff
-```bash
+```
 
 ---
 
@@ -182,7 +182,7 @@ style NodeName fill:#4CAF50,stroke:#2E7D32,color:#fff
 ```bash
 # Check mkdocs.yml for:
 cat mkdocs.yml | grep -A 5 "superfences"
-```yaml
+```
 
 **Should see:**
 

--- a/docs/guides/MONOREPO-COMMANDS-TUTORIAL.md
+++ b/docs/guides/MONOREPO-COMMANDS-TUTORIAL.md
@@ -29,7 +29,7 @@ Think of your project like a house:
 
 ```text
 🏠 One house = One project
-```text
+```
 
 **Monorepo (this project):**
 
@@ -37,7 +37,7 @@ Think of your project like a house:
 🏘️ One neighborhood = Multiple projects living together
    ├── 🏠 App house (desktop application)
    └── 🏠 CLI house (command-line tools)
-```bash
+```
 
 ### Why Does This Matter?
 
@@ -56,7 +56,7 @@ All commands follow this simple pattern:
 
 ```bash
 npm run [action]:[workspace]
-```diff
+```
 
 **Breaking it down:**
 - `npm run` - "Hey npm, run a command"
@@ -70,7 +70,7 @@ npm run test:cli
      ↑     ↑    ↑
     npm   test  cli
   (tool) (what) (where)
-```yaml
+```
 
 Translation: "Use npm to test the CLI workspace"
 
@@ -88,14 +88,14 @@ Translation: "Use npm to test the CLI workspace"
 
 ```bash
 npm run dev
-```text
+```
 
 **Example output:**
 
 ```text
 > Starting Electron app...
 > App running on http://localhost:3000
-```bash
+```
 
 ---
 
@@ -107,7 +107,7 @@ npm run dev
 
 ```bash
 npm run dev:app
-```diff
+```
 
 **Why two commands?**
 - `dev` = shortcut (most people want the app)
@@ -123,7 +123,7 @@ npm run dev:app
 
 ```bash
 npm run dev:cli
-```text
+```
 
 **Example output:**
 
@@ -132,7 +132,7 @@ npm run dev:cli
   ZSH Workflow CLI - Status Tests
 ═══════════════════════════════════════════════
 ✅ All status tests passed!
-```bash
+```
 
 ---
 
@@ -146,7 +146,7 @@ npm run dev:cli
 
 ```bash
 npm test
-```bash
+```
 
 **What happens:**
 1. Tests the app (using Jest)
@@ -163,7 +163,7 @@ npm test
 
 ```bash
 npm run test:app
-```bash
+```
 
 ---
 
@@ -175,7 +175,7 @@ npm run test:app
 
 ```bash
 npm run test:cli
-```text
+```
 
 **Example output:**
 
@@ -183,7 +183,7 @@ npm run test:cli
 🧪 Testing Status Adapter...
 Test 1: Get Current Session ✅
 Test 2: Get Project Status ✅
-```bash
+```
 
 ---
 
@@ -197,7 +197,7 @@ Test 2: Get Project Status ✅
 
 ```bash
 npm run build
-```diff
+```
 
 **What happens:**
 - Takes your source code
@@ -213,7 +213,7 @@ npm run build
 
 ```bash
 npm run build:app
-```bash
+```
 
 ---
 
@@ -225,7 +225,7 @@ npm run build:app
 
 ```bash
 npm run build:all
-```diff
+```
 
 **Note:** Right now this only builds the app, but in the future if you add more workspaces, this will build them all.
 
@@ -245,7 +245,7 @@ npm run build:all
 
 ```bash
 npm run clean
-```bash
+```
 
 **⚠️ Warning:** This deletes files! You'll need to run `npm install` after.
 
@@ -261,7 +261,7 @@ npm run clean
 
 ```bash
 npm run reset
-```diff
+```
 
 **Use this when:**
 - Weird errors you can't explain
@@ -288,7 +288,7 @@ What do you want to do?
 │
 └─ 🔧 Fix weird errors
    └─ npm run reset
-```bash
+```
 
 ---
 
@@ -307,7 +307,7 @@ npm test
 
 # Step 3: Run the app
 npm run dev
-```bash
+```
 
 **Time:** 2-5 minutes (depending on internet speed)
 
@@ -327,7 +327,7 @@ npm run dev
 npm run test:app
 
 # Step 3: If all good, you're done!
-```bash
+```
 
 ---
 
@@ -346,7 +346,7 @@ npm run test:cli
 
 # Step 3: Test everything to make sure nothing broke
 npm test
-```bash
+```
 
 ---
 
@@ -362,7 +362,7 @@ npm run reset
 
 # Test that it works now
 npm test
-```diff
+```
 
 **Common reasons you'd do this:**
 - "Module not found" errors
@@ -385,7 +385,7 @@ npm run build:all
 
 # Step 3: Find your built app
 ls app/dist/
-```diff
+```
 
 **Result:** You'll have a `.dmg` file (Mac) or `.exe` (Windows) you can distribute
 
@@ -418,7 +418,7 @@ npm run test:cli
 
 # Did you see this?
 # ✅ All status tests passed!
-```bash
+```
 
 **✅ Success!** You just ran your first monorepo command!
 
@@ -435,7 +435,7 @@ npm run test:cli
 
 # 3. Test BOTH
 npm test
-```bash
+```
 
 **Notice:** The third command runs both of the first two!
 
@@ -446,7 +446,7 @@ npm test
 ```bash
 # See all available commands
 npm run
-```diff
+```
 
 **Look for:**
 - All the commands we learned
@@ -464,7 +464,7 @@ npm run testcli
 
 # ✅ Right
 npm run test:cli
-```bash
+```
 
 **Remember:** Action**:**workspace (with the colon!)
 
@@ -480,7 +480,7 @@ npm run dev:app  # Won't work!
 # ✅ Right (in root folder)
 cd /Users/dt/projects/dev-tools/flow-cli/
 npm run dev:app  # Works!
-```bash
+```
 
 **Remember:** Always run from the **root** of the project (where the main `package.json` is)
 
@@ -495,7 +495,7 @@ npm run dev     # Error: modules not found
 # ✅ Right order
 npm install     # Install first
 npm run dev     # Then run
-```diff
+```
 
 **Remember:** First time? Run `npm install` before anything else!
 
@@ -556,7 +556,7 @@ Congratulations! You now know:
 # One big test command
 npm test
 # Tests EVERYTHING (slow!)
-```bash
+```
 
 **Workspace approach:**
 
@@ -565,7 +565,7 @@ npm test
 npm run test:cli   # Fast! Only CLI
 npm run test:app   # Fast! Only app
 npm test           # Slow but thorough
-```bash
+```
 
 **Benefit:** Faster feedback while developing!
 
@@ -580,7 +580,7 @@ npm run dev:app   # Dev mode for app
 npm run dev:cli   # Dev mode for CLI
 npm run test:app  # Test app
 npm run test:cli  # Test CLI
-```diff
+```
 
 **Pattern recognition:** Your brain learns the pattern quickly!
 - First part = action (dev, test, build)
@@ -602,13 +602,13 @@ Sometimes `node_modules/` gets corrupted:
 ```bash
 npm run clean   # Delete everything
 npm install     # Fresh start
-```bash
+```
 
 **Shortcut:**
 
 ```bash
 npm run reset   # Does both!
-```diff
+```
 
 **When to use:**
 - After pulling big changes from git
@@ -636,7 +636,7 @@ npm run test:app  # or test:cli
 
 # 5. Something broken?
 npm run reset
-```bash
+```
 
 **That's it! You're ready to go! 🚀**
 
@@ -651,7 +651,7 @@ npm run reset
 ```bash
 # Just type this to see ALL commands
 npm run
-```diff
+```
 
 **Forget which workspace?**
 - `app` = Desktop application
@@ -668,7 +668,7 @@ npm run test:app   # Super fast
 
 # Full test when done
 npm test           # Comprehensive
-```text
+```
 
 ### Dopamine Hits
 

--- a/docs/guides/PLUGIN-MANAGEMENT-WORKFLOW.md
+++ b/docs/guides/PLUGIN-MANAGEMENT-WORKFLOW.md
@@ -27,14 +27,14 @@ flow plugin list
 # Show all discovered plugins (enabled + disabled)
 flow plugin list --all
 flow plugin list -a
-```text
+```
 
 **Output example:**
 
 ```text
 ✓ example-plugin   v1.0.0  Enabled
 ○ my-custom        v0.1.0  Disabled
-```bash
+```
 
 ---
 
@@ -49,7 +49,7 @@ flow plugin disable my-custom
 
 # Reload shell to apply changes
 exec zsh
-```text
+```
 
 **Note:** Reload required after enable/disable.
 
@@ -63,7 +63,7 @@ The easiest way to create a plugin:
 
 ```bash
 flow plugin create my-workflow
-```text
+```
 
 **Prompts:**
 
@@ -73,7 +73,7 @@ Created: ~/.config/flow/plugins/my-workflow/
   ├── main.zsh
   ├── plugin.json
   └── README.md
-```sql
+```
 
 ---
 
@@ -114,14 +114,14 @@ cat > plugin.json << 'EOF'
   "hooks": ["PreWork"]
 }
 EOF
-```text
+```
 
 **Reload shell:**
 
 ```bash
 exec zsh
 flow plugin list  # Should show your plugin
-```bash
+```
 
 ---
 
@@ -135,7 +135,7 @@ flow plugin install gh:username/flow-plugin-docker
 
 # Example: Install a workflow plugin
 flow plugin install gh:data-wise/flow-plugin-deploy
-```bash
+```
 
 **What happens:**
 1. Clones repo to `~/.config/flow/plugins/`
@@ -152,7 +152,7 @@ flow plugin install /path/to/my-plugin
 
 # Example: Install from Downloads
 flow plugin install ~/Downloads/team-workflow-plugin
-```bash
+```
 
 ---
 
@@ -163,7 +163,7 @@ For active development, symlink instead of copying:
 ```bash
 cd ~/projects/dev-tools/my-flow-plugin
 flow plugin install --dev .
-```diff
+```
 
 **Benefits:**
 - Changes reflect immediately (no reinstall)
@@ -179,7 +179,7 @@ flow plugin install --dev .
 ```bash
 flow plugin create my-awesome-tool
 cd ~/.config/flow/plugins/my-awesome-tool
-```bash
+```
 
 ---
 
@@ -208,7 +208,7 @@ my_deploy() {
 
   echo "✅ Deployed to $env"
 }
-```zsh
+```
 
 ---
 
@@ -228,7 +228,7 @@ _my_plugin_post_finish() {
     slack-cli send "#dev" "Session complete: $session_note"
   fi
 }
-```diff
+```
 
 **Available hooks:**
 - `PreWork` - Before starting work session
@@ -261,7 +261,7 @@ Edit `plugin.json`:
     "notify_slack": true
   }
 }
-```bash
+```
 
 ---
 
@@ -279,7 +279,7 @@ flow plugin info my-awesome-tool
 
 # View hooks
 flow plugin hooks
-```bash
+```
 
 ---
 
@@ -293,13 +293,13 @@ git init
 git add .
 git commit -m "Initial commit"
 gh repo create flow-plugin-my-awesome-tool --public --source=. --push
-```text
+```
 
 **Now others can install:**
 
 ```bash
 flow plugin install gh:yourusername/flow-plugin-my-awesome-tool
-```bash
+```
 
 ---
 
@@ -314,7 +314,7 @@ tar -czf my-awesome-tool.tar.gz my-awesome-tool/
 # Others extract and install:
 tar -xzf my-awesome-tool.tar.gz
 flow plugin install ./my-awesome-tool
-```bash
+```
 
 ---
 
@@ -352,7 +352,7 @@ py() {
       ;;
   esac
 }
-```bash
+```
 
 ---
 
@@ -389,7 +389,7 @@ deploy-all() {
 
   echo "✅ Deployment complete!"
 }
-```bash
+```
 
 ---
 
@@ -416,7 +416,7 @@ _notify_jira() {
     echo "📝 Updated JIRA ticket: $ticket"
   fi
 }
-```bash
+```
 
 ---
 
@@ -443,7 +443,7 @@ my_deploy() {
 # MY_PLUGIN_DEFAULT_ENV="production"
 # MY_PLUGIN_AWS_REGION="eu-west-1"
 # MY_PLUGIN_SLACK_WEBHOOK="https://hooks.slack.com/..."
-```bash
+```
 
 ---
 
@@ -460,7 +460,7 @@ flow plugin hooks
 
 # Show plugin search paths
 flow plugin path
-```bash
+```
 
 ---
 
@@ -475,7 +475,7 @@ flow plugin remove -f my-plugin
 
 # Note: Cannot remove bundled plugins, only disable them
 flow plugin disable bundled-plugin
-```diff
+```
 
 ---
 
@@ -500,7 +500,7 @@ flow plugin disable bundled-plugin
 │   │   └── helpers.zsh
 │   └── completions/      # ZSH completions
 │       └── _my_command
-```bash
+```
 
 ---
 
@@ -529,7 +529,7 @@ exec zsh
 
 # Check for errors
 zsh -x ~/.config/flow/plugins/my-plugin/main.zsh
-```bash
+```
 
 ---
 
@@ -549,7 +549,7 @@ flow plugin hooks
 grep "flow_hook_register" ~/.config/flow/plugins/my-plugin/main.zsh
 
 # Correct event names: PreWork, PostWork, PreFinish, PostFinish
-```bash
+```
 
 ---
 
@@ -568,7 +568,7 @@ grep "flow_hook_register" ~/.config/flow/plugins/my-plugin/main.zsh
 
 # Or namespace with underscore
 # Good: _my_plugin_deploy()
-```zsh
+```
 
 ---
 
@@ -582,7 +582,7 @@ grep "flow_hook_register" ~/.config/flow/plugins/my-plugin/main.zsh
 # Avoid conflicts
 _myplugin_helper() { ... }
 myplugin_command() { ... }
-```zsh
+```
 
 **2. Clean up on disable**
 
@@ -592,7 +592,7 @@ _myplugin_cleanup() {
   unset -f myplugin_command
   unset MY_PLUGIN_VAR
 }
-```bash
+```
 
 **3. Document your plugin**
 
@@ -602,7 +602,7 @@ _myplugin_cleanup() {
 # - How to use it
 # - Configuration options
 # - Examples
-```text
+```
 
 **4. Version your plugin**
 
@@ -614,7 +614,7 @@ _myplugin_cleanup() {
     "1.1.0": "Improved performance"
   }
 }
-```zsh
+```
 
 ---
 
@@ -632,7 +632,7 @@ my_work_wrapper() {
   work "$@"
   # Custom post-work logic
 }
-```bash
+```
 
 **2. Don't block the shell**
 
@@ -645,7 +645,7 @@ done
 
 # ✅ Good: Background processes or one-shot
 (check_status &)
-```bash
+```
 
 **3. Don't assume dependencies**
 
@@ -659,7 +659,7 @@ if command -v docker >/dev/null 2>&1; then
 else
   echo "Docker not installed"
 fi
-```bash
+```
 
 ---
 
@@ -694,7 +694,7 @@ aws_deploy() {
 
   echo "✅ Deployed! https://my-app-$env.example.com"
 }
-```bash
+```
 
 ---
 
@@ -729,7 +729,7 @@ _slack_notify_finish() {
 }
 
 # Config: export SLACK_WEBHOOK="https://hooks.slack.com/..."
-```bash
+```
 
 ---
 

--- a/docs/guides/PROJECT-SCOPE.md
+++ b/docs/guides/PROJECT-SCOPE.md
@@ -58,7 +58,7 @@ Tracks, persists, and restores workflow state across sessions and projects.
    - Show last context (what you were doing)
    - Display next actions from .STATUS
    - Ready to work in <30 seconds
-```diff
+```
 
 **Integration:**
 - Uses **vendored functions** from zsh-claude-workflow (~300 lines ported)
@@ -99,7 +99,7 @@ Dev Tools (Active: 5, Archive: 3)
 
 Quick Wins Available: 7 tasks < 30 minutes
 Next Review: stat-440 (HW 5 due Friday)
-```diff
+```
 
 **Integration:**
 - Adapts **.STATUS parser** logic from apple-notes-sync
@@ -152,7 +152,7 @@ Medium Tasks (1-2 hours):
 Long Projects (> 4 hours):
   🏗️ probmed: Respond to all reviewer comments
   🏗️ obs-cli: Complete simplification phase
-```bash
+```
 
 ---
 
@@ -173,7 +173,7 @@ Fast fuzzy finder for switching between projects.
   🔧 flow-cli  Dev tool     Architecture design
 
 # Select → cd to project + show .STATUS
-```diff
+```
 
 **Features:**
 - Fuzzy search by name
@@ -210,7 +210,7 @@ Fast fuzzy finder for switching between projects.
 │ - aiterm (terminal context switching)                   │
 │ - apple-notes-sync (dashboard patterns)                 │
 └─────────────────────────────────────────────────────────┘
-```yaml
+```
 
 ---
 
@@ -426,7 +426,7 @@ Next actions:
   3. Update documentation
 
 [Ready to work in 20 seconds]
-```bash
+```
 
 ---
 
@@ -455,7 +455,7 @@ Next actions:
 
 Terminal profile: Teaching (yellow theme)
 [Switched in <30 seconds]
-```bash
+```
 
 ---
 
@@ -476,7 +476,7 @@ Quick Wins (< 30 min):
 
 > work rmediation
 # Knock out easy tasks, build momentum
-```yaml
+```
 
 ---
 
@@ -502,7 +502,7 @@ Recommendation:
   4. Update product-of-three analysis if API changed
 
 [Clear understanding of impact in <5 seconds]
-```yaml
+```
 
 ---
 
@@ -545,7 +545,7 @@ Personal Projects Overview (32 total)
   causal-inf    ● 2 days ago     P1  Lecture 14
 
 [Complete overview in <2 seconds]
-```diff
+```
 
 ---
 
@@ -578,7 +578,7 @@ Personal Projects Overview (32 total)
 │   └── dependencies.json         # Project relationships
 └── cache/
     └── last-scan.json            # Cached project scan results
-```yaml
+```
 
 ---
 
@@ -673,7 +673,7 @@ node --version         # Node.js 18+
 # Optional (enhanced features)
 ait --version          # aiterm (terminal context switching)
 fzf --version          # Fuzzy finder (project picker)
-```bash
+```
 
 **No external dependencies required!** flow-cli is standalone.
 
@@ -683,7 +683,7 @@ fzf --version          # Fuzzy finder (project picker)
 
 ```bash
 npm install -g flow-cli
-```bash
+```
 
 **From source (current):**
 

--- a/docs/guides/PROMPT-DISPATCHER-GUIDE.md
+++ b/docs/guides/PROMPT-DISPATCHER-GUIDE.md
@@ -13,7 +13,7 @@ prompt status        # See what's active
 prompt toggle        # Switch to another engine (interactive)
 prompt starship      # Force switch to Starship
 prompt list          # List all available engines
-```text
+```
 
 ## Quick Start
 
@@ -37,7 +37,7 @@ Prompt Engines:
     Config: ~/.config/ohmyposh/config.json
 
 To switch: prompt toggle
-```text
+```
 
 ### Switch Engines Interactively
 
@@ -50,7 +50,7 @@ Which prompt engine would you like to use?
 3) powerlevel10k
 #? 1
 ✅ Switched to Starship
-```text
+```
 
 ### Switch Directly
 
@@ -63,7 +63,7 @@ $ prompt p10k
 
 $ prompt ohmyposh
 ✅ Switched to Oh My Posh
-```text
+```
 
 ## Commands
 
@@ -73,7 +73,7 @@ Displays which engine is currently active and what alternatives are available.
 
 ```bash
 $ prompt status
-```diff
+```
 
 **Output:**
 - Current engine marked with `●` (bullet)
@@ -87,7 +87,7 @@ Shows a menu to select a different prompt engine. Best for comparing options.
 
 ```bash
 $ prompt toggle
-```diff
+```
 
 **Behavior:**
 - Shows all available engines except the current one
@@ -101,7 +101,7 @@ Force-switch to Starship without menu.
 
 ```bash
 $ prompt starship
-```diff
+```
 
 **Requirements:**
 - Starship binary installed (`brew install starship`)
@@ -114,7 +114,7 @@ $ prompt starship
 ❌ Starship not found in PATH
 
 Install with: brew install starship
-```text
+```
 
 ### `prompt p10k` - Switch to Powerlevel10k
 
@@ -122,7 +122,7 @@ Force-switch to Powerlevel10k without menu.
 
 ```bash
 $ prompt p10k
-```diff
+```
 
 **Requirements:**
 - Powerlevel10k plugin in `.zsh_plugins.txt`
@@ -134,7 +134,7 @@ Force-switch to Oh My Posh without menu.
 
 ```bash
 $ prompt ohmyposh
-```diff
+```
 
 **Requirements:**
 - Oh My Posh binary installed (`brew install oh-my-posh`)
@@ -156,7 +156,7 @@ Starship       ○          ~/.config/starship.toml
 Oh My Posh     ○          ~/.config/ohmyposh/config.json
 
 Legend: ● = current, ○ = available
-```text
+```
 
 ### `prompt setup-ohmyposh` - Configure Oh My Posh
 
@@ -164,7 +164,7 @@ Interactive wizard for setting up Oh My Posh for the first time.
 
 ```bash
 $ prompt setup-ohmyposh
-```bash
+```
 
 **What it does:**
 1. Checks if Oh My Posh is installed
@@ -183,7 +183,7 @@ oh-my-posh config
 
 # Switch to Oh My Posh
 prompt ohmyposh
-```text
+```
 
 ### `prompt help` - Show Help
 
@@ -191,7 +191,7 @@ Display complete command reference.
 
 ```bash
 $ prompt help
-```diff
+```
 
 Shows all subcommands, examples, and links to full documentation.
 
@@ -214,7 +214,7 @@ echo $FLOW_PROMPT_ENGINE
 
 # Override in .zshrc (before flow-cli loads)
 export FLOW_PROMPT_ENGINE="starship"
-```bash
+```
 
 ## Setup by Engine
 
@@ -230,26 +230,26 @@ romkatv/powerlevel10k
 
 # Load plugins
 antidote install
-```text
+```
 
 **2. Configure:**
 On first load, Powerlevel10k shows a configuration wizard. Or:
 
 ```bash
 p10k configure
-```text
+```
 
 **3. Verify:**
 
 ```bash
 prompt status
-```text
+```
 
 **4. Switch to it:**
 
 ```bash
 prompt p10k
-```bash
+```
 
 ### Starship
 
@@ -259,14 +259,14 @@ Starship is a minimal, language-agnostic prompt engine.
 
 ```bash
 brew install starship
-```bash
+```
 
 **2. Create basic config:**
 
 ```bash
 mkdir -p ~/.config
 starship config  # Validates existing config
-```text
+```
 
 Starship provides a default configuration if none exists.
 
@@ -274,13 +274,13 @@ Starship provides a default configuration if none exists.
 
 ```bash
 nano ~/.config/starship.toml
-```text
+```
 
 **4. Switch to it:**
 
 ```bash
 prompt starship
-```bash
+```
 
 ### Oh My Posh
 
@@ -290,13 +290,13 @@ Oh My Posh provides extensive themes and customization.
 
 ```bash
 brew install oh-my-posh
-```text
+```
 
 **2. Use setup wizard:**
 
 ```bash
 prompt setup-ohmyposh
-```text
+```
 
 This creates `~/.config/ohmyposh/config.json` with defaults.
 
@@ -305,13 +305,13 @@ This creates `~/.config/ohmyposh/config.json` with defaults.
 ```bash
 nano ~/.config/ohmyposh/config.json
 oh-my-posh config  # Validate
-```text
+```
 
 **4. Switch to it:**
 
 ```bash
 prompt ohmyposh
-```text
+```
 
 ## Troubleshooting
 
@@ -322,7 +322,7 @@ Example:
 ```text
 ❌ Starship not found in PATH
 Install with: brew install starship
-```bash
+```
 
 **Solution:**
 
@@ -330,7 +330,7 @@ Install with: brew install starship
 brew install starship
 # Restart shell
 exec zsh
-```text
+```
 
 ### "Config missing"
 
@@ -338,14 +338,14 @@ Example:
 
 ```text
 ⚠️  OhMyPosh config missing at ~/.config/ohmyposh/config.json
-```bash
+```
 
 **Solution:**
 
 ```bash
 prompt setup-ohmyposh
 # Or manually create the config
-```bash
+```
 
 ### Prompt doesn't change after switching
 
@@ -358,7 +358,7 @@ prompt setup-ohmyposh
 ```bash
 # Reload shell manually
 exec zsh -i
-```bash
+```
 
 ### Antidote not finding Powerlevel10k
 
@@ -366,21 +366,21 @@ exec zsh -i
 
 ```bash
 grep powerlevel10k ~/.config/zsh/.zsh_plugins.txt
-```text
+```
 
 **Solution:**
 Add to `.zsh_plugins.txt`:
 
 ```text
 romkatv/powerlevel10k
-```text
+```
 
 Then reload antidote:
 
 ```bash
 antidote install
 exec zsh
-```text
+```
 
 ## Performance Tips
 
@@ -390,7 +390,7 @@ Starship is the fastest option - optimized for shell startup speed.
 
 ```bash
 prompt starship
-```text
+```
 
 ### Powerlevel10k
 
@@ -398,7 +398,7 @@ Very fast with instant prompt feature. Configure for your system:
 
 ```bash
 p10k configure
-```diff
+```
 
 ### Oh My Posh
 
@@ -413,7 +413,7 @@ Performance depends on configuration. For best speed:
 
 ```bash
 p10k configure
-```ini
+```
 
 Interactive configuration wizard with many options.
 
@@ -429,7 +429,7 @@ symbol = "🐍"
 # Example: customize git branch
 [git_branch]
 symbol = "🌿"
-```text
+```
 
 ### Oh My Posh
 
@@ -445,7 +445,7 @@ Edit `~/.config/ohmyposh/config.json`:
     }
   ]
 }
-```text
+```
 
 ## Integration with flow-cli
 
@@ -453,7 +453,7 @@ The prompt dispatcher integrates with `flow doctor` for diagnostics:
 
 ```bash
 flow doctor
-```diff
+```
 
 Checks all prompt engines for:
 - Installation status
@@ -469,7 +469,7 @@ Fast and minimal - great for speed:
 
 ```bash
 prompt starship
-```text
+```
 
 ### Feature Development (Powerlevel10k)
 
@@ -477,7 +477,7 @@ Rich information and customizable:
 
 ```bash
 prompt p10k
-```text
+```
 
 ### Theme Exploration (Oh My Posh)
 
@@ -485,7 +485,7 @@ Extensive themes and modular:
 
 ```bash
 prompt ohmyposh
-```text
+```
 
 ### Test All Engines
 

--- a/docs/guides/QUALITY-GATES.md
+++ b/docs/guides/QUALITY-GATES.md
@@ -19,7 +19,7 @@ flow-cli uses multiple validation layers to catch issues at the earliest possibl
 
 ```text
 Keystroke → Pre-commit → Manual lint → CI → Deploy preflight → Production
-```bash
+```
 
 ---
 
@@ -56,7 +56,7 @@ The same validation runs during `teach deploy` preflight, but this pre-commit ga
 
 ```bash
 git commit --no-verify -m "message"
-```bash
+```
 
 ### Setup
 
@@ -64,7 +64,7 @@ Pre-commit hooks require a one-time install:
 
 ```bash
 npm install   # installs husky + lint-staged
-```bash
+```
 
 Husky auto-configures via the `prepare` script in `package.json`.
 
@@ -84,7 +84,7 @@ teach lint
 
 # Specific file
 teach lint lib/dispatchers/teach-deploy-enhanced.zsh
-```bash
+```
 
 ### Quarto Lint
 
@@ -96,7 +96,7 @@ teach validate lectures/week-05.qmd
 
 # Deep validation with prerequisites
 teach validate --deep
-```bash
+```
 
 ### Markdown Lint
 
@@ -108,7 +108,7 @@ npm run format:check
 
 # Fix automatically
 npm run format
-```bash
+```
 
 ### ESLint
 
@@ -117,7 +117,7 @@ JavaScript/config file linting:
 ```bash
 npm run lint
 npm run lint:fix
-```diff
+```
 
 ---
 

--- a/docs/guides/QUARTO-WORKFLOW-PHASE-2-GUIDE.md
+++ b/docs/guides/QUARTO-WORKFLOW-PHASE-2-GUIDE.md
@@ -70,7 +70,7 @@ teach profiles list              # Show available profiles
 teach profiles show draft        # Display profile configuration
 teach profiles set draft         # Activate draft profile
 teach profiles create slides     # Create new profile from template
-```diff
+```
 
 **Use Cases:**
 - **draft**: Working version with code folding and tools
@@ -84,7 +84,7 @@ teach profiles create slides     # Create new profile from template
 ```bash
 teach doctor                     # Check R package dependencies
 teach doctor --fix               # Install missing packages automatically
-```diff
+```
 
 Detects packages from:
 - `.teach/teaching.yml` (declared packages)
@@ -104,7 +104,7 @@ teach validate lectures/*.qmd                 # ~120s for 12 files
 # Parallel validation (new way)
 teach validate lectures/*.qmd --parallel      # ~35s for 12 files (3.4x faster)
 teach validate lectures/*.qmd --workers 8     # Specify worker count
-```diff
+```
 
 **Architecture:**
 - **Worker Pool**: Parallel job processors (default: CPU cores - 1)
@@ -128,7 +128,7 @@ teach validate lectures/*.qmd --workers 8     # Specify worker count
 teach validate --custom                       # Run custom validators
 teach validate --validators citations,links   # Run specific validators
 teach validate --skip-external                # Skip external link checks
-```bash
+```
 
 **Built-in Validators:**
 
@@ -155,7 +155,7 @@ chmod +x .teach/validators/check-packages.zsh
 
 # Run your validator
 teach validate lectures/week-01.qmd --custom
-```text
+```
 
 ---
 
@@ -170,7 +170,7 @@ teach cache clear --old           # Clear cache older than 7 days
 teach cache clear --unused        # Clear cache for deleted files
 
 teach cache analyze               # Detailed cache breakdown
-```text
+```
 
 **Cache Analysis Report:**
 
@@ -197,7 +197,7 @@ Recommendations:
   ✓ Cache hit rate is excellent (> 90%)
   ⚠ Consider clearing old cache (> 30 days) to save 400 MB
   ✓ Cache structure is well-organized
-```text
+```
 
 ---
 
@@ -207,7 +207,7 @@ Recommendations:
 
 ```bash
 teach status --performance        # Show performance dashboard
-```text
+```
 
 **Performance Dashboard:**
 
@@ -240,7 +240,7 @@ Top 5 Slowest Files:
   3. assignments/final.qmd   11.5s
   4. lectures/week-04.qmd     9.2s
   5. lectures/week-07.qmd     8.9s
-```diff
+```
 
 **Data Tracked:**
 - Render time per file
@@ -276,7 +276,7 @@ Top 5 Slowest Files:
 teach doctor                      # Check all dependencies
 teach doctor --json               # Machine-readable output
 teach doctor --fix                # Install missing dependencies
-```text
+```
 
 **Expected Output:**
 
@@ -309,7 +309,7 @@ R Packages:
 Status: Ready (2 warnings)
 
 Run 'teach doctor --fix' to install missing R packages.
-```yaml
+```
 
 ---
 
@@ -356,7 +356,7 @@ profile:
       revealjs:
         theme: simple
         incremental: true
-```yaml
+```
 
 #### Common Use Cases
 
@@ -379,7 +379,7 @@ profile:
         code-tools: false      # Hide code tools
         toc: true
         echo: false            # Hide code by default
-```yaml
+```
 
 **2. Student vs Instructor Versions**
 
@@ -400,7 +400,7 @@ profile:
     format:
       html:
         code-fold: false       # Solutions always visible
-```yaml
+```
 
 **3. Multiple Output Formats**
 
@@ -420,7 +420,7 @@ profile:
     format:
       revealjs:
         theme: moon
-```text
+```
 
 ---
 
@@ -430,7 +430,7 @@ profile:
 
 ```bash
 teach profiles list
-```text
+```
 
 **Output:**
 
@@ -451,13 +451,13 @@ To switch profiles:
 
 To create a new profile:
   teach profiles create <name>
-```text
+```
 
 #### Show Profile Configuration
 
 ```bash
 teach profiles show draft
-```text
+```
 
 **Output:**
 
@@ -477,13 +477,13 @@ Output Directory: _book/draft
 
 To activate:
   teach profiles set draft
-```text
+```
 
 #### Switch to a Profile
 
 ```bash
 teach profiles set draft
-```text
+```
 
 **What Happens:**
 
@@ -511,7 +511,7 @@ R Packages:
 To render with this profile:
   teach validate lectures/*.qmd
   quarto render --profile draft
-```bash
+```
 
 **Verify Active Profile:**
 
@@ -521,13 +521,13 @@ echo $QUARTO_PROFILE
 
 teach status
 # Shows: Current Profile: draft
-```text
+```
 
 #### Create a New Profile
 
 ```bash
 teach profiles create slides
-```text
+```
 
 **Interactive Prompts:**
 
@@ -558,7 +558,7 @@ Create profile? (y/n): y
 
 To activate:
   teach profiles set slides
-```yaml
+```
 
 **Generated Configuration:**
 
@@ -572,7 +572,7 @@ profile:
         incremental: true
         code-fold: true
         echo: false
-```yaml
+```
 
 ---
 
@@ -603,7 +603,7 @@ quarto_options:
 github:
   repo: "stat-545-fall-2024-draft"
   branch: "dev"
-```yaml
+```
 
 #### Example: Print Profile
 
@@ -633,7 +633,7 @@ quarto_options:
 github:
   repo: "stat-545-fall-2024"
   branch: "main"
-```bash
+```
 
 #### Priority Order
 
@@ -650,7 +650,7 @@ teach profiles set draft
 # Loads:
 # 1. .teach/teaching.yml          (base)
 # 2. .teach/teaching-draft.yml    (overrides)
-```yaml
+```
 
 ---
 
@@ -670,7 +670,7 @@ r_packages:
   - tidyverse
   - ggplot2
   - dplyr
-```text
+```
 
 **2. renv.lock**
 
@@ -683,24 +683,24 @@ r_packages:
     }
   }
 }
-```text
+```
 
 **3. Code Block Analysis** (future feature)
 
-```{r}
+```r
 library(ggplot2)      # Detected
 library(dplyr)        # Detected
-```text
+```
 
 #### Check Installation Status
 
-```bash
+```
 teach doctor
-```text
+```
 
 **Output:**
 
-```yaml
+```
 R Packages:
   ✓ tidyverse        2.0.0
   ✓ ggplot2          3.4.4
@@ -710,17 +710,17 @@ R Packages:
 Status: 2 packages missing
 
 Run 'teach doctor --fix' to install missing packages.
-```text
+```
 
 #### Auto-Install Missing Packages
 
-```bash
+```
 teach doctor --fix
-```text
+```
 
 **Interactive Prompt:**
 
-```text
+```
 Install Missing R Packages
 ─────────────────────────────────────────────────────
 
@@ -740,31 +740,31 @@ Installing packages...
 
 To verify:
   teach doctor
-```bash
+```
 
 #### Manual Installation
 
 If auto-install fails or you prefer manual control:
 
-```r
+```
 # In R console
 install.packages(c("dplyr", "knitr"))
 
 # Or using renv
 renv::restore()
-```bash
+```
 
 #### renv Integration
 
 If your project uses `renv.lock`:
 
-```bash
+```
 # Restore from lockfile
 Rscript -e 'renv::restore()'
 
 # Or let teach doctor handle it
 teach doctor --fix
-```diff
+```
 
 **Benefits:**
 - ✅ Reproducible environments
@@ -783,7 +783,7 @@ Parallel rendering uses **worker pools** to process multiple files simultaneousl
 
 #### Architecture
 
-```text
+```
 ┌─────────────────────────────────────────────────────┐
 │ Main Process (Coordinator)                         │
 ├─────────────────────────────────────────────────────┤
@@ -815,7 +815,7 @@ Parallel rendering uses **worker pools** to process multiple files simultaneousl
 │ ████████████████░░░░░░░░                           │
 │ Est. time remaining: 42s                            │
 └─────────────────────────────────────────────────────┘
-```text
+```
 
 #### Smart Queue Optimization
 
@@ -825,7 +825,7 @@ Parallel rendering uses **worker pools** to process multiple files simultaneousl
 
 **Example:**
 
-```text
+```
 File Render Times:
   file-1.qmd:  2s
   file-2.qmd:  5s
@@ -841,13 +841,13 @@ Good Queue (slowest first):
   Worker 1: [file-3: 10s]
   Worker 2: [file-2: 5s] [file-4: 3s]
   Total: 10s (80% efficient)
-```bash
+```
 
 #### Atomic Job Distribution
 
 Workers atomically dequeue jobs from a shared queue using file locking to prevent race conditions.
 
-```bash
+```
 # Pseudo-code
 acquire_lock() {
   mkdir "$LOCK_DIR/job-$N.lock" 2>/dev/null
@@ -863,7 +863,7 @@ get_next_job() {
   done
   return 1  # Queue empty
 }
-```bash
+```
 
 ---
 
@@ -871,7 +871,7 @@ get_next_job() {
 
 #### Basic Usage
 
-```bash
+```
 # Parallel validation (auto-detect worker count)
 teach validate lectures/*.qmd --parallel
 
@@ -880,25 +880,25 @@ teach validate lectures/*.qmd --workers 4
 
 # All files in directory
 teach validate lectures/ --parallel
-```bash
+```
 
 #### Worker Count Selection
 
 **Auto-Detection (Recommended):**
 
-```bash
+```
 teach validate --parallel
 # Uses: $(nproc) - 1 cores
 # Example: 8 cores → 7 workers
-```text
+```
 
 **Manual Override:**
 
-```bash
+```
 teach validate --workers 4
 teach validate --workers 8
 teach validate --workers 1  # Serial (for debugging)
-```diff
+```
 
 **Recommendations:**
 
@@ -935,13 +935,13 @@ Quarto rendering is **I/O bound** (disk reads/writes), not purely CPU bound:
 
 #### Progress Tracking
 
-```bash
+```
 teach validate lectures/*.qmd --parallel
-```text
+```
 
 **Output:**
 
-```yaml
+```
 Parallel Validation (8 workers)
 ─────────────────────────────────────────────────────
 
@@ -982,7 +982,7 @@ Summary:
   Cache hits:   8/12 (67%)
 
 Performance log updated: .teach/performance-log.json
-```diff
+```
 
 ---
 
@@ -1010,11 +1010,11 @@ Performance log updated: .teach/performance-log.json
 
 **CPU vs I/O Bound:**
 
-```bash
+```
 # During parallel validation, monitor system resources:
 htop                    # CPU usage
 iotop                   # Disk I/O
-```diff
+```
 
 **Observations:**
 - **CPU usage**: 60-80% (not maxed out)
@@ -1032,13 +1032,13 @@ iotop                   # Disk I/O
 
 #### Dry Run (Preview)
 
-```bash
+```
 teach validate --parallel --dry-run
-```text
+```
 
 **Output:**
 
-```yaml
+```
 Dry Run: Parallel Validation
 ─────────────────────────────────────────────────────
 
@@ -1057,17 +1057,17 @@ Speedup:                 3.4x
 
 To execute:
   teach validate --parallel
-```text
+```
 
 #### Verbose Output
 
-```bash
+```
 teach validate --parallel --verbose
-```text
+```
 
 **Output:**
 
-```bash
+```
 [DEBUG] Worker 1: Starting job lectures/week-08.qmd
 [DEBUG] Worker 2: Starting job lectures/week-06.qmd
 [DEBUG] Worker 1: Rendering...
@@ -1075,14 +1075,14 @@ teach validate --parallel --verbose
 [DEBUG] Worker 1: Finished in 15.2s
 [DEBUG] Worker 3: Starting job lectures/week-04.qmd
 ...
-```text
+```
 
 #### Limit Parallelism
 
-```bash
+```
 teach validate --workers 2    # Only 2 workers (slower but safer)
 teach validate --workers 1    # Serial (debugging)
-```diff
+```
 
 ---
 
@@ -1096,13 +1096,13 @@ teach validate --workers 1    # Serial (debugging)
 
 **Diagnosis:**
 
-```bash
+```
 # Check disk type
 diskutil info / | grep "Solid State"
 
 # Monitor I/O during validation
 sudo iotop -P
-```diff
+```
 
 **Solutions:**
 
@@ -1128,13 +1128,13 @@ sudo iotop -P
 
 **Diagnosis:**
 
-```bash
+```
 # Check for stale lock files
 ls -la .teach/parallel-lock/
 
 # Check worker logs
 cat .teach/parallel-log/worker-*.log
-```diff
+```
 
 **Solutions:**
 
@@ -1158,10 +1158,10 @@ cat .teach/parallel-log/worker-*.log
 
 **Diagnosis:**
 
-```bash
+```
 # Monitor memory usage
 watch -n 1 'ps aux | grep quarto'
-```diff
+```
 
 **Solutions:**
 
@@ -1188,13 +1188,13 @@ watch -n 1 'ps aux | grep quarto'
 
 **Diagnosis:**
 
-```bash
+```
 # Check worker status
 ps aux | grep quarto
 
 # Check progress file
 cat .teach/parallel-progress.txt
-```diff
+```
 
 **Solutions:**
 
@@ -1237,13 +1237,13 @@ Phase 2 includes three built-in validators:
 
 **Usage:**
 
-```bash
+```
 teach validate --validators citations
-```text
+```
 
 **Example Output:**
 
-```yaml
+```
 Citation Validation
 ─────────────────────────────────────────────────────
 
@@ -1264,7 +1264,7 @@ Summary:
   Valid:           6 (75%)
   Warnings:        2 (25%)
   Errors:          0 (0%)
-```diff
+```
 
 #### 2. check-links
 
@@ -1278,14 +1278,14 @@ Summary:
 
 **Usage:**
 
-```bash
+```
 teach validate --validators links           # Internal links only
 teach validate --validators links --external  # Include external links (slow)
-```text
+```
 
 **Example Output:**
 
-```yaml
+```
 Link Validation
 ─────────────────────────────────────────────────────
 
@@ -1306,7 +1306,7 @@ Summary:
   Broken:          1 (10%)
 
 External links checked: 1 (use --external for full check)
-```diff
+```
 
 #### 3. check-formatting
 
@@ -1320,13 +1320,13 @@ External links checked: 1 (use --external for full check)
 
 **Usage:**
 
-```bash
+```
 teach validate --validators formatting
-```text
+```
 
 **Example Output:**
 
-```yaml
+```
 Formatting Validation
 ─────────────────────────────────────────────────────
 
@@ -1345,7 +1345,7 @@ Summary:
   Clean:            1 (33%)
   With warnings:    2 (67%)
   Total warnings:   3
-```text
+```
 
 ---
 
@@ -1365,18 +1365,18 @@ Custom validators are executable scripts placed in `.teach/validators/`:
 
 **Message Format:**
 
-```yaml
+```
 [LEVEL]: [Message]
 
 Levels:
   INFO:    Informational message
   WARNING: Non-critical issue
   ERROR:   Critical issue (validation fails)
-```bash
+```
 
 #### Example: Check R Packages
 
-```bash
+```
 cat > .teach/validators/check-packages.zsh <<'EOF'
 #!/usr/bin/env zsh
 # Custom validator: Check R package usage
@@ -1410,11 +1410,11 @@ exit $exit_code
 EOF
 
 chmod +x .teach/validators/check-packages.zsh
-```bash
+```
 
 #### Example: Check External Resources
 
-```bash
+```
 cat > .teach/validators/check-resources.zsh <<'EOF'
 #!/usr/bin/env zsh
 # Custom validator: Check external resource availability
@@ -1445,11 +1445,11 @@ exit $exit_code
 EOF
 
 chmod +x .teach/validators/check-resources.zsh
-```bash
+```
 
 #### Example: Check Code Style
 
-```bash
+```
 cat > .teach/validators/check-code-style.zsh <<'EOF'
 #!/usr/bin/env zsh
 # Custom validator: Check R code style
@@ -1497,7 +1497,7 @@ exit $exit_code
 EOF
 
 chmod +x .teach/validators/check-code-style.zsh
-```text
+```
 
 ---
 
@@ -1505,13 +1505,13 @@ chmod +x .teach/validators/check-code-style.zsh
 
 #### Run All Custom Validators
 
-```bash
+```
 teach validate lectures/week-01.qmd --custom
-```text
+```
 
 **Output:**
 
-```zsh
+```
 Custom Validation
 ─────────────────────────────────────────────────────
 
@@ -1540,19 +1540,19 @@ Summary:
   Passed:         2
   Warnings:       1
   Errors:         0
-```text
+```
 
 #### Run Specific Validators
 
-```bash
+```
 teach validate --validators packages,resources
-```text
+```
 
 #### Skip External Link Checks
 
-```bash
+```
 teach validate --validators links --skip-external
-```diff
+```
 
 ---
 
@@ -1566,7 +1566,7 @@ teach validate --validators links --skip-external
 
 **Example: Caching Results**
 
-```bash
+```
 # In your validator
 cache_file=".teach/cache/validators/$(basename "$file").json"
 
@@ -1585,7 +1585,7 @@ result="..."
 
 # Cache result
 echo "$result" > "$cache_file"
-```diff
+```
 
 #### Error Handling
 
@@ -1595,7 +1595,7 @@ echo "$result" > "$cache_file"
 
 **Example: Error Handling**
 
-```bash
+```
 #!/usr/bin/env zsh
 file="$1"
 
@@ -1610,13 +1610,13 @@ if ! command -v yq &>/dev/null; then
 fi
 
 # Continue validation...
-```bash
+```
 
 #### Testing Validators
 
 **Test Script:**
 
-```bash
+```
 #!/usr/bin/env zsh
 # test-validator.zsh
 
@@ -1640,7 +1640,7 @@ if [[ $status -eq 1 ]]; then
 else
   echo "✗ Test 2 failed (expected 1, got $status)"
 fi
-```text
+```
 
 ---
 
@@ -1652,7 +1652,7 @@ Phase 2 introduces **selective cache management** and **cache analysis** to opti
 
 ### Cache Structure
 
-```text
+```
 project/
 ├── _freeze/                    # Quarto cache directory
 │   ├── lectures/
@@ -1668,27 +1668,27 @@ project/
     └── cache/
         ├── validators/         # Validator cache
         └── metadata/           # File metadata cache
-```text
+```
 
 ### Selective Cache Clearing
 
 #### Clear by Content Type
 
-```bash
+```
 teach cache clear --lectures      # Clear lecture cache only
 teach cache clear --assignments   # Clear assignment cache only
 teach cache clear --slides        # Clear slides cache only
-```text
+```
 
 **Example:**
 
-```bash
+```
 teach cache clear --lectures
-```text
+```
 
 **Output:**
 
-```text
+```
 Selective Cache Clear: Lectures
 ─────────────────────────────────────────────────────
 
@@ -1707,24 +1707,24 @@ Remaining cache:
 
 To rebuild lecture cache:
   teach validate lectures/ --parallel
-```text
+```
 
 #### Clear by Age
 
-```bash
+```
 teach cache clear --old           # Clear cache older than 7 days (default)
 teach cache clear --old 30        # Clear cache older than 30 days
-```text
+```
 
 **Example:**
 
-```bash
+```
 teach cache clear --old 14
-```text
+```
 
 **Output:**
 
-```text
+```
 Clear Old Cache (> 14 days)
 ─────────────────────────────────────────────────────
 
@@ -1747,23 +1747,23 @@ Remaining cache:
   935 files, 1.75 GB
 
 Cache hit rate (estimated): 94% → 96% (+2%)
-```text
+```
 
 #### Clear Unused Cache
 
-```bash
+```
 teach cache clear --unused        # Clear cache for deleted files
-```text
+```
 
 **Example:**
 
-```bash
+```
 teach cache clear --unused
-```text
+```
 
 **Output:**
 
-```yaml
+```
 Clear Unused Cache
 ─────────────────────────────────────────────────────
 
@@ -1787,14 +1787,14 @@ Clearing unused cache...
 
 Remaining cache:
   32 directories, 2.2 GB (all active)
-```text
+```
 
 #### Combine Flags
 
-```bash
+```
 teach cache clear --lectures --old 30
 teach cache clear --assignments --unused
-```text
+```
 
 ---
 
@@ -1802,13 +1802,13 @@ teach cache clear --assignments --unused
 
 #### Generate Analysis Report
 
-```bash
+```
 teach cache analyze
-```text
+```
 
 **Output:**
 
-```yaml
+```
 Cache Analysis Report
 ─────────────────────────────────────────────────────
 
@@ -1864,17 +1864,17 @@ Optimization Suggestions:
   1. Clear old cache:  teach cache clear --old
   2. Review large files: Check lectures/week-08.qmd for optimization
   3. Enable incremental rendering (if not already enabled)
-```text
+```
 
 #### Export Analysis (JSON)
 
-```bash
+```
 teach cache analyze --json > cache-report.json
-```text
+```
 
 **Output:**
 
-```json
+```
 {
   "timestamp": "2026-01-20T14:30:00Z",
   "total_size_gb": 2.4,
@@ -1918,21 +1918,21 @@ teach cache analyze --json > cache-report.json
     ]
   }
 }
-```bash
+```
 
 #### Monitor Cache Over Time
 
-```bash
+```
 # Generate weekly reports
 teach cache analyze > "cache-report-$(date +%Y-%m-%d).txt"
-```bash
+```
 
 **Track Trends:**
 
-```bash
+```
 # Compare reports
 diff cache-report-2026-01-13.txt cache-report-2026-01-20.txt
-```diff
+```
 
 ---
 
@@ -1947,23 +1947,23 @@ diff cache-report-2026-01-13.txt cache-report-2026-01-20.txt
 
 **Example Cron Job:**
 
-```bash
+```
 # Add to crontab
 0 2 * * 0 cd ~/projects/teaching/stat-545 && teach cache clear --old 30
-```sql
+```
 
 #### 2. Identify Slow Files
 
 From `teach cache analyze`, identify large cache entries:
 
-```text
+```
 Top 10 Largest Cache Entries:
   1. lectures/week-08/  245 MB
-```bash
+```
 
 **Investigate:**
 
-```bash
+```
 # Check file size
 wc -c lectures/week-08.qmd
 
@@ -1972,7 +1972,7 @@ grep -c '```{r}' lectures/week-08.qmd
 
 # Check cache details
 du -h _freeze/lectures/week-08/
-```diff
+```
 
 **Optimize:**
 - Reduce plot complexity
@@ -1983,11 +1983,11 @@ du -h _freeze/lectures/week-08/
 
 Enable incremental rendering in `_quarto.yml`:
 
-```yaml
+```
 execute:
   freeze: auto         # Only re-render changed files
   cache: true          # Cache computation results
-```diff
+```
 
 **Benefits:**
 - ✅ Faster re-renders (only changed files)
@@ -1998,7 +1998,7 @@ execute:
 
 Each profile can have its own cache:
 
-```yaml
+```
 # _quarto.yml
 profile:
   draft:
@@ -2008,7 +2008,7 @@ profile:
   final:
     output-dir: _book/final
     freeze: _freeze/          # Main cache
-```diff
+```
 
 **Benefits:**
 - ✅ Isolated cache per profile
@@ -2027,7 +2027,7 @@ Phase 2 automatically tracks render performance and visualizes trends over time.
 
 All validation operations log metrics to `.teach/performance-log.json`:
 
-```json
+```
 {
   "version": "1.0",
   "entries": [
@@ -2053,17 +2053,17 @@ All validation operations log metrics to `.teach/performance-log.json`:
     }
   ]
 }
-```text
+```
 
 ### Performance Dashboard
 
-```bash
+```
 teach status --performance
-```text
+```
 
 **Output:**
 
-```yaml
+```
 Performance Dashboard
 ─────────────────────────────────────────────────────
 
@@ -2142,7 +2142,7 @@ Actions:
   1. Review lectures/week-10.qmd (slowest file)
   2. Analyze lectures/week-06.qmd (trending slower)
   3. Continue current workflow (performance trending up)
-```text
+```
 
 ### Trend Visualization
 
@@ -2150,22 +2150,22 @@ The dashboard uses ASCII graphs to visualize trends:
 
 **Render Time Trend:**
 
-```text
+```
 5.2s  ██████████░░░░░░░░░░
       ↓
 3.8s  ███████░░░░░░░░░░░░░
       (↓ 27% improvement)
-```text
+```
 
 **Cache Hit Rate Trend:**
 
-```text
+```
 100% ████████████████████
  90% █████████░░░░░░░░░░░
  80% ████████░░░░░░░░░░░░
       Mon Tue Wed Thu Fri Sat Sun
        ✓   ✓   ✓   ✓   ✓   ✓   ✓
-```diff
+```
 
 ---
 
@@ -2227,13 +2227,13 @@ The dashboard uses ASCII graphs to visualize trends:
 
 #### View Raw Log
 
-```bash
+```
 cat .teach/performance-log.json | jq '.'
-```bash
+```
 
 #### Extract Specific Metrics
 
-```bash
+```
 # Average render time (last 7 days)
 jq '[.entries[] | select(.timestamp > "2026-01-13")] | map(.avg_render_time_sec) | add / length' .teach/performance-log.json
 
@@ -2242,29 +2242,29 @@ jq '[.entries[] | select(.timestamp > "2026-01-13")] | map(.cache_hit_rate) | ad
 
 # Slowest files (all time)
 jq -r '.entries[].slowest_file' .teach/performance-log.json | sort | uniq -c | sort -rn | head -10
-```bash
+```
 
 #### Export for Analysis
 
-```bash
+```
 # Export to CSV
 jq -r '.entries[] | [.timestamp, .files, .duration_sec, .cache_hit_rate] | @csv' .teach/performance-log.json > performance.csv
 
 # Import to R/Python for visualization
-```bash
+```
 
 #### Log Rotation
 
 Performance logs grow over time. Rotate logs to prevent bloat:
 
-```bash
+```
 # Archive old logs (> 90 days)
 jq '.entries |= map(select(.timestamp > "2025-10-20"))' .teach/performance-log.json > .teach/performance-log-new.json
 
 # Backup old data
 mv .teach/performance-log.json .teach/performance-log-archive-2026-01.json
 mv .teach/performance-log-new.json .teach/performance-log.json
-```bash
+```
 
 ---
 
@@ -2278,7 +2278,7 @@ This section demonstrates end-to-end workflows combining all Phase 2 features.
 
 **Steps:**
 
-```bash
+```
 # 1. Start work session
 work stat-545
 
@@ -2307,7 +2307,7 @@ teach deploy
 # Output:
 #   ✓ Created PR #42
 #   ✓ Preview: https://...
-```diff
+```
 
 **Time Saved:**
 - Serial validation: ~120s
@@ -2322,7 +2322,7 @@ teach deploy
 
 **Steps:**
 
-```bash
+```
 # 1. Initialize project
 mkdir stat-545-spring-2025
 cd stat-545-spring-2025
@@ -2396,7 +2396,7 @@ teach validate lectures/ assignments/ --parallel
 #   ✓ Validated 20 files in 52s (parallel)
 #   Serial time (est): 180s
 #   Speedup: 3.5x
-```bash
+```
 
 ---
 
@@ -2406,7 +2406,7 @@ teach validate lectures/ assignments/ --parallel
 
 **Steps:**
 
-```bash
+```
 # 1. Make updates
 # ... edit 25 lecture files ...
 
@@ -2484,7 +2484,7 @@ teach deploy
 #   ✓ Created PR #58
 #   Changed files: 25
 #   Preview: https://...
-```diff
+```
 
 **Results:**
 - Reduced validation time: 250s → 48s (5.2x faster)
@@ -2499,7 +2499,7 @@ teach deploy
 
 **Steps:**
 
-```bash
+```
 # 1. Final deployment
 teach validate lectures/ assignments/ --parallel
 teach deploy
@@ -2539,7 +2539,7 @@ teach doctor --fix
 
 # 8. Update teaching.yml for next semester
 sed -i '' 's/Fall 2024/Spring 2025/' .teach/teaching.yml
-```diff
+```
 
 ---
 
@@ -2555,13 +2555,13 @@ sed -i '' 's/Fall 2024/Spring 2025/' .teach/teaching.yml
 
 **Diagnosis:**
 
-```bash
+```
 # Check _quarto.yml syntax
 quarto check
 
 # Verify YAML structure
 yq -r '.profile' _quarto.yml
-```diff
+```
 
 **Solutions:**
 
@@ -2596,7 +2596,7 @@ yq -r '.profile' _quarto.yml
 
 **Diagnosis:**
 
-```bash
+```
 # Check R version
 R --version
 
@@ -2605,7 +2605,7 @@ Rscript -e 'getOption("repos")'
 
 # Try manual install
 Rscript -e 'install.packages("tidyverse")'
-```diff
+```
 
 **Solutions:**
 
@@ -2638,7 +2638,7 @@ Rscript -e 'install.packages("tidyverse")'
 
 **Diagnosis:**
 
-```bash
+```
 # Check for stale locks
 ls -la .teach/parallel-lock/
 
@@ -2647,7 +2647,7 @@ ps aux | grep quarto
 
 # Check for zombie processes
 ps aux | grep 'Z'
-```diff
+```
 
 **Solutions:**
 
@@ -2683,7 +2683,7 @@ ps aux | grep 'Z'
 
 **Diagnosis:**
 
-```bash
+```
 # Check validators directory
 ls -la .teach/validators/
 
@@ -2692,7 +2692,7 @@ ls -l .teach/validators/*.zsh
 
 # Test validator manually
 ./.teach/validators/check-packages.zsh lectures/week-01.qmd
-```diff
+```
 
 **Solutions:**
 
@@ -2723,7 +2723,7 @@ ls -l .teach/validators/*.zsh
 
 **Diagnosis:**
 
-```bash
+```
 # Check cache size
 du -sh _freeze/
 
@@ -2732,7 +2732,7 @@ grep 'freeze' _quarto.yml
 
 # Check for cache corruption
 find _freeze/ -name '*.json' -size 0
-```diff
+```
 
 **Solutions:**
 
@@ -2765,13 +2765,13 @@ find _freeze/ -name '*.json' -size 0
 
 **Diagnosis:**
 
-```bash
+```
 # Check JSON validity
 jq '.' .teach/performance-log.json
 
 # Check file size
 ls -lh .teach/performance-log.json
-```diff
+```
 
 **Solutions:**
 
@@ -2930,7 +2930,7 @@ ls -lh .teach/performance-log.json
 
 Phase 2 features are opt-in. To use Phase 1 behavior only:
 
-```bash
+```
 # Disable parallel rendering
 teach validate lectures/*.qmd  # (no --parallel flag)
 

--- a/docs/guides/SAFE-TESTING-v5.9.0.md
+++ b/docs/guides/SAFE-TESTING-v5.9.0.md
@@ -28,7 +28,7 @@ When testing new software features on production data (your real courses), there
 │  • Display information          • Change permissions       │
 │  • Parse and analyze            • Git commit/push          │
 └─────────────────────────────────────────────────────────────┘
-```bash
+```
 
 **Key insight:** A read operation, by definition, cannot change your data. It's like looking at a photograph vs. editing it.
 
@@ -56,7 +56,7 @@ teach exam "Topic"  → Creates exams/topic-exam.qmd
 
 # With --dry-run: Shows what WOULD be created
 teach exam "Topic" --dry-run  → Prints preview, creates NOTHING
-```bash
+```
 
 ### Why --dry-run Is Trustworthy
 
@@ -73,7 +73,7 @@ fi
 
 # This code only runs if NOT dry-run
 echo "$generated_content" > "exams/$topic-exam.qmd"
-```text
+```
 
 ---
 
@@ -99,7 +99,7 @@ Git is a **time machine** for your files. Any change can be undone:
 │  │  Every commit is saved forever (recoverable)         │   │
 │  └─────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────┘
-```bash
+```
 
 ### Recovery Commands Explained
 
@@ -119,7 +119,7 @@ git stash pop
 # "Nuclear reset" - Discard EVERYTHING since last commit
 git reset --hard HEAD
 # Think: "Time machine back to last commit, forget everything since"
-```text
+```
 
 ---
 
@@ -140,7 +140,7 @@ git reset --hard HEAD
 │  System Cache (~/.local/share/flow-cli/)                    │
 │  └── cache/teach-config.hash   ← Hash cache (harmless)     │
 └─────────────────────────────────────────────────────────────┘
-```bash
+```
 
 **Key insight:** The hash cache is written to YOUR home directory, not the course. Even if something went wrong with caching, your course files are untouched.
 
@@ -162,7 +162,7 @@ teach status
 # NOT idempotent: Each run creates a NEW file
 teach exam "Topic"
 teach exam "Topic"  # Creates topic-exam-2.qmd or overwrites!
-```diff
+```
 
 ### All v5.9.0 Read Operations Are Idempotent
 
@@ -200,7 +200,7 @@ git stash push -m "pre-v5.9.0-test"
 
 # 4. Verify stash saved
 git stash list
-```bash
+```
 
 ---
 
@@ -213,7 +213,7 @@ These commands **NEVER modify files**:
 ```bash
 # Shows course info, validation status, content inventory
 teach status
-```text
+```
 
 **What it does:** Reads config, validates, displays info
 **Risk:** ⚪ NONE
@@ -224,7 +224,7 @@ teach status
 teach help
 teach exam --help
 teach quiz --help
-```zsh
+```
 
 **What it does:** Displays help text
 **Risk:** ⚪ NONE
@@ -244,7 +244,7 @@ _teach_has_scholar_config .flow/teach-config.yml
 # Get config values (read-only)
 _teach_config_get "course.name"
 _teach_config_get "course.semester"
-```zsh
+```
 
 **What it does:** Reads and validates YAML
 **Risk:** ⚪ NONE
@@ -257,7 +257,7 @@ _flow_config_hash .flow/teach-config.yml
 
 # Check if changed (reads cache file)
 _flow_config_changed .flow/teach-config.yml
-```bash
+```
 
 **What it does:** Computes SHA-256, compares with cache
 **Risk:** ⚪ NONE (cache file is in ~/.local/share/flow-cli/)
@@ -268,7 +268,7 @@ _flow_config_changed .flow/teach-config.yml
 # Test flag validation (no execution)
 _teach_validate_flags exam --questions 5 --duration 60
 _teach_validate_flags exam --invalid-flag  # Should error
-```bash
+```
 
 **What it does:** Validates flags, returns error for invalid
 **Risk:** ⚪ NONE
@@ -284,7 +284,7 @@ These commands **preview output without writing**:
 ```bash
 # Preview exam generation (NO files written)
 teach exam "Regression Diagnostics" --dry-run
-```text
+```
 
 **What it does:** Shows what WOULD be generated
 **Risk:** ⚪ NONE (--dry-run prevents file creation)
@@ -293,7 +293,7 @@ teach exam "Regression Diagnostics" --dry-run
 
 ```bash
 teach quiz "Hypothesis Testing" --dry-run --questions 10
-```text
+```
 
 **Risk:** ⚪ NONE
 
@@ -301,7 +301,7 @@ teach quiz "Hypothesis Testing" --dry-run --questions 10
 
 ```bash
 teach slides "ANOVA" --dry-run
-```bash
+```
 
 **Risk:** ⚪ NONE
 
@@ -326,7 +326,7 @@ git checkout -- .
 
 # Or restore from stash
 git stash pop
-```bash
+```
 
 ---
 
@@ -385,7 +385,7 @@ teach exam --help | head -5
 echo "\n═══════════════════════════════════════════════"
 echo "✓ All safe tests complete - no files modified"
 echo "═══════════════════════════════════════════════"
-```zsh
+```
 
 ---
 
@@ -411,7 +411,7 @@ git status  # Should show "nothing to commit"
 
 # 6. Restore stash if needed
 git stash pop
-```yaml
+```
 
 ---
 

--- a/docs/guides/SCHOLAR-WRAPPERS-GUIDE.md
+++ b/docs/guides/SCHOLAR-WRAPPERS-GUIDE.md
@@ -43,7 +43,7 @@ Run health check to verify all dependencies:
 
 ```bash
 teach doctor
-```text
+```
 
 **Expected Output:**
 
@@ -53,7 +53,7 @@ teach doctor
 ✓ Lesson plans available (optional)
 ✓ LaTeX macros configured (optional)
 ✓ Custom prompts detected (optional)
-```yaml
+```
 
 ### Minimum Configuration
 
@@ -68,7 +68,7 @@ course:
 
 locations:
   lectures: 'lectures'
-```text
+```
 
 ---
 
@@ -95,7 +95,7 @@ flowchart LR
     J --> K[Auto-stage files]
     J --> L[Update .STATUS]
     J --> M[Commit menu]
-```text
+```
 
 ### Data Flow
 
@@ -130,7 +130,7 @@ flowchart TD
     P --> Q[AI Prompt]
     Q --> R[Claude Generation]
     R --> S[Output File]
-```text
+```
 
 ### Key Components
 
@@ -148,7 +148,7 @@ flowchart TD
 
 ```bash
 teach init "STAT-101" --github
-```diff
+```
 
 Creates:
 - `.flow/teach-config.yml` - Course metadata
@@ -159,7 +159,7 @@ Creates:
 
 ```bash
 teach doctor --fix
-```diff
+```
 
 Verifies and auto-fixes:
 - Configuration validity
@@ -170,7 +170,7 @@ Verifies and auto-fixes:
 
 ```bash
 teach plan create 1 --topic "Introduction to Statistics" --style conceptual
-```text
+```
 
 Adds week structure to `.flow/lesson-plans.yml` for enhanced AI generation.
 
@@ -178,7 +178,7 @@ Adds week structure to `.flow/lesson-plans.yml` for enhanced AI generation.
 
 ```bash
 teach lecture "Introduction to Statistics" --week 1
-```text
+```
 
 ---
 
@@ -195,7 +195,7 @@ Generate lecture notes in Quarto (.qmd) format.
 ```bash
 teach lecture <topic> [options]
 teach lecture --week N --topic "title"
-```diff
+```
 
 **What It Generates:**
 
@@ -213,7 +213,7 @@ course:
   name: 'STAT-101'              # Course code
 locations:
   lectures: 'lectures'          # Output directory
-```diff
+```
 
 **Style Options:**
 
@@ -233,7 +233,7 @@ teach lecture "Data Visualization" --week 2 --style computational --code
 
 # Generate from lesson plan (auto-fills topic and style)
 teach lecture --week 3
-```diff
+```
 
 **Output Format:**
 
@@ -257,7 +257,7 @@ format: html
 
 # Examples
 ...
-```sql
+```
 
 **Command-Specific Options:**
 
@@ -282,7 +282,7 @@ Create presentation slides from topics or existing lecture files.
 teach slides <topic> [options]
 teach slides --week N --topic "title"
 teach slides --from-lecture <file>
-```diff
+```
 
 **What It Generates:**
 
@@ -307,7 +307,7 @@ teach slides --week 5 --from-lecture week-05-regression.qmd
 teach slides --from-lecture week-05.qmd --optimize
 teach slides --week 5 --optimize --preview-breaks
 teach slides --week 5 --optimize --apply-suggestions
-```diff
+```
 
 **Optimization Flags (v5.15.0+):**
 
@@ -322,7 +322,7 @@ teach slides --week 5 --optimize --apply-suggestions
 locations:
   lectures: 'lectures'          # Source directory
   slides_output: '_site/slides' # Rendered output
-```bash
+```
 
 **Example with STAT-101:**
 
@@ -335,7 +335,7 @@ teach slides --from-lecture lectures/week-03-probability.qmd
 
 # Optimized conversion with key concepts
 teach slides --week 5 --from-lecture week-05-regression.qmd --optimize --key-concepts
-```diff
+```
 
 **Output Format:**
 
@@ -357,7 +357,7 @@ theme: default
 - Random variables
 - Probability mass functions
 - Expected value
-```diff
+```
 
 **Command-Specific Options:**
 
@@ -381,7 +381,7 @@ Generate comprehensive exams with multiple question types.
 ```bash
 teach exam <topic> [options]
 teach exam --questions N --duration minutes
-```diff
+```
 
 **What It Generates:**
 
@@ -402,7 +402,7 @@ teach macros sync
 
 # Generate exam (auto-injects macros)
 teach exam "Linear Regression" --math
-```bash
+```
 
 **Example with STAT-101:**
 
@@ -418,14 +418,14 @@ teach exam "ANOVA" --questions 8 --duration 60 --types "mc:3,sa:2,problem:3"
 
 # Math-heavy exam with consistent notation
 teach exam "Probability" --questions 12 --math --style rigorous
-```yaml
+```
 
 **Required Config Fields:**
 
 ```yaml
 course:
   name: 'STAT-101'
-```yaml
+```
 
 **Optional Config Fields (enhances output):**
 
@@ -439,7 +439,7 @@ scholar:
     sources:
       - path: "_macros.qmd"
         format: "qmd"
-```diff
+```
 
 **Output Format:**
 
@@ -466,7 +466,7 @@ format: pdf
 # Section 3: Problems (30 points)
 
 3. Calculate $\E{Y}$ for the following distribution...
-```sql
+```
 
 **Command-Specific Options:**
 
@@ -489,7 +489,7 @@ Create quiz questions for formative assessment.
 ```bash
 teach quiz <topic> [options]
 teach quiz --questions N --time-limit minutes
-```diff
+```
 
 **What It Generates:**
 
@@ -513,14 +513,14 @@ teach quiz "Regression Basics" --questions 8 --explanation
 
 # Math-focused quiz
 teach quiz "Probability Distributions" --questions 12 --math --style rigorous
-```yaml
+```
 
 **Required Config Fields:**
 
 ```yaml
 course:
   name: 'STAT-101'
-```diff
+```
 
 **Command-Specific Options:**
 
@@ -541,7 +541,7 @@ Generate homework assignments with problems and instructions.
 
 ```bash
 teach assignment <topic> [options]
-```diff
+```
 
 **What It Generates:**
 
@@ -565,7 +565,7 @@ teach assignment "Data Visualization" --style computational --code
 
 # Week-based assignment
 teach assignment "Week 5 Practice" --week 5
-```yaml
+```
 
 **Required Config Fields:**
 
@@ -574,7 +574,7 @@ course:
   name: 'STAT-101'
 locations:
   homework: 'assignments'
-```yaml
+```
 
 **Optional Config Fields:**
 
@@ -584,7 +584,7 @@ semester_info:
     homework5:
       week: 5
       offset_days: 5            # Auto-populate due date
-```sql
+```
 
 **Command-Specific Options:**
 
@@ -604,7 +604,7 @@ Create a complete course syllabus from configuration.
 
 ```bash
 teach syllabus [options]
-```diff
+```
 
 **What It Generates:**
 
@@ -625,7 +625,7 @@ teach syllabus --format pdf
 
 # Verbose mode
 teach syllabus --verbose
-```yaml
+```
 
 **Required Config Fields:**
 
@@ -648,7 +648,7 @@ scholar:
 semester_info:
   start_date: '2026-08-26'
   end_date: '2026-12-15'
-```diff
+```
 
 **Optional Enhancement:**
 
@@ -670,7 +670,7 @@ Generate grading rubrics for assignments or projects.
 
 ```bash
 teach rubric <assignment> [options]
-```diff
+```
 
 **What It Generates:**
 
@@ -690,14 +690,14 @@ teach rubric "Midterm Exam" --criteria 5
 
 # Week-based rubric
 teach rubric "Week 5 Assignment" --week 5
-```yaml
+```
 
 **Required Config Fields:**
 
 ```yaml
 course:
   name: 'STAT-101'
-```sql
+```
 
 **Command-Specific Options:**
 
@@ -716,7 +716,7 @@ Create personalized student feedback.
 
 ```bash
 teach feedback <student> [options]
-```diff
+```
 
 **What It Generates:**
 
@@ -733,14 +733,14 @@ teach feedback "John Doe - Assignment 3"
 
 # Week-based feedback
 teach feedback "Jane Smith - Midterm" --week 8
-```yaml
+```
 
 **Required Config Fields:**
 
 ```yaml
 course:
   name: 'STAT-101'
-```text
+```
 
 ---
 
@@ -752,7 +752,7 @@ Generate demo course content for testing or examples.
 
 ```bash
 teach demo [options]
-```diff
+```
 
 **What It Generates:**
 
@@ -770,7 +770,7 @@ teach demo
 
 # Specific content type
 teach demo --type lecture --topic "Introduction to Statistics"
-```bash
+```
 
 ---
 
@@ -827,7 +827,7 @@ teach slides "ANOVA" --style computational --diagrams
 
 # Custom content mix
 teach exam "Midterm" --math --code --examples --no-practice-problems
-```bash
+```
 
 ### Revision Workflow (--revise)
 
@@ -841,7 +841,7 @@ teach lecture "Linear Regression" --week 5
 
 # Revise with improvements
 teach lecture --revise lectures/week-05-regression.qmd
-```text
+```
 
 **Revision Options (interactive menu):**
 
@@ -863,7 +863,7 @@ flowchart LR
     E --> F[AI Regenerates]
     F --> B
     C -->|Yes| G[Done]
-```bash
+```
 
 ### Interactive Mode (--interactive)
 
@@ -875,7 +875,7 @@ teach lecture --interactive
 
 # Or with topic pre-filled
 teach slides "ANOVA" --interactive
-```text
+```
 
 **Wizard Steps:**
 
@@ -920,7 +920,7 @@ Generating lecture with:
   - Topic: "Probability Basics"
   - Style: computational
   - Flags: --explanation --examples --code
-```text
+```
 
 ---
 
@@ -954,7 +954,7 @@ flowchart LR
     C --> G[Inject into Scholar]
     E --> G
     F --> G
-```bash
+```
 
 **Priority:**
 
@@ -976,7 +976,7 @@ teach prompt validate
 
 # Export for Scholar integration (auto-injected)
 teach prompt export
-```yaml
+```
 
 See [REFCARD-PROMPTS.md](../reference/REFCARD-PROMPTS.md) for complete prompt management guide.
 
@@ -995,7 +995,7 @@ scholar:
         format: "qmd"
     export:
       include_in_prompts: true
-```text
+```
 
 **_macros.qmd:**
 
@@ -1005,7 +1005,7 @@ $$
 \newcommand{\Var}[1]{\text{Var}\left(#1\right)}
 \newcommand{\Cov}[2]{\text{Cov}\left(#1, #2\right)}
 $$
-```bash
+```
 
 **Result in Generated Content:**
 
@@ -1013,7 +1013,7 @@ $$
 # Expected Value
 
 The expected value of $Y$ is denoted $\E{Y}$, and variance as $\Var{Y}$.
-```bash
+```
 
 **Managing Macros:**
 
@@ -1026,7 +1026,7 @@ teach macros sync
 
 # Export for Scholar (auto-injected)
 teach macros export --format json
-```bash
+```
 
 See [Tutorial 26: LaTeX Macros](../tutorials/26-latex-macros.md) for complete macro workflow.
 
@@ -1063,7 +1063,7 @@ quarto preview
 # 8. Deploy
 teach deploy --preview
 teach deploy
-```bash
+```
 
 ### Creating an Exam from Lesson Plan
 
@@ -1087,7 +1087,7 @@ teach rubric "Midterm Exam" --criteria 6
 
 # 5. Preview
 quarto preview exams/
-```bash
+```
 
 ### Iterative Revision Workflow
 
@@ -1113,7 +1113,7 @@ quarto preview lectures/week-04-probability.qmd
 
 # 6. Deploy
 teach deploy
-```bash
+```
 
 ### Customizing Output with Prompts and Macros
 
@@ -1136,7 +1136,7 @@ teach lecture "Data Wrangling" --week 3 --code
 # Output will:
 # - Include tidyverse code examples (from prompt)
 # - Use consistent notation like \E{Y} (from macros)
-```text
+```
 
 ---
 
@@ -1148,7 +1148,7 @@ teach lecture "Data Wrangling" --week 3 --code
 
 ```text
 ❌ Error: Scholar plugin not available
-```bash
+```
 
 **Solution:**
 
@@ -1161,7 +1161,7 @@ claude plugins list | grep scholar
 
 # Verify
 teach doctor
-```text
+```
 
 ---
 
@@ -1171,7 +1171,7 @@ teach doctor
 
 ```text
 ❌ Error: Required field 'course.name' not found in teach-config.yml
-```yaml
+```
 
 **Solution:**
 
@@ -1185,7 +1185,7 @@ course:
 
 # Validate
 teach doctor
-```text
+```
 
 ---
 
@@ -1196,7 +1196,7 @@ teach doctor
 ```text
 ✓ Generation complete
 ✓ File created: lectures/week-05-regression.qmd
-```bash
+```
 
 But file is empty or contains only frontmatter.
 
@@ -1214,7 +1214,7 @@ teach lecture "Topic" --week 5 --verbose
 
 # 4. Check Scholar plugin logs
 # (See Scholar documentation for log location)
-```text
+```
 
 ---
 
@@ -1224,7 +1224,7 @@ teach lecture "Topic" --week 5 --verbose
 
 ```text
 ❌ Error: Conflicting flags: --math and --no-math
-```bash
+```
 
 **Solution:**
 
@@ -1238,7 +1238,7 @@ teach lecture "Topic" --math --no-math
 teach lecture "Topic" --math
 # OR
 teach lecture "Topic" --no-math
-```yaml
+```
 
 ---
 

--- a/docs/guides/TEACH-DEPLOY-GUIDE.md
+++ b/docs/guides/TEACH-DEPLOY-GUIDE.md
@@ -76,7 +76,7 @@ teach doctor
 
 # Install homebrew packages
 brew install gh yq
-```bash
+```
 
 ### Project Setup
 
@@ -123,7 +123,7 @@ git push -u origin main
 
 # Return to draft
 git checkout draft
-```text
+```
 
 ---
 
@@ -144,7 +144,7 @@ Deploys all changes between `draft` and `main` branches:
 
 ```bash
 teach deploy
-```bash
+```
 
 **Process:**
 1. Verify on draft branch
@@ -167,7 +167,7 @@ teach deploy lectures/week-05.qmd lectures/week-06.qmd
 
 # Entire directory
 teach deploy lectures/
-```bash
+```
 
 **Process:**
 1. Find dependencies (sourced files, cross-references)
@@ -192,7 +192,7 @@ teach deploy -d -m "Week 5 lecture updates"
 
 # CI-friendly direct deploy
 teach deploy --ci -d
-```text
+```
 
 **Process (with step progress):**
 
@@ -202,7 +202,7 @@ teach deploy --ci -d
   ✓ [3/5] Merge draft → production
   ✓ [4/5] Push production to origin
   ✓ [5/5] Switch back to draft
-```text
+```
 
 After completion, a deployment summary box is displayed:
 
@@ -215,7 +215,7 @@ After completion, a deployment summary box is displayed:
 │  🌐 URL:      https://example.github.io/stat-545/    │
 │  ⚙  Actions:  https://github.com/user/stat-545/actions│
 ╰──────────────────────────────────────────────────────╯
-```diff
+```
 
 The **Actions** line links directly to your GitHub Actions page for monitoring the deployment pipeline. It's auto-detected from your remote URL and skipped for non-GitHub remotes.
 
@@ -237,7 +237,7 @@ teach deploy --history
 
 # Show last 20
 teach deploy --history 20
-```text
+```
 
 **Output:**
 
@@ -248,7 +248,7 @@ Recent deployments:
 1  2026-02-03 14:30  direct   3      content: week-05 lecture
 2  2026-02-02 09:15  pr       15     deploy: full site update
 3  2026-02-01 16:45  partial  2      content: assignment 3
-```bash
+```
 
 ### Rollback
 
@@ -263,7 +263,7 @@ teach deploy --rollback 1
 
 # Rollback 2nd most recent (CI mode)
 teach deploy --rollback 2 --ci
-```yaml
+```
 
 **Safety:** Rollback uses `git revert` (not `git reset`), preserving full history. The rollback itself is recorded in deploy history with mode "rollback".
 
@@ -281,7 +281,7 @@ deploys:
     branch_to: 'main'
     file_count: 15
     commit_message: 'content: week-05 lecture'
-```bash
+```
 
 ---
 
@@ -298,7 +298,7 @@ teach deploy --dry-run --direct
 
 # Preview with custom message
 teach deploy --preview -m "Week 5"
-```text
+```
 
 **Output:**
 
@@ -314,7 +314,7 @@ Would commit: "content: week-05 lecture, analysis script"
 Would merge: draft -> production (direct mode)
 Would log: deploy #12 to .flow/deploy-history.yml
 Would update: .STATUS (teaching_week: 5)
-```bash
+```
 
 ---
 
@@ -330,13 +330,13 @@ git branch --show-current  # Should output: draft
 
 # If on wrong branch
 git checkout draft
-```text
+```
 
 **2. Run deploy command**
 
 ```bash
 teach deploy
-```text
+```
 
 **3. Pre-flight checks**
 
@@ -349,7 +349,7 @@ The command validates:
 ✓ No uncommitted changes
 ✓ Remote is up-to-date
 ✓ No conflicts with production
-```text
+```
 
 **4. Review changes**
 
@@ -363,7 +363,7 @@ Files Changed:
   M  home_lectures.qmd
 
 Summary: 3 files (1 added, 2 modified, 0 deleted)
-```text
+```
 
 **5. Create pull request**
 
@@ -375,7 +375,7 @@ Create pull request?
   [3] Cancel
 
 Your choice [1-3]: 1
-```text
+```
 
 **6. Verify PR created**
 
@@ -383,7 +383,7 @@ Your choice [1-3]: 1
 ✅ Pull Request Created
 
 View PR: https://github.com/username/course-repo/pull/42
-```text
+```
 
 ### Handling Conflicts
 
@@ -399,7 +399,7 @@ Production branch has updates. Rebase first?
   [3] Cancel deployment
 
 Your choice [1-3]: 1
-```text
+```
 
 **Recommended:** Always choose option [1] to rebase before deploying.
 
@@ -407,7 +407,7 @@ Your choice [1-3]: 1
 
 ```bash
 teach deploy --sync
-```diff
+```
 
 This tries fast-forward first, then falls back to a regular merge if needed.
 
@@ -427,7 +427,7 @@ Deploy before entire course is ready:
 
 ```bash
 teach deploy lectures/week-05.qmd
-```text
+```
 
 **Output:**
 
@@ -448,7 +448,7 @@ Files to deploy:
 
 Found 2 additional dependencies
 Include dependencies in deployment? [Y/n]: y
-```bash
+```
 
 ### Dependency Tracking
 
@@ -466,7 +466,7 @@ Include dependencies in deployment? [Y/n]: y
 
 # Skip dependencies (deploy only specified file)
 Include dependencies in deployment? [Y/n]: n
-```yaml
+```
 
 ### Index Management
 
@@ -481,7 +481,7 @@ lectures:
   - week-02.qmd
   - week-03.qmd
   - week-04.qmd
-```yaml
+```
 
 **After deploying week-05.qmd:**
 
@@ -492,13 +492,13 @@ lectures:
   - week-03.qmd
   - week-04.qmd
   - week-05.qmd  # ← ADDED
-```text
+```
 
 **Skip index updates:**
 
 ```bash
 teach deploy lectures/week-05.qmd --skip-index
-```text
+```
 
 ### Auto-Commit Workflow
 
@@ -511,13 +511,13 @@ If deploying files have uncommitted changes:
 
 Commit message (or Enter for auto): Fix regression example
 ✓ Committed changes
-```text
+```
 
 **Auto-commit mode:**
 
 ```bash
 teach deploy lectures/week-05.qmd --auto-commit
-```text
+```
 
 Uses default message: `Update: 2026-02-02`
 
@@ -533,7 +533,7 @@ Ensures you're on the draft branch:
 
 ```text
 ✓ On draft branch
-```text
+```
 
 If on wrong branch:
 
@@ -542,7 +542,7 @@ If on wrong branch:
 
 Switch to draft branch? [Y/n]: y
 ✓ Switched to draft
-```text
+```
 
 ### Check 2: Uncommitted Changes (v6.6.0 Enhanced)
 
@@ -550,13 +550,13 @@ Pre-flight reports working tree status:
 
 ```bash
   [ok] Working tree clean
-```text
+```
 
 If uncommitted changes exist, the pre-flight reports a warning:
 
 ```bash
   [--] Working tree has uncommitted changes
-```text
+```
 
 Then, after pre-flight, an **interactive prompt** offers to commit:
 
@@ -565,7 +565,7 @@ Then, after pre-flight, an **interactive prompt** offers to commit:
   Suggested: content: week-05 lecture
 
   Commit and continue? [Y/n]:
-```diff
+```
 
 - Press **Enter** or **Y** — stages all files (`git add -A`), commits with the smart message, continues deploy
 - Press **N** — cancels deploy, nothing changed
@@ -581,21 +581,21 @@ Then, after pre-flight, an **interactive prompt** offers to commit:
     3. Force: git commit --no-verify -m "message"
 
   Changes are still staged.
-```text
+```
 
 **CI mode:** Uncommitted changes fail immediately:
 
 ```text
 ERROR: Uncommitted changes detected
   Commit changes before deploying in CI mode
-```yaml
+```
 
 **Disable check** in `.flow/teach-config.yml`:
 
 ```yaml
 git:
   require_clean: false  # Skip uncommitted changes handling entirely
-```text
+```
 
 ### Check 3: Display Math Validation
 
@@ -611,7 +611,7 @@ Only files in the `git diff` between branches are checked (not the entire course
 
 ```bash
   [ok] Display math blocks valid
-```text
+```
 
 If blank lines are found:
 
@@ -619,7 +619,7 @@ If blank lines are found:
   [!!] Blank lines in display math (breaks PDF):
        lectures/week-05.qmd
        Remove blank lines between $$ delimiters in the files above
-```text
+```
 
 If an unclosed `$$` block is found:
 
@@ -627,7 +627,7 @@ If an unclosed `$$` block is found:
   [!!] Unclosed $$ block (breaks render):
        lectures/week-03.qmd
        Add missing closing $$ delimiter in the files above
-```diff
+```
 
 **Interactive mode:** Warns but continues (non-blocking).
 
@@ -645,7 +645,7 @@ Ensures draft branch is synced with remote:
 
 ```text
 ✓ Remote is up-to-date
-```text
+```
 
 If unpushed commits exist:
 
@@ -654,7 +654,7 @@ If unpushed commits exist:
 
 Push to origin/draft first? [Y/n]: y
 ✓ Pushed to origin/draft
-```text
+```
 
 ### Check 5: Production Conflicts
 
@@ -662,7 +662,7 @@ Detects if production has real content commits that could cause conflicts. Merge
 
 ```text
 ✓ No conflicts with production
-```text
+```
 
 If conflicts exist, see [Handling Conflicts](#handling-conflicts). You can also run `teach deploy --sync` to pull production changes into your draft branch.
 
@@ -676,7 +676,7 @@ Block deployment if concepts are used before introduction:
 
 ```bash
 teach deploy --check-prereqs
-```text
+```
 
 **Validation process:**
 
@@ -686,7 +686,7 @@ teach deploy --check-prereqs
   Building concept graph...
   Checking 42 concepts...
 ✓ All prerequisites satisfied
-```text
+```
 
 **If violations found:**
 
@@ -699,7 +699,7 @@ Deploy blocked: Prerequisite validation failed
 Fix missing prerequisites before deploying
 
 Tip: Run 'teach validate --deep' to see full details
-```text
+```
 
 ### Auto-Commit
 
@@ -707,7 +707,7 @@ Automatically commit changes without prompts:
 
 ```bash
 teach deploy lectures/week-05.qmd --auto-commit
-```text
+```
 
 Uses default commit message: `Update: YYYY-MM-DD`
 
@@ -717,7 +717,7 @@ Tag deployment with timestamp:
 
 ```bash
 teach deploy --auto-tag
-```text
+```
 
 Creates tag: `deploy-2026-02-02-1430`
 
@@ -727,7 +727,7 @@ Deploy without updating navigation files:
 
 ```bash
 teach deploy lectures/week-05.qmd --skip-index
-```diff
+```
 
 Use when:
 - File isn't listed in navigation
@@ -742,7 +742,7 @@ teach deploy lectures/week-05.qmd \
   --auto-tag \
   --skip-index \
   --check-prereqs
-```yaml
+```
 
 ---
 
@@ -761,7 +761,7 @@ git:
 
 course:
   name: "STAT-101 Regression Analysis"
-```text
+```
 
 ### Branch Setup
 
@@ -773,7 +773,7 @@ GitHub Pages deploys from `main` branch:
 Settings → Pages → Source → Deploy from a branch
 Branch: main
 Folder: / (root)
-```text
+```
 
 **2. Verify deployment:**
 
@@ -781,7 +781,7 @@ After merging PR to main, GitHub Actions builds and deploys:
 
 ```text
 https://username.github.io/course-repo/
-```bash
+```
 
 ### Custom Domain
 
@@ -791,7 +791,7 @@ https://username.github.io/course-repo/
 echo "stat101.university.edu" > CNAME
 git add CNAME
 git commit -m "Add custom domain"
-```text
+```
 
 **2. Configure DNS:**
 
@@ -801,13 +801,13 @@ A records: @ → 185.199.108.153
            @ → 185.199.109.153
            @ → 185.199.110.153
            @ → 185.199.111.153
-```text
+```
 
 **3. Update GitHub Pages settings:**
 
 ```text
 Settings → Pages → Custom domain → stat101.university.edu
-```bash
+```
 
 ### First-Time Deployment
 
@@ -822,20 +822,20 @@ echo "GitHub Pages placeholder" > index.html
 git add index.html
 git commit -m "Initialize GitHub Pages"
 git push origin gh-pages
-```text
+```
 
 **2. Configure GitHub Pages source:**
 
 ```text
 Settings → Pages → Source → gh-pages branch
-```bash
+```
 
 **3. Run first deployment:**
 
 ```bash
 git checkout draft
 teach deploy
-```text
+```
 
 ---
 
@@ -847,7 +847,7 @@ teach deploy
 
 ```bash
 gh pr list
-```text
+```
 
 **2. Review PR on GitHub:**
 
@@ -855,7 +855,7 @@ Click link from deploy output:
 
 ```text
 View PR: https://github.com/username/course-repo/pull/42
-```text
+```
 
 **3. Check CI/CD status:**
 
@@ -864,7 +864,7 @@ GitHub Actions runs on PR creation:
 ```text
 ✓ Build Quarto site (2m 34s)
 ✓ Deploy preview (15s)
-```text
+```
 
 ### Merge Pull Request
 
@@ -878,7 +878,7 @@ GitHub Actions runs on PR creation:
 
 ```bash
 gh pr merge 42 --squash --delete-branch
-```bash
+```
 
 ### Verify Live Site
 
@@ -889,13 +889,13 @@ gh pr merge 42 --squash --delete-branch
 gh api repos/:owner/:repo/pages/builds/latest
 
 # Typical deployment time: 30-60 seconds
-```text
+```
 
 **2. Visit deployed site:**
 
 ```text
 https://username.github.io/course-repo/
-```diff
+```
 
 **3. Verify changes:**
 
@@ -916,14 +916,14 @@ https://username.github.io/course-repo/
 
 ```text
 ✗ Not on draft branch (currently on: main)
-```bash
+```
 
 **Solution:**
 
 ```bash
 git checkout draft
 teach deploy
-```text
+```
 
 #### 2. Uncommitted changes
 
@@ -931,7 +931,7 @@ teach deploy
 
 ```text
 ✗ Uncommitted changes detected
-```bash
+```
 
 **Solution:**
 
@@ -946,7 +946,7 @@ git stash
 # Option 3: Allow uncommitted (in config)
 # Edit .flow/teach-config.yml:
 #   git.require_clean: false
-```text
+```
 
 #### 3. Permission denied (GitHub Pages)
 
@@ -954,7 +954,7 @@ git stash
 
 ```text
 gh: Permission denied (publickey)
-```bash
+```
 
 **Solution:**
 
@@ -965,7 +965,7 @@ ssh-keygen -t ed25519 -C "your_email@example.com"
 # Add to GitHub
 cat ~/.ssh/id_ed25519.pub
 # Copy output to GitHub Settings → SSH Keys
-```text
+```
 
 #### 4. Build failures (Quarto errors)
 
@@ -973,7 +973,7 @@ cat ~/.ssh/id_ed25519.pub
 
 ```text
 Error: Quarto render failed
-```bash
+```
 
 **Solution:**
 
@@ -986,7 +986,7 @@ quarto --version
 
 # Update Quarto if needed
 brew upgrade quarto
-```bash
+```
 
 #### 5. Missing content after deploy
 
@@ -1032,7 +1032,7 @@ brew upgrade quarto
 
 ```text
 ! [rejected] main -> main (non-fast-forward)
-```bash
+```
 
 **Solution:**
 
@@ -1046,7 +1046,7 @@ git rebase origin/main
 
 # Re-run deploy
 teach deploy
-```text
+```
 
 #### 7. Cross-reference validation failures
 
@@ -1054,7 +1054,7 @@ teach deploy
 
 ```text
 ✗ Broken reference: @fig-does-not-exist in lectures/week-05.qmd
-```bash
+```
 
 **Solution:**
 
@@ -1069,7 +1069,7 @@ teach validate lectures/week-05.qmd
 
 # Re-deploy
 teach deploy lectures/week-05.qmd
-```bash
+```
 
 #### 8. Dependency tracking issues
 
@@ -1089,7 +1089,7 @@ teach deploy lectures/week-05.qmd
 
 # Manual workaround: deploy dependencies separately
 teach deploy lectures/week-05.qmd _macros.qmd
-```yaml
+```
 
 ---
 
@@ -1130,7 +1130,7 @@ jobs:
           target: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```diff
+```
 
 **Benefits:**
 
@@ -1150,14 +1150,14 @@ Use Netlify/Vercel for PR previews:
 
 [context.deploy-preview]
   command = "quarto render"
-```text
+```
 
 Deploy preview URL appears in PR comments:
 
 ```text
 ✓ Deploy Preview ready!
 https://deploy-preview-42--course-site.netlify.app
-```bash
+```
 
 ### Rollback Procedure
 
@@ -1172,7 +1172,7 @@ teach deploy --rollback 1
 
 # Verify site
 open https://username.github.io/course-repo/
-```bash
+```
 
 **Manual rollback (if needed):**
 
@@ -1180,7 +1180,7 @@ open https://username.github.io/course-repo/
 git log --oneline main | head -5
 git revert -m 1 <merge-commit-hash>
 git push origin main
-```bash
+```
 
 ---
 

--- a/docs/guides/TEACHING-COMMANDS-DETAILED.md
+++ b/docs/guides/TEACHING-COMMANDS-DETAILED.md
@@ -53,7 +53,7 @@ flowchart TB
     style init fill:#4CAF50,color:#fff
     style deploy fill:#2196F3,color:#fff
     style archive fill:#FF9800,color:#fff
-```text
+```
 
 ### Branch Strategy
 
@@ -73,7 +73,7 @@ gitGraph
     merge draft id: "Deploy v2" tag: "live"
     checkout draft
     commit id: "Week 4 materials"
-```text
+```
 
 **Key Principle:** You always work on `draft`. Students always see `production`. The `teach deploy` command safely moves changes between them.
 
@@ -122,7 +122,7 @@ flowchart TD
     style Start fill:#4CAF50,color:#fff
     style CreateConfig fill:#2196F3,color:#fff
     style End fill:#9E9E9E,color:#fff
-```text
+```
 
 #### Decision Tree
 
@@ -138,7 +138,7 @@ flowchart TD
 teach init "Course Name"              # Interactive mode
 teach init -y "Course Name"           # Non-interactive (safe defaults)
 teach init --dry-run "Course Name"    # Preview without changes
-```diff
+```
 
 **When to use:**
 - First time setting up a course repository
@@ -236,14 +236,14 @@ teach init "STAT 545"
 #
 # Next: push to GitHub
 # $ git push -u origin draft production
-```bash
+```
 
 **Non-interactive (safe defaults):**
 
 ```bash
 teach init -y "STAT 440"
 # Uses all defaults, completes in seconds
-```text
+```
 
 ---
 
@@ -315,7 +315,7 @@ flowchart TD
     style ErrorConfig fill:#f44336,color:#fff
     style ErrorDirty fill:#f44336,color:#fff
     style End fill:#9E9E9E,color:#fff
-```text
+```
 
 #### Pre-flight Checks Summary
 
@@ -333,7 +333,7 @@ flowchart TD
 ```bash
 teach deploy              # Standard PR workflow
 teach deploy --direct-push # Bypass PR (advanced users only)
-```diff
+```
 
 **Requirements:**
 - Must be in a git repository
@@ -432,7 +432,7 @@ teach deploy
 # ✅ Deployed to production in 47s
 # 🌐 Site: https://user.github.io/stat-545
 # ⏳ GitHub Actions deploying (usually < 2 min)
-```text
+```
 
 **Error scenarios:**
 
@@ -442,7 +442,7 @@ teach deploy
 ❌ Must be on draft branch
 Current branch: production
 Run: git checkout draft
-```text
+```
 
 **Uncommitted changes:**
 
@@ -451,7 +451,7 @@ Run: git checkout draft
 Commit or stash changes first:
 $ git add .
 $ git commit -m "your message"
-```diff
+```
 
 **Merge conflicts:**
 - Automatically resolves most conflicts
@@ -502,7 +502,7 @@ flowchart TD
     style Start fill:#9C27B0,color:#fff
     style RenderDashboard fill:#2196F3,color:#fff
     style End fill:#9E9E9E,color:#fff
-```text
+```
 
 #### Status Indicators
 
@@ -517,7 +517,7 @@ flowchart TD
 
 ```bash
 teach status
-```diff
+```
 
 **When to use:**
 - Starting a work session (quick orientation)
@@ -575,7 +575,7 @@ teach status
 │  💡 Tip: Run 'teach deploy' to publish changes     │
 │                                                    │
 ╰────────────────────────────────────────────────────╯
-```text
+```
 
 ---
 
@@ -617,7 +617,7 @@ flowchart TD
     style ShowWeek fill:#4CAF50,color:#fff
     style ShowBreak fill:#9C27B0,color:#fff
     style End fill:#9E9E9E,color:#fff
-```text
+```
 
 #### Week Calculation
 
@@ -636,14 +636,14 @@ flowchart LR
 
     Jan13 --> |14 days| Jan27
     Jan27 --> |14 ÷ 7 + 1| Result
-```text
+```
 
 **Syntax:**
 
 ```bash
 teach week           # Current week
 teach week 5         # Info for week 5
-```diff
+```
 
 **When to use:**
 - Planning course materials
@@ -665,7 +665,7 @@ Semester Timeline:
 
 ⚡ No breaks this week
 💡 Coming up: Spring Break (Mar 10-17)
-```diff
+```
 
 ---
 
@@ -716,7 +716,7 @@ flowchart TD
     style CreateTag fill:#4CAF50,color:#fff
     style ShowNext fill:#2196F3,color:#fff
     style End fill:#9E9E9E,color:#fff
-```text
+```
 
 #### Archive Tag Naming
 
@@ -736,7 +736,7 @@ flowchart LR
         E2["spring-2026-final"]
         E3["summer-2026-final"]
     end
-```bash
+```
 
 #### Semester Lifecycle
 
@@ -753,13 +753,13 @@ stateDiagram-v2
         Creates immutable snapshot
         spring-2026-final
     end note
-```text
+```
 
 **Syntax:**
 
 ```bash
 teach archive
-```diff
+```
 
 **When to use:**
 - End of each semester (after final grades submitted)
@@ -822,7 +822,7 @@ teach archive
 #    $ git add .flow/teach-config.yml
 #    $ git commit -m "prep: update for Fall 2026"
 #    $ teach deploy
-```text
+```
 
 ---
 
@@ -835,7 +835,7 @@ Opens the `.flow/teach-config.yml` file in your editor for customization.
 
 ```bash
 teach config
-```diff
+```
 
 **When to use:**
 - Updating semester dates
@@ -877,7 +877,7 @@ branches:
 shortcuts:
   s545: "work stat-545"      # Quick work shortcut
   s545d: "./scripts/quick-deploy.sh"  # Quick deploy
-```bash
+```
 
 **Common edits:**
 
@@ -894,7 +894,7 @@ semester: "fall"
 year: 2026
 start_date: "2026-08-25"
 end_date: "2026-12-10"
-```yaml
+```
 
 **Adding breaks:**
 
@@ -906,7 +906,7 @@ breaks:
   - name: "Winter Break"
     start: "2026-12-20"
     end: "2027-01-08"
-```text
+```
 
 ---
 
@@ -920,7 +920,7 @@ Creates a new exam/quiz template using the `examark` tool (if installed). Sets u
 ```bash
 teach exam "Midterm 1"
 teach exam "Final Exam"
-```diff
+```
 
 **When to use:**
 - Creating new exams or quizzes
@@ -977,7 +977,7 @@ d) ...
 
 ### Question 2 (10 points)
 ...
-```bash
+```
 
 ---
 
@@ -1012,7 +1012,7 @@ teach deploy
 
 # 5. Verify live
 open https://yoursite.github.io/stat-545
-```bash
+```
 
 **Time:** 5 minutes total
 
@@ -1049,7 +1049,7 @@ teach deploy
 teach status
 # → Shows deployment successful
 # → Shows week number for verification
-```bash
+```
 
 **Time:** 15 minutes
 
@@ -1089,7 +1089,7 @@ teach deploy
 
 # 5. Done!
 # Next semester starts fresh with new dates, same branch structure
-```bash
+```
 
 **Time:** 10 minutes
 
@@ -1116,7 +1116,7 @@ teach deploy
 # No need to email them, they'll see it when they check
 
 # Result: Problem solved in 2 minutes, students notified automatically
-```bash
+```
 
 **Time:** 2 minutes
 
@@ -1136,7 +1136,7 @@ teach init "Course Name"
 
 # Or with non-interactive mode
 teach init -y "Course Name"
-```diff
+```
 
 **What this creates:**
 - `.flow/teach-config.yml` - Configuration file
@@ -1160,7 +1160,7 @@ teach deploy
 # Option 2: Switch manually
 git checkout draft
 teach deploy
-```bash
+```
 
 **Prevention:** Work sessions automatically warn if on production
 
@@ -1184,7 +1184,7 @@ git commit -m "fix: update lecture notes"
 
 # Now deploy
 teach deploy
-```bash
+```
 
 ---
 
@@ -1200,7 +1200,7 @@ gh run list
 
 # Or visit GitHub Actions tab:
 # github.com/your-org/repo-name/actions
-```diff
+```
 
 Usually caused by:
 - Large file changes (PDFs, images)
@@ -1220,7 +1220,7 @@ work stat-545
 # → Course name displayed
 # → Week number shown
 # → Shortcuts loaded
-```bash
+```
 
 ### With `pick` command
 
@@ -1229,7 +1229,7 @@ work stat-545
 pick
 # 🎓 stat-545
 # 🎓 stat-440
-```bash
+```
 
 ### With `dash` command
 

--- a/docs/guides/TEACHING-DATES-GUIDE.md
+++ b/docs/guides/TEACHING-DATES-GUIDE.md
@@ -33,7 +33,7 @@ Teaching a course involves managing dates in multiple places:
 ❌ assignments/hw1.qmd:  due: "2025-01-20"  # ← Mismatch!
 ❌ schedule.qmd:        "Week 2: January 22, 2025"
 ❌ lectures/week02.qmd: "Due: Jan 22, 2025"
-```diff
+```
 
 **Problems:**
 - 📅 40+ dates to update manually each semester
@@ -50,7 +50,7 @@ semester_info:
     hw1:
       week: 2
       offset_days: 2  # Due Friday of Week 2
-```bash
+```
 
 Run `teach dates sync` and all files update automatically.
 
@@ -83,7 +83,7 @@ date --version         # GNU date or BSD date
 
 # flow-cli v5.11.0+
 teach dates help
-```bash
+```
 
 ### Initial Setup
 
@@ -99,7 +99,7 @@ Semester start date (YYYY-MM-DD): 2025-01-13
 
 # Step 3: Verify config was created
 cat .flow/teach-config.yml
-```diff
+```
 
 **What gets created:**
 - 15 weeks with start dates (auto-calculated)
@@ -142,7 +142,7 @@ teach dates sync
 
 # ✅ Date Sync Complete
 # Applied: 1 files
-```yaml
+```
 
 ---
 
@@ -161,7 +161,7 @@ semester_info:
   holidays: []                  # Array of holiday/break objects
   deadlines: {}                 # Object mapping assignment IDs to dates
   exams: []                     # Array of exam objects
-```yaml
+```
 
 ### Required Fields
 
@@ -177,7 +177,7 @@ semester_info:
       start_date: "2025-01-13"
       topic: "Introduction"
     # ... weeks 2-15
-```diff
+```
 
 **Validation:**
 - `start_date` and `end_date` must be ISO format (`YYYY-MM-DD`)
@@ -201,7 +201,7 @@ weeks:
     start_date: "2025-01-20"
     topic: "Data Manipulation with dplyr"
     reading: "Chapter 3"
-```diff
+```
 
 **Fields:**
 - `number` (required): Week number (integer)
@@ -227,7 +227,7 @@ holidays:
   - name: "No class - conference"
     date: "2025-04-15"
     type: "no_class"
-```diff
+```
 
 **Types:**
 - `break` - Multi-day break (Spring/Fall break)
@@ -253,7 +253,7 @@ deadlines:
   project_proposal:
     week: 8
     offset_days: -2      # Due before week 8 starts
-```diff
+```
 
 **Why relative dates?**
 - Automatically adjust when semester dates shift
@@ -280,7 +280,7 @@ exams:
     date: "2025-05-08"
     time: "10:00 AM - 12:00 PM"
     location: "Same as midterm"
-```text
+```
 
 ### Date Formats Supported
 
@@ -291,7 +291,7 @@ exams:
 ```yaml
 start_date: "2025-01-13"
 due_date: "2025-03-22"
-```diff
+```
 
 Used in:
 - ✅ Config file (`teach-config.yml`)
@@ -306,7 +306,7 @@ Used in:
 hw1:
   week: 2
   offset_days: 2   # Week 2 start (Mon) + 2 = Wed
-```diff
+```
 
 **Examples:**
 - `week: 2, offset_days: 0` → Monday of week 2
@@ -323,7 +323,7 @@ spring_break:
   start_date: "2025-03-10"
   end_date: "2025-03-14"
   type: "break"
-```yaml
+```
 
 ---
 
@@ -343,7 +343,7 @@ published: "2025-01-15"         # Publication date
 modified: "2025-01-20"          # Last modified
 exam_date: "2025-03-05"         # Exam date
 ---
-```diff
+```
 
 **Recognized fields:**
 - `date`, `due`, `published`, `modified`
@@ -360,7 +360,7 @@ office_hours_start: "2025-01-13"
 project_checkpoint_1: "2025-02-15"
 peer_review_due: "2025-03-01"
 ---
-```diff
+```
 
 The parser will extract any field ending in `_date` or named `due`.
 
@@ -374,7 +374,7 @@ title: "Homework 1: Data Wrangling"
 due: "2025-01-22"
 points: 100
 ---
-```diff
+```
 
 **Syllabus:**
 
@@ -384,7 +384,7 @@ title: "Course Syllabus"
 date: "2025-01-13"
 semester: "Spring 2025"
 ---
-```diff
+```
 
 **Lecture:**
 
@@ -394,7 +394,7 @@ title: "Week 2: dplyr Basics"
 date: "2025-01-20"
 week: 2
 ---
-```yaml
+```
 
 ### Markdown Inline Dates
 
@@ -406,7 +406,7 @@ The parser also finds dates in prose text:
 **Week 2: January 20, 2025** - Data Manipulation
 
 Due: Week 2, Friday (January 22, 2025)
-```diff
+```
 
 Matches:
 - `Week N: <date>`
@@ -418,7 +418,7 @@ Matches:
 The midterm exam is on **March 5, 2025** at 2:00 PM.
 
 Assignment due: January 22, 2025
-```diff
+```
 
 Matches:
 - `January 22, 2025`
@@ -430,7 +430,7 @@ Matches:
 ```markdown
 Due: 1/22/2025
 Exam: 3/5/2025
-```diff
+```
 
 Matches:
 - `M/D/YYYY`
@@ -446,7 +446,7 @@ Matches:
 | 1    | Jan 13     | Introduction       |
 | 2    | Jan 20     | Data Manipulation  |
 | 3    | Jan 27     | Visualization      |
-```diff
+```
 
 Matches:
 - `Jan 13` (infers current year)
@@ -465,7 +465,7 @@ Synchronize dates from config to all teaching files.
 
 ```bash
 teach dates sync [options]
-```bash
+```
 
 #### Flags
 
@@ -496,7 +496,7 @@ Apply changes? [y/n/d/q]
   n - No, skip this file
   d - Show diff
   q - Quit (no more changes)
-```diff
+```
 
 **Options:**
 - `y` - Apply changes to this file
@@ -520,7 +520,7 @@ teach dates sync --dry-run
 
 ℹ  Dry-run mode: No changes made
   Run without --dry-run to apply changes
-```bash
+```
 
 #### Examples
 
@@ -545,7 +545,7 @@ teach dates sync --file assignments/hw3.qmd
 
 # Verbose output
 teach dates sync -v
-```text
+```
 
 ### teach dates status
 
@@ -555,7 +555,7 @@ Show date configuration summary and consistency status.
 
 ```bash
 teach dates status
-```text
+```
 
 #### Output Format
 
@@ -571,7 +571,7 @@ Upcoming Deadlines (Next 7 Days):
   Jan 24 - Quiz 1 (4 days)
 
 Date Sync Status: ✅ All files in sync
-```bash
+```
 
 #### Examples
 
@@ -582,7 +582,7 @@ teach dates status
 # Check before making changes
 teach dates status
 teach dates sync --dry-run
-```text
+```
 
 ### teach dates init
 
@@ -592,7 +592,7 @@ Initialize date configuration with interactive wizard.
 
 ```bash
 teach dates init
-```text
+```
 
 #### Wizard Flow
 
@@ -613,7 +613,7 @@ Next: Edit .flow/teach-config.yml to add:
   - Holidays
   - Assignment deadlines
   - Exam dates
-```bash
+```
 
 **What it creates:**
 1. `semester_info.start_date`
@@ -632,7 +632,7 @@ teach dates init
 
 # Config is created, now edit it:
 vim .flow/teach-config.yml
-```text
+```
 
 ### teach dates validate
 
@@ -642,7 +642,7 @@ Validate date configuration for errors.
 
 ```bash
 teach dates validate
-```diff
+```
 
 #### Validation Rules
 
@@ -682,7 +682,7 @@ teach dates validate
 ✓ Week dates chronological
 ⚠️  Warning: holiday "Spring Break" on Saturday
 ✅ Validation complete: 0 errors, 1 warning
-```bash
+```
 
 ---
 
@@ -708,7 +708,7 @@ git diff
 # 5. Commit
 git add -A
 git commit -m "chore: sync dates to config"
-```bash
+```
 
 **Frequency:** Run before each deployment or weekly.
 
@@ -740,7 +740,7 @@ teach dates sync             # Apply
 # 5. Commit setup
 git add -A
 git commit -m "feat: initialize Spring 2025 dates"
-```bash
+```
 
 **Time:** ~15 minutes (vs 2 hours manually)
 
@@ -774,7 +774,7 @@ git commit -m "chore: extend hw3 deadline by 2 days"
 
 # 4. Deploy
 teach deploy
-```bash
+```
 
 **Time:** ~15 seconds with `teach deploy -d` (or < 2 min via PR)
 
@@ -815,7 +815,7 @@ git diff | less
 # 7. Commit
 git add -A
 git commit -m "feat: roll over to Spring 2026"
-```bash
+```
 
 **Time:** ~5 minutes (vs 2+ hours of manual find/replace)
 
@@ -846,7 +846,7 @@ teach dates sync --assignments
 # 4. Commit
 git add assignments/ .flow/teach-config.yml
 git commit -m "chore: update assignment deadlines"
-```yaml
+```
 
 ---
 
@@ -884,7 +884,7 @@ Config: hw1 due 2025-01-22
 File:   hw1.qmd due: 2025-01-20
 
 → File will be updated to 2025-01-22
-```diff
+```
 
 **Override:** Manually edit the file after sync if config is wrong.
 
@@ -952,7 +952,7 @@ weeks:
     topic: string (optional)
     notes: string (optional)
     reading: string (optional)
-```yaml
+```
 
 **Example:**
 
@@ -968,7 +968,7 @@ weeks:
     start_date: "2025-01-20"
     topic: "Data Wrangling with dplyr"
     reading: "Chapters 3-4"
-```yaml
+```
 
 ### holidays Array
 
@@ -980,7 +980,7 @@ holidays:
     date: string (YYYY-MM-DD)
     type: enum(break|holiday|no_class)
     notes: string (optional)
-```yaml
+```
 
 **Example:**
 
@@ -998,7 +998,7 @@ holidays:
   - name: "Instructor at conference"
     date: "2025-04-15"
     type: "no_class"
-```yaml
+```
 
 ### deadlines Object
 
@@ -1017,7 +1017,7 @@ deadlines:
     # Optional metadata
     points: integer
     notes: string
-```yaml
+```
 
 **Example:**
 
@@ -1036,7 +1036,7 @@ deadlines:
   final_project:
     due_date: "2025-05-08"  # Fixed: finals week
     points: 300
-```yaml
+```
 
 ### exams Array
 
@@ -1049,7 +1049,7 @@ exams:
     time: string (optional)
     location: string (optional)
     notes: string (optional)
-```yaml
+```
 
 **Example:**
 
@@ -1070,7 +1070,7 @@ exams:
     date: "2025-05-08"
     time: "10:00 AM - 12:00 PM"
     location: "Check registrar for room"
-```text
+```
 
 ---
 
@@ -1084,7 +1084,7 @@ exams:
 
 ```text
 ERROR: Invalid date format: 01/22/2025 (expected YYYY-MM-DD)
-```bash
+```
 
 **Cause:** Date in config is not ISO format
 
@@ -1096,7 +1096,7 @@ start_date: 01/22/2025
 
 # Right:
 start_date: "2025-01-22"
-```text
+```
 
 #### Missing Config Fields
 
@@ -1105,7 +1105,7 @@ start_date: "2025-01-22"
 ```text
 ⚠️  No dates found in config
 Add semester_info section to .flow/teach-config.yml
-```bash
+```
 
 **Cause:** Config missing `semester_info` or it's empty
 
@@ -1114,7 +1114,7 @@ Add semester_info section to .flow/teach-config.yml
 ```bash
 # Initialize dates
 teach dates init
-```yaml
+```
 
 Or manually add:
 
@@ -1123,7 +1123,7 @@ semester_info:
   start_date: "2025-01-13"
   end_date: "2025-05-02"
   weeks: []
-```text
+```
 
 #### File Not Found
 
@@ -1131,7 +1131,7 @@ semester_info:
 
 ```text
 ERROR: File not found: assignments/hw1.qmd
-```bash
+```
 
 **Cause:** Trying to sync a file that doesn't exist
 
@@ -1143,7 +1143,7 @@ ls assignments/
 
 # Use correct path
 teach dates sync --file assignments/homework-1.qmd
-```text
+```
 
 #### Invalid Date Calculation
 
@@ -1151,7 +1151,7 @@ teach dates sync --file assignments/homework-1.qmd
 
 ```text
 ERROR: Week 5 not found in config
-```bash
+```
 
 **Cause:** Relative date references week that doesn't exist
 
@@ -1163,7 +1163,7 @@ yq eval '.semester_info.weeks | length' .flow/teach-config.yml
 
 # If < 15, add more weeks
 teach dates init  # Regenerates 15 weeks
-```text
+```
 
 #### yq Command Not Found
 
@@ -1172,7 +1172,7 @@ teach dates init  # Regenerates 15 weeks
 ```text
 ERROR: yq required for date syncing
 Install: brew install yq
-```bash
+```
 
 **Cause:** `yq` not installed
 
@@ -1187,7 +1187,7 @@ sudo apt install yq
 
 # Verify
 yq --version  # Should be v4.0+
-```diff
+```
 
 #### Dates Not Syncing to Files
 
@@ -1202,7 +1202,7 @@ yq --version  # Should be v4.0+
 ---
 due: "2025-01-22"
 ---
-```yaml
+```
 
 **Cause 2:** Filename doesn't match config key
 
@@ -1216,7 +1216,7 @@ deadlines:
   homework_one:
     week: 2
     offset_days: 4
-```bash
+```
 
 #### Relative Dates Not Computing
 
@@ -1232,7 +1232,7 @@ yq eval '.semester_info.weeks[] | select(.number == 2)' .flow/teach-config.yml
 
 # If empty, add week:
 yq eval '.semester_info.weeks += [{"number": 2, "start_date": "2025-01-20"}]' -i .flow/teach-config.yml
-```bash
+```
 
 #### sed/yq Corruption
 
@@ -1250,7 +1250,7 @@ mv assignments/hw1.qmd.bak assignments/hw1.qmd
 git restore assignments/hw1.qmd
 
 # Report issue to flow-cli
-```bash
+```
 
 ### Error Messages Explained
 
@@ -1277,7 +1277,7 @@ teach dates sync --verbose
 # - Config dates loaded
 # - Comparison logic
 # - sed/yq commands executed
-```yaml
+```
 
 ---
 
@@ -1331,7 +1331,7 @@ teach dates sync
 # 8. Commit
 git add -A
 git commit -m "feat: centralize course dates in config"
-```bash
+```
 
 ### Migrating from Manual Date Management
 
@@ -1345,7 +1345,7 @@ git commit -m "feat: centralize course dates in config"
 # 4. Cross-check syllabus vs assignments
 # 5. Fix inconsistencies
 # Time: 2-4 hours
-```bash
+```
 
 **After (automated):**
 
@@ -1362,7 +1362,7 @@ teach dates sync --force
 git add -A && git commit -m "feat: Spring 2026"
 
 # Time: 5 minutes
-```bash
+```
 
 ### Rollback Strategy
 
@@ -1376,7 +1376,7 @@ git revert HEAD
 
 # Or restore specific files
 git restore assignments/*.qmd
-```bash
+```
 
 **Option 2: Remove automation**
 
@@ -1390,7 +1390,7 @@ semester_info:
 
 # Files keep their current dates (no change)
 # teach dates sync becomes no-op
-```yaml
+```
 
 **Option 3: Hybrid approach**
 
@@ -1404,7 +1404,7 @@ deadlines:
     offset_days: 4
 
 # Don't add exams (keep manual in files)
-```yaml
+```
 
 ---
 
@@ -1423,7 +1423,7 @@ weeks:
         topic: "Introduction"
       - date: "2025-01-15"
         topic: "Setup & RStudio"
-```bash
+```
 
 **Current workaround:** Use single meeting date (Monday) and handle others manually
 
@@ -1434,7 +1434,7 @@ weeks:
 ```bash
 # Planned command:
 teach dates import-calendar university-calendar.ics
-```diff
+```
 
 Would auto-populate `holidays` array
 
@@ -1449,7 +1449,7 @@ due: "2025-01-22"
 available: "2025-01-15"        # Custom field
 peer_review_due: "2025-01-24"  # Custom field
 ---
-```yaml
+```
 
 **To sync custom fields:**
 
@@ -1468,7 +1468,7 @@ semester_info:
     strict_week_spacing: true   # Enforce 7-day week spacing
     allow_weekend_exams: false  # Flag exams on weekends
     warn_tight_deadlines: true  # Warn if deadlines < 7 days apart
-```yaml
+```
 
 ---
 
@@ -1495,7 +1495,7 @@ semester_info:
 
   # 5. Major events (exams)
   exams: [...]
-```yaml
+```
 
 **Add comments for clarity:**
 
@@ -1512,7 +1512,7 @@ deadlines:
   # Major project (due end of semester)
   final_project:
     due_date: "2026-05-08"
-```diff
+```
 
 ### Naming Conventions
 
@@ -1539,7 +1539,7 @@ teach dates sync --force
 teach dates sync --dry-run
 # Review output
 teach dates sync
-```bash
+```
 
 **Workflow:**
 
@@ -1564,14 +1564,14 @@ git commit -m "chore: update hw3 deadline"
 # Commit 2: File sync
 git add assignments/hw3.qmd
 git commit -m "chore: sync hw3 date to config"
-```bash
+```
 
 **Option 2: Combined commit**
 
 ```bash
 git add .flow/teach-config.yml assignments/
 git commit -m "chore: extend hw3 deadline by 2 days"
-```bash
+```
 
 **Recommendation:** Use combined commits (less noise)
 
@@ -1594,7 +1594,7 @@ git commit -m "feat: roll over to Spring 2026"
 # PR/merge
 git push origin spring-2026-dates
 # Create PR on GitHub
-```yaml
+```
 
 ---
 
@@ -1670,7 +1670,7 @@ A: Yes. Add to git pre-commit hook:
 # .git/hooks/pre-commit
 #!/bin/bash
 teach dates sync --dry-run || exit 1
-```yaml
+```
 
 **Q: What if students already have old dates?**
 
@@ -1689,7 +1689,7 @@ teach dates sync --file assignments/hw3.qmd
 
 # 3. Deploy immediately
 teach deploy
-```yaml
+```
 
 **Q: Can I preview semester rollover?**
 
@@ -1697,7 +1697,7 @@ A: Yes (after v5.12.0 `teach semester rollover` ships):
 
 ```bash
 teach semester rollover --dry-run
-```yaml
+```
 
 ---
 
@@ -1791,7 +1791,7 @@ semester_info:
       date: "2025-05-08"
       time: "10:00 AM - 12:00 PM"
       location: "Per registrar (TBD)"
-```diff
+```
 
 ### Example Course Schedule
 
@@ -1829,7 +1829,7 @@ date: "2025-01-13"
 - **Midterm 2:** April 2, 2025 (2:00 PM)
 - **Final Project:** Due May 8, 2025
 - **Final Exam:** May 8, 2025 (10:00 AM)
-```diff
+```
 
 **After running `teach dates sync`, all dates match config automatically.**
 

--- a/docs/guides/TEACHING-DEMO-GUIDE.md
+++ b/docs/guides/TEACHING-DEMO-GUIDE.md
@@ -39,7 +39,7 @@ teach init -y "STAT 545"
 ls -la .flow/
 ls -la scripts/
 git log --oneline | head -3
-```bash
+```
 
 **Key points to highlight:**
 1. Single command creates everything
@@ -63,7 +63,7 @@ teach status
 
 # Also show:
 teach week
-```diff
+```
 
 **Key points:**
 1. Course name and semester
@@ -106,7 +106,7 @@ teach deploy
 
 # 6. Verify
 teach status
-```diff
+```
 
 **Key points:**
 1. `work` shows course context
@@ -150,7 +150,7 @@ Next steps for new semester:
 3. git commit
 4. teach deploy
 EOF
-```bash
+```
 
 **Key points:**
 1. Creates immutable snapshot
@@ -170,7 +170,7 @@ EOF
 
 ```bash
 brew install asciinema
-```bash
+```
 
 **Record:**
 
@@ -182,13 +182,13 @@ asciinema rec teaching-demo-1.cast
 # ...
 
 # Stop recording (Ctrl-D)
-```text
+```
 
 **Play:**
 
 ```bash
 asciinema play teaching-demo-1.cast
-```bash
+```
 
 **Convert to GIF:**
 
@@ -200,7 +200,7 @@ svg-term --cast teaching-demo-1.cast --out teaching-demo-1.svg
 
 # Convert SVG to GIF (if needed)
 # Use online converter or: cairosvg teaching-demo-1.svg -o teaching-demo-1.gif
-```bash
+```
 
 ---
 
@@ -210,7 +210,7 @@ svg-term --cast teaching-demo-1.cast --out teaching-demo-1.svg
 
 ```bash
 brew install ttyrec
-```bash
+```
 
 **Record:**
 
@@ -222,13 +222,13 @@ ttyrec teaching-demo-1.ttyrec
 # ...
 
 # Stop (Ctrl-D)
-```text
+```
 
 **Play:**
 
 ```bash
 ttyplay teaching-demo-1.ttyrec
-```bash
+```
 
 ---
 
@@ -247,7 +247,7 @@ ttyplay teaching-demo-1.ttyrec
 brew install ffmpeg
 
 ffmpeg -i recording.mov -vf "fps=10,scale=1280:-1:flags=lanczos" -c:v pngquant -f image2pipe - | ffmpeg -f image2pipe -i - output.gif
-```bash
+```
 
 ---
 
@@ -282,7 +282,7 @@ head -20 scripts/quick-deploy.sh
 
 echo ""
 echo "✓ Course setup complete in seconds!"
-```bash
+```
 
 ### Script 2: teach status
 
@@ -302,7 +302,7 @@ teach status
 echo ""
 echo "$ teach week"
 teach week
-```bash
+```
 
 ### Script 3: Full Workflow
 
@@ -348,7 +348,7 @@ teach deploy
 
 echo ""
 echo "✓ Materials live in seconds with teach deploy -d!"
-```text
+```
 
 ---
 
@@ -405,7 +405,7 @@ echo "✓ Materials live in seconds with teach deploy -d!"
     │ teach deploy                           │
     │ (ready for next semester)              │
     └────────────────────────────────────────┘
-```sql
+```
 
 ---
 
@@ -439,7 +439,7 @@ git commit -m "add sample materials"
 teach deploy
 
 # Now ready for demos!
-```text
+```
 
 ---
 
@@ -455,7 +455,7 @@ Examples:
 - teaching-deploy-workflow.gif
 - teaching-status-dashboard.gif
 - teaching-full-workflow.gif
-```text
+```
 
 **Storage location:**
 
@@ -465,7 +465,7 @@ docs/assets/gifs/teaching/
 ├── teaching-deploy-workflow.gif
 ├── teaching-status-dashboard.gif
 └── teaching-workflow-daily.gif
-```text
+```
 
 **Markdown embed:**
 
@@ -475,7 +475,7 @@ docs/assets/gifs/teaching/
 ![Deploy workflow GIF](../../assets/gifs/teaching/teaching-deploy-workflow.gif)
 
 The deploy command merges your changes to production in seconds.
-```diff
+```
 
 ---
 
@@ -510,7 +510,7 @@ The deploy command merges your changes to production in seconds.
 ```bash
 # Reduce quality/fps
 ffmpeg -i recording.mov -vf "fps=5,scale=960:-1:flags=lanczos" -c:v pngquant -f image2pipe - | ffmpeg -f image2pipe -i - output.gif
-```bash
+```
 
 ### Asciinema cast won't convert?
 

--- a/docs/guides/TEACHING-SYSTEM-ARCHITECTURE.md
+++ b/docs/guides/TEACHING-SYSTEM-ARCHITECTURE.md
@@ -70,7 +70,7 @@ teach week                # Current week info
 teach archive             # Create semester snapshot
 teach config              # Update settings
 teach exam "Midterm"      # Create exam (placeholder for Scholar integration)
-```diff
+```
 
 **Key Features:**
 
@@ -97,7 +97,7 @@ teach exam "Midterm"      # Create exam (placeholder for Scholar integration)
 ├─────────────────────────────────────────┤
 │  Underlying: Git + GitHub Actions       │
 └─────────────────────────────────────────┘
-```yaml
+```
 
 ---
 
@@ -117,7 +117,7 @@ teach exam "Midterm"      # Create exam (placeholder for Scholar integration)
 /teaching:lecture "Topic"   # Generate lecture outline
 /teaching:assignment "Topic" # Generate assignment
 /teaching:syllabus "Data"   # Generate course syllabus
-```diff
+```
 
 **Key Features (Planned):**
 
@@ -155,7 +155,7 @@ teach exam "Midterm"      # Create exam (placeholder for Scholar integration)
 ├─────────────────────────────────────────┤
 │  Underlying: Claude API + Templates     │
 └─────────────────────────────────────────┘
-```bash
+```
 
 ---
 
@@ -173,7 +173,7 @@ work stat-545
 
 # 3. Deploy
 teach deploy
-```bash
+```
 
 **Result:** Full teaching workflow, no Scholar needed
 
@@ -194,7 +194,7 @@ work stat-545
 
 # 4. Deploy
 teach deploy
-```text
+```
 
 **Result:** flow-cli handles workflow, Scholar handles content generation
 

--- a/docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md
+++ b/docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md
@@ -47,7 +47,7 @@ Teaching Workflow v3.0 provides a complete solution for managing course content 
 ```bash
 teach doctor            # Quick check (< 3s): deps, R, config, git
 teach doctor --full     # Full check: all 11 categories
-```bash
+```
 
 Quick mode validates essentials: dependencies, R environment + renv, project configuration, and git setup.
 Full mode adds: R packages, Quarto extensions, Scholar integration, hooks, cache, macros (opt-in), teaching style.
@@ -77,7 +77,7 @@ teach validate --watch
 # Validate specific files or directories
 teach validate lectures/week-05.qmd
 teach validate lectures/
-```text
+```
 
 **Validation modes:**
 
@@ -98,7 +98,7 @@ lectures/.backups/
   └── week-05-regression.2026-01-18-1430/
   └── week-05-regression.2026-01-17-0915/
   └── week-05-regression.2026-01-15-1620/
-```diff
+```
 
 **Retention policies:**
 - **Archive** - Keep forever, move to `.flow/archives/` at semester end
@@ -114,7 +114,7 @@ lectures/.backups/
 
 ```bash
 teach status
-```diff
+```
 
 Shows everything at a glance:
 - Course and semester info
@@ -130,7 +130,7 @@ Shows everything at a glance:
 
 ```bash
 teach deploy
-```text
+```
 
 Before creating a PR, see exactly what changed:
 
@@ -146,7 +146,7 @@ Files changed since last deployment:
 Summary: 1 added, 2 modified, 1 deleted
 
 View full diff? [y/N]
-```text
+```
 
 **Why it matters:** No surprises. Know exactly what students will see.
 
@@ -159,7 +159,7 @@ View full diff? [y/N]
 ```bash
 teach exam "Midterm" --template typst
 teach assignment "HW4" --template docx
-```sql
+```
 
 Choose output format for generated content:
 - `markdown` - Standard Markdown (default)
@@ -192,7 +192,7 @@ teach plan show 5
 
 # Edit in $EDITOR (jumps to correct line)
 teach plan edit 5
-```yaml
+```
 
 Plans are stored in `.flow/lesson-plans.yml`:
 
@@ -207,7 +207,7 @@ weeks:
     subtopics: []
     key_concepts: []
     prerequisites: []
-```bash
+```
 
 Scholar commands automatically load plans for enhanced context.
 
@@ -223,7 +223,7 @@ teach init --config ~/templates/stats-course.yml
 
 # Create and push to GitHub in one step
 teach init "STAT 440" --github
-```bash
+```
 
 **Why it matters:** Faster setup, consistent configuration across courses.
 
@@ -242,7 +242,7 @@ teach hooks install --force
 
 # Check what's installed
 teach hooks status
-```text
+```
 
 **Example output from `teach hooks status`:**
 
@@ -254,7 +254,7 @@ Hook status:
 ✓ prepare-commit-msg: v1.0.0 (up to date)
 
 Summary: 3 up to date, 0 outdated, 0 missing
-```bash
+```
 
 #### What Each Hook Does
 
@@ -272,7 +272,7 @@ git commit -m "Add lecture 5"
 ✓ Cross-reference integrity
 ✓ Sourced R file dependencies
 ✓ Code chunk syntax
-```text
+```
 
 **Real-world example:**
 
@@ -286,7 +286,7 @@ Running pre-commit validation...
 ✗ ERROR: lectures/week-05.qmd missing required field: 'date'
 
 Commit aborted. Fix the errors above and try again.
-```bash
+```
 
 **2. pre-push Hook** - Ensures deployment readiness
 
@@ -301,7 +301,7 @@ git push origin main
 ✓ No untracked files in critical directories
 ✓ All required files present
 ✓ Git working tree is clean
-```text
+```
 
 **Real-world example:**
 
@@ -316,7 +316,7 @@ Running pre-push checks...
 
 Please commit or stash these changes before pushing.
 Push aborted.
-```bash
+```
 
 **3. prepare-commit-msg Hook** - Auto-formats commit messages
 
@@ -331,7 +331,7 @@ git commit
 # - Timing information (if enabled)
 # - Content type detection
 # - Change summary
-```diff
+```
 
 **Real-world example:**
 
@@ -346,7 +346,7 @@ Your commit message: "update lecture"
 - Render time: 3.2s
 
 Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
-```bash
+```
 
 #### Configuration Options
 
@@ -370,7 +370,7 @@ export QUARTO_COMMIT_SUMMARY=1
 
 # Skip hooks temporarily (use sparingly!)
 git commit --no-verify -m "WIP: draft changes"
-```bash
+```
 
 **Configuration Examples:**
 
@@ -383,7 +383,7 @@ export QUARTO_COMMIT_TIMING=0
 export QUARTO_COMMIT_SUMMARY=0
 
 # Commits are fast, hooks only check YAML syntax
-```bash
+```
 
 **Scenario 2: Production mode** (before deployment)
 
@@ -396,7 +396,7 @@ export QUARTO_COMMIT_TIMING=1
 export QUARTO_COMMIT_SUMMARY=1
 
 # Commits are slower but catch all issues
-```bash
+```
 
 **Scenario 3: CI/CD mode** (automated workflows)
 
@@ -406,7 +406,7 @@ export QUARTO_HOOKS_QUIET=1
 export QUARTO_HOOKS_CI=1
 
 # Hooks run non-interactively, suitable for automation
-```bash
+```
 
 #### Hook Management
 
@@ -420,7 +420,7 @@ teach hooks status
 ⚠ pre-push: v0.9.0 (upgrade to v1.0.0)
 
 Run 'teach hooks upgrade' to update outdated hooks
-```bash
+```
 
 **Upgrade hooks:**
 
@@ -438,7 +438,7 @@ Upgrade these hooks? [Y/n] y
 ✓ Upgraded pre-push (v1.0.0)
 
 All hooks upgraded successfully (2 hooks)
-```bash
+```
 
 **Uninstall hooks:**
 
@@ -455,7 +455,7 @@ Continue? [y/N] y
 ✓ Removed prepare-commit-msg
 
 Uninstalled 3 hook(s)
-```diff
+```
 
 #### Common Workflows
 
@@ -487,7 +487,7 @@ git push origin main
 ✓ Working tree clean
 ✓ All files committed
 Push successful!
-```bash
+```
 
 **Emergency bypass (use with caution):**
 
@@ -498,7 +498,7 @@ git push --no-verify
 
 # Later: validate manually
 teach validate lectures/
-```bash
+```
 
 **Testing hooks without committing:**
 
@@ -509,7 +509,7 @@ teach validate lectures/
 # Output shows what would happen:
 Running pre-commit validation...
 ✓ All checks passed
-```bash
+```
 
 #### Troubleshooting
 
@@ -528,7 +528,7 @@ ls -la .git/hooks/
 chmod +x .git/hooks/pre-commit
 chmod +x .git/hooks/pre-push
 chmod +x .git/hooks/prepare-commit-msg
-```bash
+```
 
 **Hook fails with "command not found":**
 
@@ -538,7 +538,7 @@ teach doctor
 
 # Install missing dependencies
 teach doctor --fix
-```bash
+```
 
 **Hook takes too long:**
 
@@ -549,7 +549,7 @@ export QUARTO_PRE_COMMIT_RENDER=0
 # Or use parallel rendering
 export QUARTO_PARALLEL_RENDER=1
 export QUARTO_MAX_PARALLEL=8
-```bash
+```
 
 **Hook conflicts with existing hooks:**
 
@@ -565,7 +565,7 @@ teach hooks install
 
 # Existing hooks are backed up as:
 # .git/hooks/pre-commit.backup-<timestamp>
-```text
+```
 
 #### Why Use Hooks?
 
@@ -589,7 +589,7 @@ With hooks:
 - YAML validated before commit → Never push broken files
 - Pre-push checks catch missing files → Always complete
 - Auto-formatted messages → Clear history
-```text
+```
 
 See [Teaching Git Workflow Refcard](../reference/MASTER-DISPATCHER-GUIDE.md#teach-dispatcher) for complete hook documentation and advanced configuration.
 
@@ -603,7 +603,7 @@ Before creating your first course:
 
 ```bash
 teach doctor
-```bash
+```
 
 If any checks fail:
 
@@ -613,7 +613,7 @@ teach doctor --fix
 
 # Manual install
 brew install yq gh quarto
-```bash
+```
 
 ### Step 2: Initialize Course
 
@@ -630,7 +630,7 @@ teach init "STAT 440" --config ~/templates/stats-course.yml
 
 # With GitHub repo creation
 teach init "STAT 440" --github
-```diff
+```
 
 **What gets created:**
 
@@ -658,7 +658,7 @@ teach plan create 3 --topic "Model Diagnostics" --style applied
 
 # Review what you've created
 teach plan list
-```text
+```
 
 Plans are stored in `.flow/lesson-plans.yml` and loaded by Scholar for targeted content generation.
 
@@ -670,7 +670,7 @@ Plans are stored in `.flow/lesson-plans.yml` and loaded by Scholar for targeted 
 
 ```bash
 teach status
-```text
+```
 
 Expected output:
 
@@ -689,7 +689,7 @@ Content Inventory:
   • Lectures:    0
   • Exams:       0
   • Assignments: 0
-```diff
+```
 
 ---
 
@@ -717,7 +717,7 @@ Quick mode runs 4 essential categories. Full mode adds R packages, Quarto extens
 
 ```bash
 teach doctor
-```text
+```
 
 Output:
 
@@ -755,13 +755,13 @@ Git Setup:
 ────────────────────────────────────────────────────────────
 Passed: 17  [0s]
 ────────────────────────────────────────────────────────────
-```text
+```
 
 ### Full Check
 
 ```bash
 teach doctor --full
-```text
+```
 
 Adds 7 more categories with a spinner for slower checks (R packages, cache analysis).
 
@@ -772,13 +772,13 @@ teach doctor --brief      # Warnings and failures only
 teach doctor --verbose    # Detailed: per-package R, full macro list (implies --full)
 teach doctor --json       # Machine-readable JSON
 teach doctor --ci         # CI mode: no color, key=value, exit 1 on failure
-```text
+```
 
 ### Interactive Fix Mode
 
 ```bash
 teach doctor --fix
-```yaml
+```
 
 Implies `--full` and prompts for each fixable issue:
 
@@ -795,7 +795,7 @@ R Packages:
   ⚠ 3/5 R packages installed | Missing: tidyr, knitr
     Install via renv or system? [r/s]: r
     → renv::install(c("tidyr", "knitr"))
-```bash
+```
 
 ### Health Indicator
 
@@ -817,7 +817,7 @@ Run `teach doctor` to refresh the dot.
 teach doctor --fix
 # Installs missing: yq, quarto, gh, R packages
 # Ready to start teaching!
-```bash
+```
 
 **Scenario 2: Semester preparation**
 
@@ -833,7 +833,7 @@ teach doctor --full
 vim .flow/teach-config.yml
 git checkout -b draft
 teach doctor
-```bash
+```
 
 **Scenario 3: CI/CD integration**
 
@@ -847,7 +847,7 @@ if [ "$status" = "red" ]; then
   echo "Health check failed"
   exit 1
 fi
-```bash
+```
 
 **Scenario 4: Troubleshooting deployment**
 
@@ -859,7 +859,7 @@ teach doctor --brief
 git add -A && git commit -m "Update content"
 git remote add origin https://github.com/user/stat-440
 teach deploy
-```bash
+```
 
 ### Common Issues and Solutions
 
@@ -910,7 +910,7 @@ cat lesson-plan.yml | yq ".weeks[] | select(.number == 5)"
 #   - "VIF (Variance Inflation Factor)"
 #   - "Partial F-tests"
 #   - "Model selection criteria"
-```bash
+```
 
 **Tuesday-Thursday:** Create content
 
@@ -925,7 +925,7 @@ teach lecture "Multiple Regression" --week 5
 
 # Content is automatically backed up
 # Scholar auto-loads lesson-plan.yml for context
-```bash
+```
 
 **Friday:** Create assessments
 
@@ -937,7 +937,7 @@ teach quiz "Week 5 Quiz" --questions 10 --time-limit 15
 teach assignment "Homework 4" \
   --due-date "2026-02-18" \
   --points 100
-```bash
+```
 
 **Weekend:** Review and deploy
 
@@ -947,7 +947,7 @@ teach status
 
 # Deploy with preview
 teach deploy
-```text
+```
 
 ### Creating Exams
 
@@ -959,7 +959,7 @@ teach exam "Midterm - Chapters 1-5" \
   --duration 120 \
   --types "mc,short,essay" \
   --template typst
-```text
+```
 
 **What happens:**
 
@@ -975,7 +975,7 @@ teach exam "Final Exam - Comprehensive" \
   --questions 50 \
   --duration 180 \
   --format quarto
-```text
+```
 
 ### Creating Assignments
 
@@ -984,7 +984,7 @@ teach assignment "Problem Set 3 - Diagnostics" \
   --due-date "2026-03-01" \
   --points 100 \
   --template docx
-```diff
+```
 
 **Scholar will include:**
 
@@ -999,7 +999,7 @@ teach assignment "Problem Set 3 - Diagnostics" \
 
 ```bash
 teach lecture "Collinearity and VIF" --week 6
-```text
+```
 
 **Slides from lecture:**
 
@@ -1007,7 +1007,7 @@ teach lecture "Collinearity and VIF" --week 6
 teach slides "Week 6 Slides" \
   --from-lecture lectures/week-06-collinearity.qmd \
   --theme academic
-```text
+```
 
 **Guest lecture (custom styling):**
 
@@ -1015,7 +1015,7 @@ teach slides "Week 6 Slides" \
 teach slides "Guest: Machine Learning in Stats" \
   --theme minimal \
   --template typst
-```bash
+```
 
 ### Template Selection Guide
 
@@ -1060,7 +1060,7 @@ g commit "feat: add Week 6 content"
 
 # 4. Deploy with preview
 teach deploy
-```text
+```
 
 ### Deploy Preview
 
@@ -1078,7 +1078,7 @@ Files changed since last deployment:
 Summary: 2 added, 2 modified, 1 deleted
 
 View full diff? [y/N]
-```diff
+```
 
 **Options:**
 
@@ -1100,7 +1100,7 @@ Commits included:
   • i7j8k9l - docs: update schedule
 
 Review and merge on GitHub when ready.
-```text
+```
 
 ### Pre-flight Checks
 
@@ -1124,7 +1124,7 @@ You have 3 uncommitted files:
 → Commit or stash changes first:
     g commit "your message"
     g stash
-```text
+```
 
 ### Direct Push (Advanced)
 
@@ -1132,7 +1132,7 @@ Bypass PR workflow for hotfixes:
 
 ```bash
 teach deploy --direct-push
-```diff
+```
 
 ⚠️ **Warning:** Use sparingly. PR workflow provides:
 - Change review before going live
@@ -1159,7 +1159,7 @@ lectures/.backups/
   └── week-05.2026-01-18-1430/  # Latest
   └── week-05.2026-01-17-0915/  # Yesterday
   └── week-05.2026-01-15-1620/  # Last week
-```yaml
+```
 
 **Retention policies:**
 
@@ -1171,13 +1171,13 @@ backups:
     assessments: archive    # Keep exam/quiz backups
     lectures: semester      # Delete at semester end
     syllabi: archive        # Keep syllabus backups
-```text
+```
 
 ### View Backup Status
 
 ```bash
 teach status
-```text
+```
 
 Output includes:
 
@@ -1190,7 +1190,7 @@ Backup Summary:
     • Exams:       3 backups (4.2 MB)
     • Lectures:    5 backups (8.1 MB)
     • Assignments: 4 backups (2.3 MB)
-```bash
+```
 
 ### Restore from Backup
 
@@ -1203,7 +1203,7 @@ ls -lt lectures/.backups/
 # 2. Copy content back
 cp -R lectures/.backups/week-05.2026-01-15-1620/* \
       lectures/week-05.qmd
-```bash
+```
 
 **Using git (if backed up):**
 
@@ -1213,7 +1213,7 @@ git log --oneline lectures/week-05.qmd
 
 # Restore specific version
 git checkout <commit-hash> lectures/week-05.qmd
-```bash
+```
 
 ### Delete Old Backups
 
@@ -1222,19 +1222,19 @@ git checkout <commit-hash> lectures/week-05.qmd
 ```bash
 # Will prompt before deleting
 rm -rf lectures/.backups/week-05.2026-01-15-1620
-```text
+```
 
 **Force deletion (scripts):**
 
 ```bash
 _teach_delete_backup lectures/.backups/week-05.2026-01-15-1620 --force
-```text
+```
 
 ### Archive at Semester End
 
 ```bash
 teach archive "Spring 2025"
-```text
+```
 
 **What happens:**
 
@@ -1249,7 +1249,7 @@ teach archive "Spring 2025"
 
   Archived: 8 content folders
   Deleted:  5 content folders (semester retention)
-```diff
+```
 
 ---
 
@@ -1277,13 +1277,13 @@ teach deploy
 
 # Verify PR merged
 gh pr list --state merged
-```text
+```
 
 **2. Archive backups**
 
 ```bash
 teach archive "Spring 2025"
-```bash
+```
 
 **3. Create semester tag**
 
@@ -1291,7 +1291,7 @@ teach archive "Spring 2025"
 # Tag final state
 git tag -a spring-2025-final -m "End of Spring 2025 semester"
 git push origin spring-2025-final
-```yaml
+```
 
 **4. Update .STATUS**
 
@@ -1304,7 +1304,7 @@ next_semester: Fall 2025
 notes: |
   Spring 2025 semester complete.
   Archive: .flow/archives/Spring-2025
-```bash
+```
 
 **5. Prepare for next semester**
 
@@ -1319,7 +1319,7 @@ teach config
 
 # Initialize dates
 teach dates init
-```bash
+```
 
 ---
 
@@ -1341,7 +1341,7 @@ done
 
 # Review for gaps
 teach plan list
-```diff
+```
 
 **Benefits:**
 
@@ -1358,7 +1358,7 @@ teach doctor --brief
 
 # Monthly full check
 teach doctor
-```bash
+```
 
 ### 3. Commit Often
 
@@ -1369,7 +1369,7 @@ g commit "feat: add Homework 4"
 
 # Not this
 g commit "added a bunch of stuff"
-```bash
+```
 
 **Why:** Easy to track what changed, revert if needed.
 
@@ -1378,7 +1378,7 @@ g commit "added a bunch of stuff"
 ```bash
 # Always review changes
 teach deploy   # Don't skip the preview!
-```yaml
+```
 
 ### 5. Backup Configuration
 
@@ -1390,7 +1390,7 @@ backups:
     assessments: archive   # Safe: keep forever
     lectures: archive      # Safe: keep forever
     syllabi: archive       # Safe: keep forever
-```yaml
+```
 
 **Aggressive settings (if disk space limited):**
 
@@ -1400,7 +1400,7 @@ backups:
     assessments: archive   # Keep exams
     lectures: semester     # Delete lecture backups
     syllabi: archive       # Keep syllabus
-```yaml
+```
 
 ### 6. Use Templates
 
@@ -1423,13 +1423,13 @@ backups:
     assessments: archive
     lectures: semester
     syllabi: archive
-```text
+```
 
 **Use it:**
 
 ```bash
 teach init "STAT 440" --config ~/templates/stats-course.yml
-```bash
+```
 
 ---
 
@@ -1448,7 +1448,7 @@ brew install yq gh quarto
 
 # Verify fix
 teach doctor
-```bash
+```
 
 **Issue:** Config validation fails
 
@@ -1463,7 +1463,7 @@ cat lib/templates/teaching/teach-config.schema.json
 # - Invalid date format (use YYYY-MM-DD)
 # - Missing required fields (course.name, semester_info)
 # - Invalid YAML syntax
-```bash
+```
 
 ### teach deploy Fails
 
@@ -1475,7 +1475,7 @@ git checkout draft
 
 # Try again
 teach deploy
-```bash
+```
 
 **Issue:** Uncommitted changes
 
@@ -1488,7 +1488,7 @@ g commit "your message"
 
 # Or stash
 g stash
-```bash
+```
 
 **Issue:** Conflicts with production
 
@@ -1506,7 +1506,7 @@ git rebase --continue
 
 # Deploy
 teach deploy
-```bash
+```
 
 **Issue:** Config file not found
 
@@ -1516,7 +1516,7 @@ teach init "Course Name"
 
 # Verify
 ls -la .flow/teach-config.yml
-```bash
+```
 
 ### Backup Issues
 
@@ -1531,7 +1531,7 @@ teach archive "Fall 2024"
 
 # Or manual cleanup
 rm -rf lectures/.backups/*2024*
-```bash
+```
 
 **Issue:** Can't restore backup
 
@@ -1544,7 +1544,7 @@ ls -ld lectures/.backups/
 
 # Restore manually
 cp -R lectures/.backups/week-05.LATEST/* lectures/
-```bash
+```
 
 ### Scholar Integration Issues
 
@@ -1559,7 +1559,7 @@ yq eval lesson-plan.yml
 
 # Validate against schema
 teach doctor
-```bash
+```
 
 **Issue:** Scholar not generating context-aware content
 
@@ -1572,7 +1572,7 @@ cat lesson-plan.yml
 
 # Try explicit context
 teach exam "Topic" --context
-```bash
+```
 
 ---
 
@@ -1600,7 +1600,7 @@ teach deploy --dry-run
 # Prompt for confirmation
 read -q "REPLY?Deploy to production? [y/N] "
 [[ "$REPLY" = "y" ]] && teach deploy
-```bash
+```
 
 **Backup verification script:**
 
@@ -1621,7 +1621,7 @@ if (( count < 5 )); then
 fi
 
 echo "✓ Backup verification passed: $count backups"
-```bash
+```
 
 ### Custom Workflows
 
@@ -1643,7 +1643,7 @@ teach rubric "Midterm" --criteria 5
 # 5. Commit all together
 g add exams/
 g commit "feat: add midterm exam with solutions and rubric"
-```bash
+```
 
 **Lecture workflow:**
 
@@ -1662,7 +1662,7 @@ teach assignment "Practice Problems N" \
 # 4. Deploy together
 g commit "feat: complete Week N materials"
 teach deploy
-```yaml
+```
 
 ---
 
@@ -1748,7 +1748,7 @@ teach deploy
 # ✓ URL: https://github.com/user/stat-440/pull/1
 #
 # Merge PR and site will deploy automatically!
-```bash
+```
 
 ### Example 2: Weekly Content Creation Cycle
 
@@ -1857,7 +1857,7 @@ teach deploy
 # Preview changes, create PR
 # GitHub Actions builds site, deploys to Pages
 # Students see updated content within 2 minutes
-```bash
+```
 
 ### Example 3: Midterm Exam Creation
 
@@ -1930,7 +1930,7 @@ git push origin exam-midterm-private
 git checkout main
 git rm exams/midterm-solutions.qmd
 git commit -m "Remove solution key from public branch"
-```bash
+```
 
 ### Example 4: End of Semester Workflow
 
@@ -1999,7 +1999,7 @@ teach deploy
 # Output:
 # ✓ Created PR #1: Fall 2026 setup
 # ✓ Course ready for new semester!
-```bash
+```
 
 ### Example 5: Fixing Common Issues
 
@@ -2052,7 +2052,7 @@ teach deploy
 # Output:
 # ✓ Fix deployed in ~15 seconds (direct mode)
 # ✓ Student can access corrected content
-```text
+```
 
 ---
 
@@ -2068,7 +2068,7 @@ teach deploy
 
 ```bash
 teach doctor
-```text
+```
 
 1. **Enable backups:**
 
@@ -2076,7 +2076,7 @@ Already enabled by default! Check status:
 
 ```bash
 teach status  # See "Backup Summary" section
-```yaml
+```
 
 1. **Configure retention policies:**
 
@@ -2088,7 +2088,7 @@ backups:
     assessments: archive
     lectures: semester   # New option
     syllabi: archive
-```yaml
+```
 
 1. **Create lesson plan (optional):**
 
@@ -2100,7 +2100,7 @@ weeks:
   - number: 1
     topic: "Introduction"
 EOF
-```bash
+```
 
 1. **Use new features:**
 

--- a/docs/guides/TEACHING-WORKFLOW-VISUAL.md
+++ b/docs/guides/TEACHING-WORKFLOW-VISUAL.md
@@ -24,13 +24,13 @@ drwxr-xr-x   5 you  staff   160 Jan 13 10:00 .
 drwxr-xr-x   3 you  staff    96 Jan 13 09:55 ..
 drwxr-xr-x   9 you  staff   288 Jan 13 09:55 .git
 -rw-r--xr-x   1 you  staff  1024 Jan 13 10:00 README.md
-```text
+```
 
 ### Step 2: Initialize teaching workflow
 
 ```bash
 $ teach init -y "STAT 545"
-```text
+```
 
 **What happens behind the scenes:**
 
@@ -53,7 +53,7 @@ teach init command
     ├── Git: git add .
     ├── Git: git commit -m "init: teaching workflow"
     └── Display: Success message
-```yaml
+```
 
 ### Step 3: Verify setup
 
@@ -75,7 +75,7 @@ branches:
 semester_info:
   start_date: "2026-01-13"
   end_date: "2026-05-08"
-```bash
+```
 
 ### Step 4: Verify branches created
 
@@ -91,7 +91,7 @@ Switched to branch 'draft'
 $ git log --oneline | head -3
 a1b2c3d init: teaching workflow
 f4e5d6c initial commit
-```diff
+```
 
 ### Result ✓
 
@@ -124,7 +124,7 @@ $ work stat-545
 # Week: 9
 #
 # Editor opening: /Users/you/projects/teaching/stat-545
-```text
+```
 
 **What `work` command does:**
 
@@ -137,7 +137,7 @@ work stat-545
     ├── Display: 📚 Course name, week number, branch
     ├── Open: Your editor ($EDITOR)
     └── Ready: Start editing!
-```diff
+```
 
 ### Step 2: Create course materials
 
@@ -156,7 +156,7 @@ title: "Week 9: Hypothesis Testing"
 
 ## Lecture Notes
 ...
-```diff
+```
 
 ```markdown
 # assignments/week09.qmd
@@ -171,7 +171,7 @@ Complete the following exercises...
 
 ## Submission
 Submit your R Markdown file...
-```text
+```
 
 ### Step 3: Check what changed
 
@@ -185,13 +185,13 @@ Untracked files:
     assignments/week09.qmd
 
 nothing added to commit but untracked files present (tracking will use 'git commit' to list all)
-```text
+```
 
 ### Step 4: Stage changes
 
 ```bash
 $ git add lectures/ assignments/
-```sql
+```
 
 ### Step 5: Commit with descriptive message
 
@@ -202,13 +202,13 @@ $ git commit -m "feat: add week 9 course materials"
  2 files changed, 45 insertions(+)
  create mode 100644 assignments/week09.qmd
  create mode 100644 lectures/week09.qmd
-```text
+```
 
 ### Step 6: Deploy to students
 
 ```bash
 $ teach deploy
-```text
+```
 
 **What happens:**
 
@@ -234,7 +234,7 @@ teach deploy
         ├── Students see materials in ~2 minutes
         ├── No manual steps needed
         └── You're back on draft branch ready for more edits
-```text
+```
 
 ### Output
 
@@ -255,7 +255,7 @@ Insertions: 45
 ⏳ Direct mode: live in ~15 seconds | PR mode: GitHub Actions (< 2 minutes)
 
 💡 Tip: Check Actions tab to monitor build progress
-```bash
+```
 
 ### Step 7: Verify students can access
 
@@ -265,7 +265,7 @@ $ open https://yourname.github.io/stat-545
 # → Week 9 materials visible
 # → Links working
 # → Ready for students
-```diff
+```
 
 ### Result ✓
 
@@ -294,7 +294,7 @@ A student found a typo in assignment 8 answer key. Fix ASAP!
 $ work stat-545
 # → Already on draft
 # → Editor opens
-```bash
+```
 
 ### Step 2: Find and fix typo
 
@@ -306,14 +306,14 @@ solutions/assignment-08.qmd:The regression coefficients is [0.42, -1.3]
 
 # Edit in editor
 # Change: "coefficients is" → "coefficients are"
-```text
+```
 
 ### Step 3: Quick commit
 
 ```bash
 $ git add solutions/assignment-08.qmd
 $ git commit -m "fix: grammar in assignment 8 answer key"
-```bash
+```
 
 ### Step 4: Deploy immediately
 
@@ -322,7 +322,7 @@ $ teach deploy
 
 # Output: (same as before)
 ✅ Deployed in 8 seconds
-```diff
+```
 
 ### Result ✓
 
@@ -360,7 +360,7 @@ $ teach status
 │  ✓ No pending changes                             │
 │  ✓ Ready to archive                               │
 ╰────────────────────────────────────────────────────╯
-```sql
+```
 
 ### Step 2: Archive semester
 
@@ -376,7 +376,7 @@ Archive tag: spring-2026-final
 Create archive? [Y/n] y
 
 ✅ Archive created: spring-2026-final
-```text
+```
 
 **What happened:**
 
@@ -393,7 +393,7 @@ teach archive
         ├── Complete semester snapshot
         ├── Browse at: github.com/you/repo/releases/tag/spring-2026-final
         └── Can restore if needed
-```bash
+```
 
 ### Step 3: Verify tag created
 
@@ -407,7 +407,7 @@ Tagger: Your Name <you@email.com>
 Date:   May 8, 2026 14:45:00 +0000
 
     Semester archive for Spring 2026
-```bash
+```
 
 ### Step 4: Update config for next semester
 
@@ -424,7 +424,7 @@ $ teach config
 #   semester: "fall"
 #   year: 2026
 #   start_date: "2026-08-25"
-```bash
+```
 
 ### Step 5: Commit and deploy
 
@@ -437,7 +437,7 @@ $ teach deploy
 # ✅ Config updated
 # ✅ Semester metadata updated
 # ✅ New semester ready to go
-```diff
+```
 
 ### Result ✓
 
@@ -483,7 +483,7 @@ $ teach status
 │  💡 Tip: Use 'teach deploy' to publish changes    │
 │                                                    │
 ╰────────────────────────────────────────────────────╯
-```text
+```
 
 ### Step 2: Check current week details
 
@@ -501,7 +501,7 @@ Semester Timeline:
 
 ⚡ No breaks this week
 💡 Coming up: Spring Break (Mar 10-17)
-```diff
+```
 
 ### Result ✓
 
@@ -555,7 +555,7 @@ Semester Timeline:
 │  git commit && teach deploy         │
 │  (ready for new semester)           │
 └─────────────────────────────────────┘
-```diff
+```
 
 ---
 
@@ -582,7 +582,7 @@ Semester Timeline:
 ```bash
 $ git branch --show-current
 production
-```bash
+```
 
 **Solution:**
 
@@ -597,7 +597,7 @@ draft
 # Next time: use 'work' command which auto-warns
 $ work stat-545
 # → Would show warning if on production
-```bash
+```
 
 ---
 
@@ -616,7 +616,7 @@ $ gh run view {run-id}
 # - Build failed: Check Quarto/site build
 # - Deploy failed: Check GitHub Pages settings
 # - Large files: Check file size limits
-```text
+```
 
 ---
 
@@ -629,7 +629,7 @@ $ git status  # See what's changed
 $ git add .
 $ git commit -m "fix: latest changes"
 $ teach deploy
-```bash
+```
 
 ---
 
@@ -640,7 +640,7 @@ $ teach deploy
 ```bash
 git revert HEAD  # Creates new commit that undoes previous
 teach deploy     # Deploys the revert
-```bash
+```
 
 **Option 2: Go back to previous version**
 

--- a/docs/guides/TEACHING-WORKFLOW.md
+++ b/docs/guides/TEACHING-WORKFLOW.md
@@ -25,7 +25,7 @@ The **Teaching Workflow** is a deployment-focused workflow system designed to so
 ```bash
 cd ~/projects/teaching/my-course
 teach-init "STAT 545"
-```diff
+```
 
 **What happens:**
 - Creates `draft` and `production` branches
@@ -38,7 +38,7 @@ teach-init "STAT 545"
 
 ```bash
 work stat-545
-```diff
+```
 
 **What happens:**
 - Checks current git branch
@@ -51,7 +51,7 @@ work stat-545
 
 ```bash
 ./scripts/quick-deploy.sh
-```diff
+```
 
 **What happens:**
 - Validates you're on `draft` branch
@@ -76,7 +76,7 @@ graph LR
     style A fill:#e1f5ff
     style C fill:#fff4e1
     style E fill:#e8f5e9
-```text
+```
 
 ### Work Session Flow
 
@@ -101,7 +101,7 @@ sequenceDiagram
     Work Command->>Work Command: Load shortcuts
     Work Command->>User: Display course context
     Work Command->>Editor: Open project
-```bash
+```
 
 ### Deployment Pipeline
 
@@ -133,7 +133,7 @@ graph TB
     style F fill:#fff4e1
     style K fill:#e8f5e9
     style E fill:#ffebee
-```text
+```
 
 ---
 
@@ -147,7 +147,7 @@ graph TB
 
 ```bash
 teach-init "Course Name"
-```diff
+```
 
 **Prerequisites:**
 - Git repository initialized
@@ -170,7 +170,7 @@ scripts/
 
 .github/workflows/
   deploy.yml            # GitHub Actions workflow
-```text
+```
 
 **Example:**
 
@@ -202,7 +202,7 @@ Continue? [y/N] y
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 🎉 Teaching workflow initialized!
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```text
+```
 
 ---
 
@@ -214,7 +214,7 @@ Continue? [y/N] y
 
 ```bash
 work <course-name>
-```sql
+```
 
 **Features:**
 
@@ -256,7 +256,7 @@ Shortcuts loaded:
   s545d → ./scripts/quick-deploy.sh
 
 [Editor opens]
-```bash
+```
 
 **Example (During Break Week):**
 
@@ -275,7 +275,7 @@ $ work stat-545
 Shortcuts loaded:
   s545 → work stat-545
   s545d → ./scripts/quick-deploy.sh
-```text
+```
 
 **Example (Warning - On Production Branch):**
 
@@ -301,7 +301,7 @@ Switched to branch 'draft'
 
 📚 STAT 545
   Branch: draft
-```yaml
+```
 
 ---
 
@@ -342,7 +342,7 @@ automation:
 shortcuts:
   s545: "work stat-545"
   s545d: "./scripts/quick-deploy.sh"
-```diff
+```
 
 **Required Fields:**
 - `course.name` - Course display name
@@ -369,7 +369,7 @@ shortcuts:
 
 ```bash
 ./scripts/quick-deploy.sh
-```bash
+```
 
 **Safety Checks:**
 1. ✅ Validates on `draft` branch (fails otherwise)
@@ -397,7 +397,7 @@ Pushing to remote...
 
 💡 Tip: Check deployment status at:
    https://github.com/data-wise/stat-545/actions
-```bash
+```
 
 **Error Handling:**
 
@@ -411,7 +411,7 @@ Run: git checkout draft
 ❌ Merge conflict detected
 Resolve conflicts and run again
 [Aborts merge, returns to draft]
-```bash
+```
 
 ---
 
@@ -423,7 +423,7 @@ Resolve conflicts and run again
 
 ```bash
 ./scripts/semester-archive.sh
-```sql
+```
 
 **What it does:**
 1. Reads semester info from config
@@ -448,7 +448,7 @@ Create archive tag? [Y/n] y
    1. Update .flow/teach-config.yml for next semester
    2. Update course.year (or course.semester)
    3. Commit config changes to draft branch
-```bash
+```
 
 ---
 
@@ -492,7 +492,7 @@ gh repo create stat-545 --public --source=. --push
 
 # 8. Start working
 work stat-545
-```bash
+```
 
 ---
 
@@ -523,7 +523,7 @@ git checkout draft
 
 # 7. Verify GitHub Pages still works
 # Check: https://your-username.github.io/stat-440
-```bash
+```
 
 ---
 
@@ -555,7 +555,7 @@ s545d
 # Visit course website
 
 # Total time: ~15 seconds with teach deploy -d (or < 2 min via PR)
-```yaml
+```
 
 ---
 
@@ -590,7 +590,7 @@ git commit -m "Add week 5 lecture"
 s545d
 
 # Lecture is live in < 2 min
-```bash
+```
 
 ---
 
@@ -628,7 +628,7 @@ git add lectures/.gitkeep
 git commit -m "Initialize Fall 2026 lectures"
 
 # Ready for new semester!
-```bash
+```
 
 ---
 
@@ -642,7 +642,7 @@ git commit -m "Initialize Fall 2026 lectures"
 
 ```bash
 brew install yq
-```bash
+```
 
 **Why:** Config validation requires `yq` to parse YAML files
 
@@ -657,7 +657,7 @@ brew install yq
 ```bash
 git checkout draft
 ./scripts/quick-deploy.sh
-```bash
+```
 
 **Why:** Deployment script only runs from draft branch for safety
 
@@ -686,7 +686,7 @@ git commit -m "Resolve merge conflict"
 
 # 4. Try deployment again
 ./scripts/quick-deploy.sh
-```bash
+```
 
 ---
 
@@ -705,7 +705,7 @@ git checkout draft
 # Or set environment variable to skip prompt (not recommended)
 export FLOW_TEACHING_ALLOW_PRODUCTION=1
 work stat-545
-```bash
+```
 
 **Best Practice:** Always work on draft branch
 
@@ -726,7 +726,7 @@ work stat-545
 
 # Now shortcuts are available
 s545d
-```diff
+```
 
 ---
 
@@ -778,7 +778,7 @@ work my-r-package
 # Teaching project (has .flow/teach-config.yml)
 work stat-545
 # → Teaching-aware session (branch check + shortcuts)
-```text
+```
 
 No conflict! Teaching features only activate for teaching projects.
 
@@ -794,7 +794,7 @@ $ pick teach
 🎓 stat-545              ~/projects/teaching/stat-545
 🎓 stat-440              ~/projects/teaching/stat-440
 🎓 causal-inference      ~/projects/teaching/causal-inference
-```text
+```
 
 Press Enter → `cd` to project
 Press Ctrl-O → `cd` + launch Claude
@@ -817,7 +817,7 @@ $ dash teach
 │ 🎓 STAT 440          ~/teaching/stat-440     │
 │    spring 2026 • production branch ⚠️         │
 ╰───────────────────────────────────────────────╯
-```yaml
+```
 
 ---
 
@@ -831,7 +831,7 @@ $ dash teach
 branches:
   draft: "dev"           # Instead of "draft"
   production: "main"     # Instead of "production"
-```bash
+```
 
 Scripts adapt automatically.
 
@@ -853,7 +853,7 @@ teach-init "STAT 440"
 # Creates shortcuts: s440, s440d
 
 # No conflicts!
-```yaml
+```
 
 ---
 
@@ -868,7 +868,7 @@ deployment:
     type: "netlify"         # Or vercel, custom, etc.
     branch: "production"
     url: "https://my-course.netlify.app"
-```bash
+```
 
 Adapt `quick-deploy.sh` if needed, or just use it for git workflow.
 
@@ -882,7 +882,7 @@ Adapt `quick-deploy.sh` if needed, or just use it for git workflow.
 export FLOW_TEACHING_ALLOW_PRODUCTION=1
 work stat-545
 # Skip branch warning
-```yaml
+```
 
 **Risk:** Students might see incomplete changes!
 
@@ -898,7 +898,7 @@ shortcuts:
   deploy: "./scripts/quick-deploy.sh"
   preview: "quarto preview"
   archive: "./scripts/semester-archive.sh"
-```diff
+```
 
 Shortcuts load when you run `work stat-545`.
 
@@ -934,7 +934,7 @@ Semester Schedule
   Break name [Spring Break]:
   Break start [2026-03-10]:
   Break end [2026-03-17]:
-```yaml
+```
 
 **Generated Config:**
 
@@ -946,7 +946,7 @@ semester_info:
     - name: "Spring Break"
       start: "2026-03-10"
       end: "2026-03-17"
-```sql
+```
 
 **Result in Work Session:**
 
@@ -961,7 +961,7 @@ $ work stat-545
   Recent Changes:
     Add week 8 lecture notes
     Update assignment rubric
-```diff
+```
 
 **Edge Cases Handled:**
 - Before semester start → Shows no week
@@ -995,7 +995,7 @@ npm install -g examark
 
 # Enable in config
 yq -i '.examark.enabled = true' .flow/teach-config.yml
-```bash
+```
 
 ---
 
@@ -1024,7 +1024,7 @@ Next steps:
 
   3. Upload to Canvas:
      Quizzes → Import → QTI 1.2 format
-```yaml
+```
 
 ---
 
@@ -1041,7 +1041,7 @@ course: STAT 545
 duration: 90 minutes
 points: 100
 ---
-```text
+```
 
 #### 2. Multiple Choice Section
 
@@ -1053,7 +1053,7 @@ points: 100
    - [ ] Option B
    - [x] Option C (correct answer)
    - [ ] Option D
-```text
+```
 
 #### 3. Short Answer Section
 
@@ -1064,7 +1064,7 @@ points: 100
 
    **Answer:**
    <!-- Student writes answer here -->
-```text
+```
 
 #### 4. Computational Problems
 
@@ -1075,7 +1075,7 @@ points: 100
 
    **Solution:**
    <!-- Student shows work here -->
-```text
+```
 
 #### 5. Answer Key (Instructor Only)
 
@@ -1087,7 +1087,7 @@ points: 100
 
 ### Section 2: Short Answer
 1. Expected answer with point breakdown
-```yaml
+```
 
 **Note:** Remove answer key before distributing to students
 
@@ -1120,7 +1120,7 @@ Upload to Canvas:
 6. Click: Import
 
 Note: Review and edit questions in Canvas after import
-```yaml
+```
 
 ---
 
@@ -1136,7 +1136,7 @@ examark:
   question_bank: "exams/questions"  # Reusable questions
   default_duration: 120       # Default exam duration (minutes)
   default_points: 100         # Default total points
-```sql
+```
 
 ---
 
@@ -1152,14 +1152,14 @@ exams/
     ├── regression.md        # Regression questions
     ├── anova.md             # ANOVA questions
     └── inference.md         # Inference questions
-```bash
+```
 
 **Reusing questions:**
 
 ```bash
 # Copy questions from bank to exam
 cat exams/questions/regression.md >> exams/midterm1.md
-```bash
+```
 
 ---
 
@@ -1186,7 +1186,7 @@ cat exams/questions/regression.md >> exams/final.md
 
 # 6. Review and publish in Canvas
 # (Manual: Edit point values, time limits, etc.)
-```bash
+```
 
 **Time:** Create exam in markdown (30 min) → Convert and upload (2 min)
 
@@ -1200,7 +1200,7 @@ cat exams/questions/regression.md >> exams/final.md
 
 ```bash
 npm install -g examark
-```diff
+```
 
 **Problem:** Conversion fails with "Invalid markdown format"
 
@@ -1219,7 +1219,7 @@ Check examark documentation: https://github.com/daveagp/examark
    - [ ] Option A
    - [x] Option B (correct)
    - [ ] Option C
-```diff
+```
 
 **Problem:** Questions not importing correctly to Canvas
 

--- a/docs/guides/TOKEN-MANAGEMENT-COMPLETE.md
+++ b/docs/guides/TOKEN-MANAGEMENT-COMPLETE.md
@@ -61,7 +61,7 @@ flow-cli uses **two storage backends simultaneously** for optimal balance of sec
                      │
                      ▼
             Token available for use
-```text
+```
 
 ### 1.2 Why Two Backends?
 
@@ -90,7 +90,7 @@ Every token stores metadata in JSON format:
   "expires": "2026-04-24",
   "github_user": "username"
 }
-```diff
+```
 
 **Storage locations:**
 - **Bitwarden:** `notes` field (full text)
@@ -107,7 +107,7 @@ security add-generic-password \
   -w "$token_value" \          # Password: ENCRYPTED (Touch ID required)
   -j "$metadata" \             # JSON attrs: searchable metadata
   -U                           # Update if exists
-```diff
+```
 
 **Security properties:**
 - ✅ Password (`-w`) is **encrypted** (requires authentication)
@@ -138,7 +138,7 @@ security add-generic-password \
 
 ```bash
 tok github
-```text
+```
 
 **Interactive steps:**
 
@@ -194,7 +194,7 @@ Expires: 2026-04-24 (90 days)
 │    gh auth login --with-token <<< \              │
 │      $(sec github-token)                  │
 ╰───────────────────────────────────────────────────╯
-```diff
+```
 
 **What happens behind the scenes:**
 
@@ -237,7 +237,7 @@ Expires: 2026-04-24 (90 days)
 
 ```bash
 tok github
-```text
+```
 
 **Interactive steps:**
 
@@ -284,7 +284,7 @@ Token: github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 Token name: github-token
 Expires: 2026-04-24 (90 days)
-```diff
+```
 
 **Token format:** `github_pat_*` (different from classic `ghp_*`)
 
@@ -299,7 +299,7 @@ Expires: 2026-04-24 (90 days)
 
 ```bash
 tok npm
-```text
+```
 
 **Interactive steps:**
 
@@ -332,7 +332,7 @@ Token: npm_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 Token name: npm-token
 Type: Publish
 Expires: 2027-01-24 (365 days)
-```text
+```
 
 **Metadata stored:**
 
@@ -344,7 +344,7 @@ Expires: 2027-01-24 (365 days)
   "created": "2026-01-24T14:30:00Z",
   "expires_days": 365
 }
-```diff
+```
 
 ### 2.3 PyPI API Token
 
@@ -356,7 +356,7 @@ Expires: 2027-01-24 (365 days)
 
 ```bash
 tok pypi
-```text
+```
 
 **Interactive steps:**
 
@@ -390,7 +390,7 @@ Token: pypi-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 Token name: pypi-my-awesome-package
 Type: Project-specific
 Expires: Never (manual rotation recommended)
-```text
+```
 
 **Important:** PyPI tokens don't expire automatically. Set calendar reminder for 90-day rotation.
 
@@ -404,7 +404,7 @@ Expires: Never (manual rotation recommended)
 
 ```bash
 sec <token-name>
-```bash
+```
 
 **Example:**
 
@@ -415,7 +415,7 @@ GITHUB_TOKEN=$(sec github-token)
 # Verify retrieval (check length, not value)
 echo "Token length: ${#GITHUB_TOKEN}"
 # Output: Token length: 40
-```bash
+```
 
 **What happens:**
 
@@ -439,7 +439,7 @@ gh auth login --with-token <<< $(sec github-token)
 # Method 3: Persistent login
 echo $(sec github-token) | gh auth login --with-token
 gh auth status
-```bash
+```
 
 #### npm Publishing
 
@@ -453,7 +453,7 @@ npm publish
 
 # Or use .npmrc (not recommended - plaintext)
 echo "//registry.npmjs.org/:_authToken=$(sec npm-token)" >> .npmrc
-```bash
+```
 
 #### PyPI Publishing
 
@@ -468,7 +468,7 @@ python -m twine upload dist/*
 # Or use pyproject.toml (poetry)
 poetry config pypi-token.pypi $(sec pypi-my-package)
 poetry publish
-```bash
+```
 
 ### 3.3 CI/CD Integration
 
@@ -505,7 +505,7 @@ jobs:
         run: |
           npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
           npm publish
-```bash
+```
 
 **Note:** For CI/CD, consider using GitHub Secrets instead of Keychain for better portability.
 
@@ -532,7 +532,7 @@ sec delete github-token
 # 2. Add new token
 tok github
 # Create with same name
-```diff
+```
 
 **What happens:**
 
@@ -564,7 +564,7 @@ security add-generic-password \
   -s flow-cli \
   -w "$TOKEN_VALUE" \
   -j '{"dot_version":"2.1","type":"github","token_type":"classic","created":"2026-01-24T15:00:00Z","expires_days":90,"expires":"2026-04-24","github_user":"newusername"}'
-```diff
+```
 
 **Future enhancement:** `sec update-metadata <name>` command planned.
 
@@ -584,7 +584,7 @@ security add-generic-password \
 
 ```bash
 tok rotate
-```text
+```
 
 **Interactive steps:**
 
@@ -628,7 +628,7 @@ Token: ghp_NEWTOKEN...
 │  IMPORTANT: Revoke old token on GitHub!           │
 │  https://github.com/settings/tokens               │
 ╰───────────────────────────────────────────────────╯
-```diff
+```
 
 **What happens:**
 
@@ -686,7 +686,7 @@ sec delete github-token-backup-20260124
 
 # 6. Revoke old token on provider
 # https://github.com/settings/tokens
-```diff
+```
 
 ### 5.3 Backup Strategy
 
@@ -704,7 +704,7 @@ sec add github-token-backup-$(date +%Y%m%d)
 
 # After verification, delete backup
 sec delete github-token-backup-20260124
-```bash
+```
 
 **Backup cleanup:**
 
@@ -719,7 +719,7 @@ sec list | grep backup
 
 # Delete old backups (> 7 days)
 sec delete github-token-backup-20260117
-```text
+```
 
 ---
 
@@ -731,13 +731,13 @@ sec delete github-token-backup-20260117
 
 ```bash
 sec delete <token-name>
-```text
+```
 
 **Example:**
 
 ```bash
 sec delete github-token
-```text
+```
 
 **Interactive confirmation:**
 
@@ -770,7 +770,7 @@ Token deleted successfully.
 
 Remember to revoke on provider:
   https://github.com/settings/tokens
-```bash
+```
 
 **What happens:**
 
@@ -810,7 +810,7 @@ done
 for token in github-token-backup-202601{10..23}; do
   sec delete "$token" 2>/dev/null || true
 done
-```bash
+```
 
 **Future enhancement:** `sec prune` command planned.
 
@@ -829,7 +829,7 @@ open https://github.com/settings/tokens
 # Or use GitHub CLI
 gh auth refresh -s delete_repo
 gh api -X DELETE /applications/{client_id}/token
-```bash
+```
 
 #### npm
 
@@ -840,7 +840,7 @@ open https://www.npmjs.com/settings/~/tokens
 # Or use npm CLI (requires login)
 npm token list
 npm token revoke <token-id>
-```bash
+```
 
 #### PyPI
 
@@ -849,7 +849,7 @@ npm token revoke <token-id>
 open https://pypi.org/manage/account/token/
 
 # No CLI method - manual deletion only
-```text
+```
 
 ---
 
@@ -861,7 +861,7 @@ open https://pypi.org/manage/account/token/
 
 ```bash
 tok expiring
-```text
+```
 
 **Output (multiple tokens):**
 
@@ -890,7 +890,7 @@ Summary:
   1 token expiring soon (⚠️)
   1 token healthy (✅)
   1 token no expiration (⏳)
-```diff
+```
 
 **Exit codes:**
 - `0`: All tokens healthy (> 7 days)
@@ -907,7 +907,7 @@ else
   echo "Tokens expiring soon!" >&2
   exit 1
 fi
-```bash
+```
 
 ### 7.2 Update Expiration Date
 
@@ -941,7 +941,7 @@ security add-generic-password \
 
 # Verify
 tok expiring
-```bash
+```
 
 **Future enhancement:** `tok update-expiration <name> <days>` command planned.
 
@@ -957,7 +957,7 @@ sec config github-token --no-expiration-check
 
 # Disable globally
 export FLOW_TOKEN_CHECK_DISABLED=1
-```diff
+```
 
 **Current workaround:** Ignore warnings in scripts.
 
@@ -988,7 +988,7 @@ open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibil
 # Enable Terminal.app or iTerm.app
 # System Settings → Privacy & Security → Accessibility
 # Click [+] → Add Terminal/iTerm → Toggle ON
-```bash
+```
 
 #### Unlock Keychain Manually
 
@@ -1003,7 +1003,7 @@ security unlock-keychain login.keychain-db
 # Verify unlock
 security show-keychain-info login.keychain-db
 # Should show: "no-timeout"
-```bash
+```
 
 #### SSH Session Workaround
 
@@ -1014,7 +1014,7 @@ security unlock-keychain -p "your-password" login.keychain-db
 
 # Or: Use Bitwarden backend directly
 sec bw github-token
-```diff
+```
 
 ### 8.2 Token Validation Failed
 
@@ -1045,7 +1045,7 @@ echo "$TOKEN" | grep -E '^npm_[A-Za-z0-9]{36}$'
 
 # PyPI token
 echo "$TOKEN" | grep -E '^pypi-[A-Za-z0-9_-]+$'
-```bash
+```
 
 #### Manual Token Test
 
@@ -1058,7 +1058,7 @@ curl -H "Authorization: token ghp_YOUR_TOKEN" \
 
 # Expected: {"login":"username",...}
 # If error: {"message":"Bad credentials"}
-```bash
+```
 
 **npm:**
 
@@ -1068,14 +1068,14 @@ curl -H "Authorization: Bearer npm_YOUR_TOKEN" \
   https://registry.npmjs.org/-/whoami
 
 # Expected: {"username":"yourname"}
-```bash
+```
 
 **PyPI:**
 
 ```bash
 # PyPI tokens can't be tested via API
 # Only way: try publishing
-```bash
+```
 
 #### Check Token Scopes
 
@@ -1087,14 +1087,14 @@ curl -I -H "Authorization: token ghp_YOUR_TOKEN" \
   https://api.github.com/user | grep x-oauth-scopes
 
 # Output: x-oauth-scopes: repo, workflow, read:org
-```bash
+```
 
 **npm:**
 
 ```bash
 # npm tokens don't expose scopes via API
 # Check on website: https://www.npmjs.com/settings/~/tokens
-```diff
+```
 
 ### 8.3 Keychain Access Denied
 
@@ -1116,7 +1116,7 @@ security find-generic-password \
 # If error, reset Keychain access:
 security delete-generic-password -s flow-cli -a github-token
 tok github  # Re-add
-```zsh
+```
 
 #### Verify Service Name
 
@@ -1127,7 +1127,7 @@ echo $_DOT_KEYCHAIN_SERVICE
 
 # If empty, reload plugin
 source flow.plugin.zsh
-```diff
+```
 
 ### 8.4 Bitwarden Sync Issues
 
@@ -1146,7 +1146,7 @@ brew install bitwarden-cli
 
 # Verify installation
 bw --version
-```bash
+```
 
 #### Login to Bitwarden
 
@@ -1159,7 +1159,7 @@ bw login
 
 # If session expired:
 export BW_SESSION=$(bw unlock --raw)
-```bash
+```
 
 #### Manual Sync
 
@@ -1169,7 +1169,7 @@ bw sync --session $BW_SESSION
 
 # Verify sync
 bw list items --session $BW_SESSION | jq '.[] | select(.name=="github-token")'
-```text
+```
 
 ---
 
@@ -1201,7 +1201,7 @@ bw list items --session $BW_SESSION | jq '.[] | select(.name=="github-token")'
 ❌ AVOID broad scopes:
   admin:org     (unless truly needed)
   delete_repo   (rarely needed)
-```text
+```
 
 **GitHub Fine-grained PAT:**
 
@@ -1217,7 +1217,7 @@ bw list items --session $BW_SESSION | jq '.[] | select(.name=="github-token")'
 ❌ AVOID:
   All repositories (use specific repos)
   Admin permissions (unless required)
-```text
+```
 
 **npm token:**
 
@@ -1225,7 +1225,7 @@ bw list items --session $BW_SESSION | jq '.[] | select(.name=="github-token")'
 ✅ Use publish token only for publishing
 ✅ Use read-only token for CI/CD installs
 ❌ AVOID automation token for publishing
-```text
+```
 
 #### Token Naming
 
@@ -1241,7 +1241,7 @@ bw list items --session $BW_SESSION | jq '.[] | select(.name=="github-token")'
   token                    (vague)
   github-1                 (meaningless)
   temp                     (forgot to delete?)
-```bash
+```
 
 ### 9.2 Keychain Security
 
@@ -1260,7 +1260,7 @@ security find-generic-password \
   -a github-token \
   -g
 # Should prompt for Touch ID
-```bash
+```
 
 **Fallback to password:**
 
@@ -1268,7 +1268,7 @@ security find-generic-password \
 # If Touch ID fails, use password
 security unlock-keychain login.keychain-db
 # Enter password when prompted
-```text
+```
 
 #### Lock Screen When Away
 
@@ -1279,7 +1279,7 @@ System Settings → Lock Screen
   • Require password: Immediately
   • Turn display off: 5 minutes
   • Show password hints: OFF
-```bash
+```
 
 **Keyboard shortcut:** `⌃⌘Q` (Control-Command-Q) to lock immediately
 
@@ -1297,7 +1297,7 @@ zip -e ~/Backups/keychain-backup-$(date +%Y%m%d).zip \
   ~/Backups/login.keychain-backup-*.db
 
 # Upload to secure storage (iCloud, 1Password, etc.)
-```bash
+```
 
 **Restore Keychain:**
 
@@ -1311,7 +1311,7 @@ cp login.keychain-backup-*.db \
 
 # Unlock
 security unlock-keychain login.keychain-db
-```diff
+```
 
 ### 9.3 Bitwarden Security
 
@@ -1328,7 +1328,7 @@ security unlock-keychain login.keychain-db
 ```bash
 # Use Bitwarden password generator
 bw generate --length 20 --uppercase --lowercase --number --special
-```diff
+```
 
 #### Enable 2FA
 
@@ -1364,7 +1364,7 @@ tok expiring
 
 # 5. Rotate expiring tokens
 tok rotate
-```bash
+```
 
 **Automated audit (script):**
 
@@ -1391,7 +1391,7 @@ done
 
 # Log audit
 echo "Audit completed: $(date)" >> ~/.flow/token-audit.log
-```yaml
+```
 
 ---
 
@@ -1437,7 +1437,7 @@ sec import
 ✓ Storing in Keychain...
 
 Imported: github-token
-```bash
+```
 
 **Manual migration (batch):**
 
@@ -1477,7 +1477,7 @@ EOF
 
 chmod +x migrate-tokens.sh
 ./migrate-tokens.sh
-```bash
+```
 
 ### 10.2 From Environment Variables to Keychain
 
@@ -1489,7 +1489,7 @@ chmod +x migrate-tokens.sh
 # ~/.zshrc
 export GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 export NPM_TOKEN="npm_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-```bash
+```
 
 **Migration steps:**
 
@@ -1527,7 +1527,7 @@ source ~/.zshrc
 # 5. Verify
 echo "GitHub token length: ${#GITHUB_TOKEN}"
 echo "npm token length: ${#NPM_TOKEN}"
-```diff
+```
 
 **Result:**
 - ✅ Tokens no longer in plaintext config
@@ -1585,7 +1585,7 @@ rm -rf flow-cli-tokens-$(date +%Y%m%d)/
 
 # 5. Upload encrypted zip to secure storage
 # (iCloud, 1Password, Bitwarden Attachments, etc.)
-```bash
+```
 
 **Restore from backup:**
 

--- a/docs/guides/WORKFLOW-TUTORIAL.md
+++ b/docs/guides/WORKFLOW-TUTORIAL.md
@@ -16,7 +16,7 @@
 │  status     → Update its status              │
 │                                              │
 └──────────────────────────────────────────────┘
-```diff
+```
 
 **That's it!** Four commands.
 
@@ -52,7 +52,7 @@ dash teaching        # Just teaching projects
 dash research        # Just research projects
 dash packages        # Just R packages
 dash dev             # Just dev tools
-```diff
+```
 
 ### ✅ When to use it
 
@@ -81,7 +81,7 @@ dash dev             # Just dev tools
   📊 collider [P2] 90% - Waiting for review
 
 💡 Quick: work <name> to start
-```diff
+```
 
 **Colors:**
 
@@ -108,7 +108,7 @@ Automatically picks your highest-priority project and takes you there.
 
 ```bash
 just-start      # That's it!
-```diff
+```
 
 ### ✅ When to use it
 
@@ -137,7 +137,7 @@ just-start      # That's it!
    dash          = See all projects
 
 📁 /Users/dt/projects/r-packages/active/mediationverse
-```bash
+```
 
 **How it picks:**
 
@@ -172,7 +172,7 @@ work .              # Open current project
 
 # No args (not implemented yet)
 work                # Would open current project or show picker
-```diff
+```
 
 ### ✅ When to use it
 
@@ -185,7 +185,7 @@ work                # Would open current project or show picker
 
 ```bash
 work mediationverse
-```yaml
+```
 
 **What happens:**
 
@@ -229,25 +229,25 @@ status mediationverse
    New progress (0-100): 95
 
 ✅ Updated mediationverse!
-```text
+```
 
 **Quick mode** (if you know all values):
 
 ```bash
 status mediationverse active P0 "Complete sims" 95
-```text
+```
 
 **Create mode** (start tracking a new project):
 
 ```bash
 status newproject --create
-```text
+```
 
 **Show mode** (just view, don't update):
 
 ```bash
 status mediationverse --show
-```diff
+```
 
 ### ✅ When to use it
 
@@ -281,7 +281,7 @@ Progress? [85]
 > 95
 
 ✅ Updated! Press Enter to continue...
-```diff
+```
 
 **Fields explained:**
 
@@ -316,7 +316,7 @@ just-start
 
 # 3. Start working
 work .
-```bash
+```
 
 **Time:** <30 seconds
 **Decisions:** Zero
@@ -334,7 +334,7 @@ dash teaching
 
 # Jump to a project
 work stat-440
-```bash
+```
 
 **Time:** <10 seconds
 
@@ -352,7 +352,7 @@ status mediationverse
 > Progress: 95
 
 ✅ Updated!
-```bash
+```
 
 **Time:** <30 seconds
 **Benefit:** You'll remember where you left off!
@@ -378,7 +378,7 @@ category: r-packages
 
 # Now appears in dashboard!
 dash
-```bash
+```
 
 ---
 
@@ -394,7 +394,7 @@ work mediationverse
 
 # Update its status
 status mediationverse active P0 "Critical fix" 0
-```diff
+```
 
 ---
 
@@ -424,7 +424,7 @@ work mediationverse
 
 # Type:
 work med
-```bash
+```
 
 ### Tip 2: Morning + Evening Routine
 
@@ -434,7 +434,7 @@ dash && just-start && work .
 
 # Evening:
 status . paused P0 "Resume here tomorrow" 90
-```bash
+```
 
 ### Tip 3: Categories for Focus
 
@@ -447,7 +447,7 @@ dash research
 
 # Package work
 dash packages
-```bash
+```
 
 ### Tip 4: Combine with `win` command
 
@@ -457,7 +457,7 @@ win "Completed Phase 1 of help system"
 
 # See today's wins
 wins
-```bash
+```
 
 ### Tip 5: Use Dispatchers
 
@@ -467,7 +467,7 @@ cc               # Claude Code (project-aware)
 gm               # Gemini (project-aware)
 peek <file>      # Smart file viewer
 qu               # Quarto operations
-```yaml
+```
 
 ---
 
@@ -519,7 +519,7 @@ Evening:
   win "..."     → Log your win
     ↓
   wins          → Feel good about progress!
-```diff
+```
 
 ---
 

--- a/docs/guides/WORKFLOWS-QUICK-WINS.md
+++ b/docs/guides/WORKFLOWS-QUICK-WINS.md
@@ -44,13 +44,13 @@ tags:
 
 ```bash
 rtest                # Run all tests
-```text
+```
 
 ### Visual Flow
 
 ```text
 Code changes → rtest → 2-4 min wait → ✅ Green or ❌ Red
-```diff
+```
 
 ### Decision Points
 
@@ -80,13 +80,13 @@ Code changes → rtest → 2-4 min wait → ✅ Green or ❌ Red
 
 ```bash
 rload && rtest       # Load then test
-```text
+```
 
 ### Visual Flow
 
 ```bash
 Start work → rload && rtest → Package loads → Tests run → ✅ or ❌
-```diff
+```
 
 ### Why This Works (ADHD-Optimized)
 
@@ -117,13 +117,13 @@ Start work → rload && rtest → Package loads → Tests run → ✅ or ❌
 
 ```bash
 rdoc && rtest        # Document then test
-```text
+```
 
 ### Visual Flow
 
 ```bash
 Change @param docs → rdoc && rtest → Docs regenerate → Tests run → ✅
-```text
+```
 
 ### What This Does
 
@@ -138,7 +138,7 @@ You: Added new function parameter
 You: Updated @param documentation
 Run: rdoc && rtest
 Result: Documentation updated + tests verify it works
-```diff
+```
 
 ### Pro Tips
 
@@ -164,13 +164,13 @@ Result: Documentation updated + tests verify it works
 rcycle               # Full cycle: doc → test → check
 # OR (step by step)
 rdoc && rtest && rcheck
-```text
+```
 
 ### Visual Flow
 
 ```text
 Ready to commit → rcycle → 60 min wait → ✅ 0 errors/warnings/notes
-```diff
+```
 
 ### What This Does
 
@@ -221,13 +221,13 @@ rdoc && rtest && git add . && git commit -m "message"
 
 # Option 3: Ultra-safe (full check + commit)
 rdoc && rtest && rcheck && git add . && git commit -m "message"
-```text
+```
 
 ### Visual Flow
 
 ```text
 Code ready → git commit → Done in 30s
-```bash
+```
 
 ### Commit Message Templates
 
@@ -246,7 +246,7 @@ git commit -m "test: add tests for interaction effects"
 
 # Refactor
 git commit -m "refactor: simplify bootstrap algorithm"
-```text
+```
 
 ### Decision Tree
 
@@ -255,7 +255,7 @@ Did you run rcheck?
 ├─ Yes → git add . && git commit -m "message"
 ├─ No → rdoc && rtest then commit (safer)
 └─ Not sure → Full check first (safest)
-```diff
+```
 
 ### Pro Tips
 
@@ -281,7 +281,7 @@ Did you run rcheck?
 
 ```bash
 rtest                # Run tests, read error messages
-```diff
+```
 
 Look for:
 
@@ -294,7 +294,7 @@ Look for:
 ```bash
 # Run specific test file in R:
 devtools::test_file("tests/testthat/test-myfunction.R")
-```bash
+```
 
 #### Step 3: Interactive Debugging (varies)
 
@@ -303,14 +303,14 @@ rload                # Load package
 # Then in R console:
 # debug(myfunction)
 # Run test interactively
-```bash
+```
 
 #### Step 4: Fix and Verify (2 min)
 
 ```bash
 # Fix the code
 rtest                # Re-run all tests
-```diff
+```
 
 ### Common Test Failures
 
@@ -337,7 +337,7 @@ rtest                # Re-run all tests
 3. Make ONE small change
 4. Test immediately with `rtest`
 5. Repeat until green
-```bash
+```
 
 ### Pro Tips
 
@@ -358,7 +358,7 @@ rtest                # Re-run all tests
 pwd                  # Show current directory
 rpkg                 # Package info & status
 git status           # Check git status
-```text
+```
 
 ### Visual Output
 
@@ -367,7 +367,7 @@ rpkg → Shows:
 - 📦 R package name + version
 - 📊 Package description
 - 🔧 Git branch
-```diff
+```
 
 ### Quick Recovery Checklist
 
@@ -384,21 +384,21 @@ rpkg → Shows:
 pwd                  # Current directory
 rpkg                 # Package info
 cat .STATUS          # Check status file
-```bash
+```
 
 **"I don't remember what this package does"**
 
 ```bash
 rpkg                 # Package info
 cat DESCRIPTION      # Read full description
-```bash
+```
 
 **"Did I make changes?"**
 
 ```bash
 git status           # Git status
 git diff             # See changes
-```text
+```
 
 ### Pro Tips
 
@@ -419,7 +419,7 @@ git diff             # See changes
 focus                # Minimize distractions
 focus 25             # Focus + 25-min timer (Pomodoro)
 unfocus              # Restore notifications
-```text
+```
 
 ### What `focus` Does
 
@@ -432,7 +432,7 @@ unfocus              # Restore notifications
 
 ```text
 Need focus → focus 25 → Work uninterrupted → Timer alert → Break
-```bash
+```
 
 ### Recommended Focus Workflows
 
@@ -443,7 +443,7 @@ f25                  # 25-minute focus timer
 # Work for 25 min
 # Timer alerts when done
 # Take 5-min break
-```bash
+```
 
 **Deep Work (50 min)**
 
@@ -452,14 +452,14 @@ f50                  # 50-minute deep work timer
 # Work for 50 min
 # Timer alerts when done
 # Take 10-15 min break
-```bash
+```
 
 **Custom Duration**
 
 ```bash
 focus 90             # Custom 90-minute session
 # Work until timer ends
-```bash
+```
 
 ### Pro Tips
 
@@ -472,7 +472,7 @@ focus 90             # Custom 90-minute session
 ```bash
 # Update status and commit progress
 git add . && git commit -m "Progress on X"
-```bash
+```
 
 ---
 
@@ -489,7 +489,7 @@ git add . && git commit -m "Progress on X"
 pwd                  # Verify location
 rpkg                 # Check package info
 git status           # Check git status
-```bash
+```
 
 #### [ ] 2. Create Function File (30s)
 
@@ -497,7 +497,7 @@ git status           # Check git status
 # Create R/myfunction.R manually
 # OR use usethis:
 usethis::use_r("myfunction")
-```bash
+```
 
 #### [ ] 3. Create Test File (30s)
 
@@ -505,7 +505,7 @@ usethis::use_r("myfunction")
 # Create tests/testthat/test-myfunction.R
 # OR use usethis:
 usethis::use_test("myfunction")
-```bash
+```
 
 #### [ ] 4. Document Template (30s)
 
@@ -522,7 +522,7 @@ Add roxygen skeleton:
 myfunction <- function(x) {
   # TODO: Implement
 }
-```text
+```
 
 #### [ ] 5. First Test (30s)
 
@@ -531,21 +531,21 @@ test_that("myfunction works", {
   result <- myfunction(x = 1)
   expect_true(!is.null(result))
 })
-```bash
+```
 
 #### [ ] 6. Verify Setup
 
 ```bash
 rload && rtest       # Load + test
 # Should load successfully, test might fail (that's OK!)
-```bash
+```
 
 ### Quick Start Template
 
 ```bash
 # Create files, then verify:
 rload && rtest
-```bash
+```
 
 ### Pro Tips
 
@@ -568,7 +568,7 @@ rload && rtest
 pwd                  # Where am I?
 git status           # What changed?
 rtest                # Do tests pass?
-```bash
+```
 
 #### Step 2: Identify Problem
 
@@ -578,7 +578,7 @@ rtest                # Do tests pass?
 rtest                # Run tests
 # Read error messages carefully
 # Jump to workflow #6 (Fix Failing Tests)
-```bash
+```
 
 **Package won't load?**
 
@@ -586,14 +586,14 @@ rtest                # Run tests
 rload                # Try to load
 # Read error messages
 # Common: syntax error, missing dependency
-```bash
+```
 
 **Git issues?**
 
 ```bash
 git status           # Git status
 git log --oneline -5 # Recent commits
-```bash
+```
 
 ### Recovery Options (Choose One)
 
@@ -605,7 +605,7 @@ git reset HEAD~1
 # Fix the issue
 rtest                # Verify tests pass
 git add . && git commit -m "fix: ..."
-```bash
+```
 
 #### Option B: Code Error
 
@@ -614,7 +614,7 @@ git add . && git commit -m "fix: ..."
 # Then:
 rload                # Try loading again
 rtest                # Run tests
-```bash
+```
 
 #### Option C: Clean Build (Last Resort)
 
@@ -622,7 +622,7 @@ rtest                # Run tests
 # Clean and rebuild
 rm -rf man/ NAMESPACE
 rdoc && rtest        # Regenerate docs + test
-```diff
+```
 
 ### Prevention Checklist
 
@@ -679,7 +679,7 @@ What do you want to do?
 │
 └─ Something broke
    └─ See workflow #10 (Emergency Recovery)
-```yaml
+```
 
 ---
 
@@ -780,25 +780,25 @@ What do you want to do?
 
 ```bash
 rpkg → rload && rtest → Coffee while tests run → Review results → Code
-```bash
+```
 
 **Quick Feature (30 min)**
 
 ```bash
 f25 → Create files → Code → rdoc && rtest
-```text
+```
 
 **Pre-Commit (65 min)**
 
 ```bash
 rcheck → f60 focus session → Switch tasks → Check results → commit
-```text
+```
 
 **End of Day (5 min)**
 
 ```bash
 rtest → git commit -m "wip: progress on X" → Update .STATUS for tomorrow
-```bash
+```
 
 ---
 
@@ -821,13 +821,13 @@ g feature sync
 
 # Finish: push + create PR
 g feature finish
-```text
+```
 
 ### Visual Flow
 
 ```text
 Start → feature start → code → commit → sync → finish → PR → merge
-```bash
+```
 
 ### Quick Reference
 
@@ -853,7 +853,7 @@ git checkout main && g push   # Direct push to main blocked
 g feature start my-fix        # Create feature branch
 g push                        # Push feature branch OK
 g promote                     # Create PR instead
-```bash
+```
 
 ### Pro Tips
 
@@ -882,13 +882,13 @@ wt
 
 # Clean up stale worktrees
 wt clean
-```text
+```
 
 ### Visual Flow
 
 ```text
 Main work → wt create feature/b → Parallel work → wt clean
-```bash
+```
 
 ### Claude Code + Worktrees
 

--- a/docs/guides/WORKTREE-WORKFLOW.md
+++ b/docs/guides/WORKTREE-WORKFLOW.md
@@ -40,7 +40,7 @@ git checkout -b hotfix     # Create fix branch
 # Fix bug...
 git checkout experiment-refactor  # Back to experiment
 git stash pop              # Restore work
-```diff
+```
 
 **Issues:**
 - ⚠️ Constant stashing/unstashing
@@ -57,7 +57,7 @@ git stash pop              # Restore work
 ~/.git-worktrees/flow-cli-refactor/       # Experiment 1
 ~/.git-worktrees/flow-cli-hotfix/         # Urgent fix
 ~/.git-worktrees/flow-cli-new-feature/    # Feature work
-```diff
+```
 
 **Benefits:**
 - ✅ Each branch has its own directory
@@ -78,7 +78,7 @@ wt create feature/new-auth
 
 # Or via git directly
 git worktree add ~/.git-worktrees/flow-cli-feature-new-auth feature/new-auth
-```bash
+```
 
 **Location:** `~/.git-worktrees/<repo>-<branch>/`
 
@@ -90,14 +90,14 @@ wt list
 
 # Or via git
 git worktree list
-```text
+```
 
 **Output:**
 
 ```text
 /Users/dt/projects/flow-cli          abc123 [main]
 /Users/dt/.git-worktrees/flow-cli-refactor  def456 [feature/refactor]
-```bash
+```
 
 ### Remove Worktree
 
@@ -107,7 +107,7 @@ wt remove feature/new-auth
 
 # Or via git
 git worktree remove ~/.git-worktrees/flow-cli-feature-new-auth
-```bash
+```
 
 ---
 
@@ -121,7 +121,7 @@ The CC dispatcher now supports **consistent** mode → target syntax:
 # Pattern: cc [mode] [target]
 # Modes: (none), yolo, plan, opus, haiku
 # Targets: (here), pick, wt <branch>, <project>
-```bash
+```
 
 ### Basic Worktree Launch
 
@@ -134,7 +134,7 @@ cc wt pick
 
 # List worktrees with session info
 cc wt status
-```text
+```
 
 ### Mode-First Pattern (NEW!)
 
@@ -143,21 +143,21 @@ cc wt status
 ```bash
 cc yolo wt feature/refactor     # Mode → worktree
 cc yolo wt pick                 # Mode → worktree picker
-```text
+```
 
 **Plan mode:**
 
 ```bash
 cc plan wt feature/refactor     # Plan mode in worktree
 cc plan wt pick                 # Pick worktree for planning
-```text
+```
 
 **Model selection:**
 
 ```bash
 cc opus wt experiment/ui        # Opus model in worktree
 cc haiku wt feature/docs        # Haiku model in worktree
-```text
+```
 
 ### Backward Compatible Pattern
 
@@ -167,7 +167,7 @@ cc haiku wt feature/docs        # Haiku model in worktree
 cc wt yolo feature/refactor     # Target → mode (still works)
 cc wt plan feature/refactor     # Target → mode (still works)
 cc wt opus experiment/ui        # Target → mode (still works)
-```text
+```
 
 **Aliases:**
 
@@ -176,7 +176,7 @@ ccw feature/refactor            # cc wt
 ccwy feature/refactor           # cc wt yolo
 ccwp                            # cc wt pick
 ccy                             # cc yolo
-```bash
+```
 
 ---
 
@@ -216,7 +216,7 @@ git push
 # Option B: Failed experiment - just delete
 wt remove experiment/commands-refactor
 # All changes gone, main repo untouched
-```diff
+```
 
 **Why this works:**
 - ✅ YOLO mode = no permission prompts
@@ -243,7 +243,7 @@ cd ~/.git-worktrees/flow-cli-feature-docs-update
 cd ~/projects/flow-cli
 git status
 pytest
-```diff
+```
 
 **Benefits:**
 - Each feature isolated
@@ -277,7 +277,7 @@ git push
 # Back to feature work (untouched!)
 cd ~/.git-worktrees/flow-cli-feature-refactor
 # Continue where you left off
-```bash
+```
 
 ### Workflow 4: Experimenting with Different Approaches
 
@@ -316,7 +316,7 @@ git diff experiment/approach-c..main -- commands/ | wc -l
 git merge experiment/approach-b
 wt remove experiment/approach-a
 wt remove experiment/approach-c
-```bash
+```
 
 ---
 
@@ -327,7 +327,7 @@ wt remove experiment/approach-c
 ```bash
 # Show all worktrees with Claude session info
 cc wt status
-```text
+```
 
 **Output:**
 
@@ -340,7 +340,7 @@ Worktrees with Claude Session Info
 ⚪ ~/.git-worktrees/flow-cli-hotfix       [hotfix/bug]
 
 Legend: 🟢 Recent session (< 24h) | 🟡 Old session | ⚪ No session
-```diff
+```
 
 **Indicators:**
 - 🟢 Recent session (< 24 hours ago)
@@ -354,7 +354,7 @@ Legend: 🟢 Recent session (< 24h) | 🟡 Old session | ⚪ No session
 ```bash
 # FZF picker shows worktrees
 cc wt pick
-```diff
+```
 
 **Display includes:**
 - Session indicators (🟢/🟡)
@@ -381,7 +381,7 @@ watch -n 2 'git diff --stat'  # Monitor changes
 # After work
 git diff                      # Review ALL changes
 git add -p                    # Stage selectively
-```bash
+```
 
 ### 2. Cleanup Regularly
 
@@ -395,7 +395,7 @@ git worktree list
 # Remove finished experiments
 wt remove experiment/old-idea
 wt remove feature/completed
-```bash
+```
 
 ### 3. Keep Main Clean
 
@@ -408,7 +408,7 @@ cc yolo wt experiment/risky-change
 # Bad: YOLO mode in main project
 cd ~/projects/flow-cli
 cc yolo                       # ❌ Too risky!
-```diff
+```
 
 ### 4. Name Worktrees Clearly
 
@@ -436,7 +436,7 @@ cc yolo
 cc yolo wt feature/auth
 # Terminal 2
 cc yolo wt feature/auth      # ❌ Two sessions, same files
-```bash
+```
 
 ---
 
@@ -459,7 +459,7 @@ git push origin experiment/new-parser
 git worktree add ~/.git-worktrees/flow-cli-experiment-new-parser origin/experiment/new-parser
 cd ~/.git-worktrees/flow-cli-experiment-new-parser
 cc  # Review with Claude
-```bash
+```
 
 ### Worktree for CI/CD Testing
 
@@ -484,7 +484,7 @@ git merge feature/new-feature
 cd ~/.git-worktrees/flow-cli-feature-new-feature
 cc yolo
 > Fix the failing tests
-```bash
+```
 
 ### Long-Running Experiments
 
@@ -514,7 +514,7 @@ cd ~/projects/flow-cli
 git checkout main
 git merge --squash experiment/async-rewrite
 git commit -m "feat: migrate to async architecture"
-```bash
+```
 
 ---
 
@@ -535,7 +535,7 @@ wt remove feature/auth
 
 # Or use the existing worktree
 cd ~/.git-worktrees/flow-cli-feature-auth
-```bash
+```
 
 ### Can't Find Worktree
 
@@ -549,7 +549,7 @@ wt list
 
 # Or use picker
 cc wt pick
-```bash
+```
 
 ### Worktree Out of Sync
 
@@ -561,7 +561,7 @@ cc wt pick
 cd ~/.git-worktrees/flow-cli-feature-auth
 git status
 git pull origin feature/auth
-```diff
+```
 
 ### Session Indicator Wrong
 
@@ -587,7 +587,7 @@ wt remove experiment/old-2
 
 # Or clean up manually
 git worktree prune
-```diff
+```
 
 ---
 
@@ -646,7 +646,7 @@ cc wt <branch>              # acceptEdits mode
 cc yolo wt <branch>         # YOLO mode
 cc plan wt <branch>         # Plan mode
 cc opus wt <branch>         # Opus model
-```text
+```
 
 ### Pick Existing
 
@@ -654,7 +654,7 @@ cc opus wt <branch>         # Opus model
 cc wt pick                  # acceptEdits mode
 cc yolo wt pick             # YOLO mode
 cc plan wt pick             # Plan mode
-```text
+```
 
 ### Status & Management
 
@@ -662,7 +662,7 @@ cc plan wt pick             # Plan mode
 cc wt status                # Show all with sessions
 wt list                     # List all worktrees
 wt remove <branch>          # Delete worktree
-```text
+```
 
 ### Aliases
 

--- a/docs/guides/YOLO-MODE-WORKFLOW.md
+++ b/docs/guides/YOLO-MODE-WORKFLOW.md
@@ -87,7 +87,7 @@ The VS Code extension has a built-in mode toggle:
 5. Claude edits files automatically (no confirmation per edit)
 6. Review changes with: git diff
 7. Commit or revert as needed
-```bash
+```
 
 ---
 
@@ -100,7 +100,7 @@ The **real** YOLO mode only exists in the command-line interface:
 ```bash
 # This bypasses ALL permissions
 claude --dangerously-skip-permissions
-```bash
+```
 
 ### What It Does
 
@@ -148,7 +148,7 @@ git diff commands/
 git add -A && git commit -m "refactor: modernize commands"
 # OR
 git reset --hard HEAD  # Discard everything
-```diff
+```
 
 ---
 
@@ -186,7 +186,7 @@ cc yolo wt pick             # Pick worktree → YOLO (NEW!)
 
 # Alias
 ccy                         # Short for: cc yolo
-```bash
+```
 
 **What it does:** Launches `claude --dangerously-skip-permissions` for true permission bypass.
 
@@ -207,7 +207,7 @@ cc plan wt pick                 # FZF picker → Plan mode
 # Backward compatible (still works)
 cc wt yolo feature/refactor     # Old pattern
 ccwy feature/refactor           # Alias: cc wt yolo
-```diff
+```
 
 **Why worktrees?** Isolated environments with easy cleanup:
 
@@ -240,7 +240,7 @@ git merge experiment/commands-refactor
 
 # Bad: Just delete worktree
 wt remove experiment/commands-refactor
-```bash
+```
 
 **Safest approach:** Worktree + YOLO gives isolation AND speed.
 
@@ -267,7 +267,7 @@ git commit                    # Save good changes
 
 # If things go wrong
 git reset --hard HEAD         # Nuclear option
-```bash
+```
 
 ### 2. Use Worktrees for Isolation
 
@@ -284,7 +284,7 @@ claude --dangerously-skip-permissions
 # Experiment fails? Just delete
 cd ~/projects/flow-cli
 wt remove yolo-experiment
-```diff
+```
 
 ### 3. Start Small
 
@@ -309,7 +309,7 @@ Don't let Claude make 100 changes unchecked:
 # Review every 5-10 operations
 git diff --stat               # See what changed
 git diff lib/core.zsh         # Review specific file
-```bash
+```
 
 ### 5. Backup Critical State
 
@@ -322,7 +322,7 @@ git checkout main
 
 # Or stash current state
 git stash save "pre-yolo-$(date +%Y%m%d-%H%M)"
-```text
+```
 
 ---
 
@@ -339,7 +339,7 @@ These settings **do not exist** in the official extension:
   "claude-code.autoSave": true,          // ❌ Fake
   "claude-code.showTokenCount": true     // ❌ Fake
 }
-```text
+```
 
 **Why the confusion?** These were incorrectly documented earlier. The VS Code extension doesn't have these settings.
 
@@ -354,7 +354,7 @@ Creating a `.code-workspace` file with fake settings **does nothing**:
     "claude-code.yoloMode": true  // ❌ Has no effect
   }
 }
-```bash
+```
 
 **Reality:** The VS Code extension ignores these settings.
 
@@ -365,7 +365,7 @@ The CLI flag **does not work** when using the VS Code extension:
 ```bash
 # This only works in CLI, not VS Code extension
 claude --dangerously-skip-permissions
-```diff
+```
 
 **Why?** The VS Code extension has its own separate permission system.
 
@@ -395,7 +395,7 @@ claude --dangerously-skip-permissions
 cd ~/projects/flow-cli
 git status                    # Clean working tree
 git checkout -b refactor-cmds
-```bash
+```
 
 **Option A: VS Code (Auto-Accept Edits)**
 
@@ -418,7 +418,7 @@ Watch files change in real-time
 # 6. Commit
 git add -A
 git commit -m "refactor: consistent error handling"
-```bash
+```
 
 **Option B: CLI (True YOLO)**
 
@@ -438,7 +438,7 @@ git diff
 git add -A && git commit -m "refactor: error handling"
 # OR
 git reset --hard HEAD
-```text
+```
 
 ---
 
@@ -450,21 +450,21 @@ git reset --hard HEAD
 
 ```text
 Extensions → Search "Claude Code" → Should be installed
-```text
+```
 
 **Check 2:** Is mode actually toggled?
 
 ```text
 Look for indicator: "Auto-accept edits: ON" in chat
 Try pressing Shift+Tab again
-```text
+```
 
 **Check 3:** Are you asking for edits?
 
 ```text
 Auto-accept only works for file edits
 Reads/writes/executes still prompt
-```bash
+```
 
 ### CLI Mode Not Bypassing Permissions?
 
@@ -477,7 +477,7 @@ claude --dangerously-skip-permissions
 # Wrong
 claude --yolo               # ❌ Not a real flag
 claude --skip-permissions   # ❌ Missing "dangerously"
-```bash
+```
 
 **Check 2:** Using CLI, not extension?
 

--- a/docs/guides/ZSH-PLUGIN-ECOSYSTEM-GUIDE.md
+++ b/docs/guides/ZSH-PLUGIN-ECOSYSTEM-GUIDE.md
@@ -42,7 +42,7 @@
 │  Total: 22 plugins + flow-cli = 351 aliases                │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
-```bash
+```
 
 ### Key Concepts
 
@@ -78,7 +78,7 @@
 ├── .zshrc                    # Main config (sources antidote)
 ├── .zsh_plugins.txt          # Plugin list (antidote reads this)
 └── .zsh_plugins.zsh          # Generated cache (auto-updated)
-```zsh
+```
 
 ### How It Works
 
@@ -90,7 +90,7 @@ flowchart LR
     D -->|loads| E[18 OMZ plugins]
     D -->|loads| F[4 community plugins]
     A -->|also sources| G[flow-cli/flow.plugin.zsh]
-```zsh
+```
 
 **Startup sequence:**
 
@@ -149,7 +149,7 @@ These make you faster:
 $ git pu▊                    # Gray text appears
 $ git push origin main       # → to accept full suggestion
 $ git pu                     # Alt+→ to accept next word
-```diff
+```
 
 **Commands:**
 - `→` - Accept full suggestion
@@ -164,7 +164,7 @@ $ ls        # Green (valid)
 $ lss       # Red (command not found)
 $ cd /tmp   # Green path exists
 $ cd /xyz   # Red path doesn't exist
-```bash
+```
 
 **No commands - automatic highlighting**
 
@@ -176,7 +176,7 @@ $ git status
 
 $ docker ps
 # → You should use: dkps
-```bash
+```
 
 **Teaches you to use aliases automatically!**
 
@@ -217,7 +217,7 @@ gstl        # git stash list
 gd          # git diff
 gds         # git diff --staged
 gsh         # git show
-```bash
+```
 
 **Full list:** Run `aliases git` or see [OMZ git plugin docs](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git)
 
@@ -231,7 +231,7 @@ repo user/repo          # Opens specific repo
 # Gist management
 gist file.txt          # Create gist from file
 gist -p file.txt       # Private gist
-```bash
+```
 
 ---
 
@@ -243,7 +243,7 @@ gist -p file.txt       # Private gist
 # Type a long command, then press Ctrl+O
 $ kubectl get pods --all-namespaces --field-selector...
 # [Ctrl+O] → Entire line copied to clipboard
-```bash
+```
 
 #### copypath
 
@@ -253,14 +253,14 @@ copypath              # Copies $(pwd)
 
 # Copy specific file path
 copypath file.txt     # Copies absolute path
-```bash
+```
 
 #### copyfile
 
 ```bash
 # Copy file contents
 copyfile config.json  # File contents → clipboard
-```bash
+```
 
 ---
 
@@ -275,7 +275,7 @@ $ cd bar
 # [Alt+Left] → Back to ~/projects/foo
 # [Alt+Left] → Back to ~/projects
 # [Alt+Right] → Forward to ~/projects/foo
-```bash
+```
 
 **Like browser back/forward buttons!**
 
@@ -289,7 +289,7 @@ zi                     # Interactive picker (fzf)
 
 # Add directory manually
 za ~/custom/path
-```bash
+```
 
 ---
 
@@ -304,7 +304,7 @@ alias-finder git status
 
 alias-finder docker ps
 # → dkps='docker ps'
-```bash
+```
 
 #### aliases (built-in)
 
@@ -316,7 +316,7 @@ aliases                # Categorized view
 aliases git            # All git aliases
 aliases claude         # All Claude Code aliases
 aliases r              # All R package aliases
-```bash
+```
 
 ---
 
@@ -330,7 +330,7 @@ x file.zip
 x archive.tar.gz
 x package.rar
 x data.7z
-```text
+```
 
 **Supports:** zip, tar, tar.gz, tar.bz2, rar, 7z, xz, lzma, and more
 
@@ -347,7 +347,7 @@ dkpsa       # docker ps -a
 dkrm        # docker rm
 dkrmi       # docker rmi
 dkb         # docker build
-```bash
+```
 
 #### fzf plugin
 
@@ -360,7 +360,7 @@ dkb         # docker build
 
 # Fuzzy cd
 [Alt+C]                # Fuzzy cd into subdirectory
-```bash
+```
 
 ---
 
@@ -372,7 +372,7 @@ dkb         # docker build
 # Just view any man page
 man ls                 # Colors automatically applied
 man git                # Much easier to read!
-```bash
+```
 
 #### command-not-found
 
@@ -381,14 +381,14 @@ $ pytohn
 # zsh: command not found: pytohn
 # Did you mean: python?
 # Install with: brew install python
-```bash
+```
 
 #### sudo (ESC ESC)
 
 ```bash
 $ apt install foo
 # [ESC ESC] → sudo apt install foo
-```bash
+```
 
 ---
 
@@ -414,7 +414,7 @@ gp                     # Instead of: git push
 
 # 5. View log
 glog                   # Pretty git log with graph
-```bash
+```
 
 **Practice:**
 1. Create test file: `touch test.txt`
@@ -446,7 +446,7 @@ copyfile config.json   # Contents copied
 # 4. Copy long command (Ctrl+O)
 kubectl get pods --all-namespaces --field-selector status.phase=Running
 # [Ctrl+O] → Entire command copied
-```bash
+```
 
 ---
 
@@ -465,7 +465,7 @@ cd baz
 # 2. Use zoxide
 z medfit               # Jump to recently used "medfit" directory
 zi                     # Interactive picker
-```bash
+```
 
 ---
 
@@ -481,7 +481,7 @@ curl -O https://example.com/backup.zip
 # Extract with x
 x data.tar.gz          # Extracts to current directory
 x backup.zip           # Works for any format!
-```bash
+```
 
 ---
 
@@ -503,7 +503,7 @@ git pu▊                # See suggestion appear
 # 3. Find aliases
 alias-finder docker ps
 # → dkps='docker ps'
-```bash
+```
 
 ---
 
@@ -517,7 +517,7 @@ antidote update
 
 # Check what updated
 # (antidote shows git log for each updated plugin)
-```zsh
+```
 
 **Frequency:** Run monthly or when you see plugin bugs
 
@@ -533,7 +533,7 @@ ohmyzsh/ohmyzsh path:plugins/npm
 
 # Reload shell
 source ~/.zshrc
-```bash
+```
 
 **Popular plugins to consider:**
 
@@ -546,7 +546,7 @@ ohmyzsh/ohmyzsh path:plugins/rust
 # Productivity
 ohmyzsh/ohmyzsh path:plugins/tmux
 ohmyzsh/ohmyzsh path:plugins/ssh-agent
-```zsh
+```
 
 ---
 
@@ -560,7 +560,7 @@ ohmyzsh/ohmyzsh path:plugins/ssh-agent
 
 # Reload
 source ~/.zshrc
-```bash
+```
 
 ---
 
@@ -576,7 +576,7 @@ ohmyzsh/ohmyzsh path:plugins/docker kind:defer
 
 # Load github plugin only when needed
 ohmyzsh/ohmyzsh path:plugins/github kind:defer
-```bash
+```
 
 **Already optimized in your setup!**
 
@@ -592,7 +592,7 @@ ohmyzsh/ohmyzsh path:plugins/github kind:defer
 # Check what the alias does
 which g                # Shows: g is aliased to git
 type g                 # More detailed info
-```bash
+```
 
 **Solution:** Use full command or different alias
 
@@ -602,7 +602,7 @@ git status
 
 # Or find alternative alias
 alias-finder git
-```bash
+```
 
 ---
 
@@ -618,7 +618,7 @@ grep "plugin-name" ~/.config/zsh/.zsh_plugins.zsh
 
 # Check for errors
 source ~/.zshrc 2>&1 | grep -i error
-```bash
+```
 
 **Solution:**
 
@@ -626,7 +626,7 @@ source ~/.zshrc 2>&1 | grep -i error
 # Regenerate cache
 rm ~/.config/zsh/.zsh_plugins.zsh
 source ~/.zshrc
-```bash
+```
 
 ---
 
@@ -639,7 +639,7 @@ source ~/.zshrc
 ```bash
 # Time your shell startup
 time zsh -i -c exit
-```bash
+```
 
 **Solution:**
 
@@ -650,7 +650,7 @@ time zsh -i -c exit
 
 # Example: Only load what you need
 # ohmyzsh/ohmyzsh path:lib  # REMOVE if too slow
-```bash
+```
 
 ---
 
@@ -667,7 +667,7 @@ compinit
 
 # Reload shell
 exec zsh
-```bash
+```
 
 ---
 
@@ -699,7 +699,7 @@ z <dir>                      # Smart cd (zoxide)
 
 # Extraction
 x <archive>                  # Extract any format
-```diff
+```
 
 ---
 

--- a/docs/implementation/GIT-DETECTION-IMPLEMENTATION.md
+++ b/docs/implementation/GIT-DETECTION-IMPLEMENTATION.md
@@ -26,7 +26,7 @@ _dot_check_git_in_path() {
     # Returns: space-separated list of .git directories found
     # Exit code: 0 if found, 1 if none
 }
-```diff
+```
 
 ---
 
@@ -65,7 +65,7 @@ _dot_check_git_in_path() {
 # Only checks the symlink target for .git
 local real_target=$(readlink "$target")
 [[ -d "${real_target}/.git" ]] && git_dirs+=("${real_target}/.git")
-```bash
+```
 
 **User follows symlink:**
 
@@ -74,7 +74,7 @@ local real_target=$(readlink "$target")
 resolved=$(readlink -f "$target" 2>/dev/null || realpath "$target" 2>/dev/null)
 target="$resolved"
 # Continue with full scan
-```bash
+```
 
 ### 2. Fast Path: Git Repositories
 
@@ -88,7 +88,7 @@ if [[ -d "$target/.git" ]] && command -v git &>/dev/null; then
     # Extract submodule paths
     git -C "$target" submodule foreach --quiet 'echo $sm_path' 2>/dev/null
 fi
-```diff
+```
 
 **Benefits:**
 - 10-50x faster than `find` on large repos
@@ -108,7 +108,7 @@ fi
 
 # Find with 2-second timeout
 _flow_timeout 2 find "$target" -name ".git" -type d -maxdepth 5 2>/dev/null
-```zsh
+```
 
 **Timeout Handling:**
 
@@ -118,7 +118,7 @@ if (( find_exit == 124 )); then
     _flow_log_warning "Git directory scan timed out after 2 seconds"
     _flow_log_info "Large directories may have .git subdirectories not detected"
 fi
-```bash
+```
 
 ### 4. Cross-Platform Compatibility
 
@@ -127,7 +127,7 @@ fi
 ```zsh
 # Try readlink -f (GNU), fallback to realpath (BSD)
 resolved=$(readlink -f "$target" 2>/dev/null || realpath "$target" 2>/dev/null)
-```diff
+```
 
 **Timeout Command:**
 - Uses `_flow_timeout()` from `lib/core.zsh`
@@ -141,7 +141,7 @@ count=$(command | wc -l | tr -d ' ')  # Remove all spaces
 count="${count##*( )}"                 # Strip leading spaces (ZSH)
 count="${count%%*( )}"                 # Strip trailing spaces (ZSH)
 [[ "$count" =~ ^[0-9]+$ ]] || count=0  # Validate numeric
-```text
+```
 
 ---
 
@@ -151,7 +151,7 @@ count="${count%%*( )}"                 # Strip trailing spaces (ZSH)
 
 ```text
 /path/to/target/.git /path/to/target/subdir/.git
-```diff
+```
 
 - Space-separated paths
 - Exit code: 0
@@ -160,7 +160,7 @@ count="${count%%*( )}"                 # Strip trailing spaces (ZSH)
 
 ```text
 (empty string)
-```diff
+```
 
 - Exit code: 1
 
@@ -181,7 +181,7 @@ if git_dirs=$(_dot_check_git_in_path "$target"); then
     echo
     [[ $REPLY =~ ^[Yy]$ ]] || return 1
 fi
-```bash
+```
 
 ### Example 2: Automatic exclusion
 
@@ -193,7 +193,7 @@ if _dot_check_git_in_path "$target" >/dev/null; then
     echo ".git" >> ~/.local/share/chezmoi/.chezmoiignore
     _flow_log_success "Added .git to ignore patterns"
 fi
-```zsh
+```
 
 ### Example 3: Performance-aware scan
 
@@ -206,7 +206,7 @@ if (( dir_size > 100000 )); then  # > 100MB
 fi
 
 result=$(_dot_check_git_in_path "$target")
-```yaml
+```
 
 ---
 
@@ -247,7 +247,7 @@ _dot_check_git_in_path "/tmp/test-link"
 # Test 4: Performance
 time _dot_check_git_in_path "/large/directory"
 # Should complete in < 2s or timeout gracefully
-```bash
+```
 
 ---
 
@@ -261,7 +261,7 @@ if [[ -d "$target/.git" ]] && command -v git &>/dev/null; then
 else
     # Fallback to find (slow path)
 fi
-```bash
+```
 
 ### 2. Symlink Loop Protection
 
@@ -272,21 +272,21 @@ if [[ -z "$resolved" ]]; then
     _flow_log_error "Failed to resolve symlink"
     return 1
 fi
-```bash
+```
 
 ### 3. Permission Denied
 
 ```zsh
 # find stderr redirected to /dev/null
 find "$target" -name ".git" -type d -maxdepth 5 2>/dev/null
-```bash
+```
 
 ### 4. Very Deep Nesting
 
 ```zsh
 # Limit to maxdepth 5 to prevent excessive recursion
 find "$target" -name ".git" -type d -maxdepth 5
-```zsh
+```
 
 ### 5. Timeout Recovery
 
@@ -296,7 +296,7 @@ if (( find_exit == 124 )); then
     _flow_log_warning "Git directory scan timed out after 2 seconds"
     # Return partial results already collected
 fi
-```bash
+```
 
 ---
 

--- a/docs/internal/conventions/adhd/GETTING-STARTED-TEMPLATE.md
+++ b/docs/internal/conventions/adhd/GETTING-STARTED-TEMPLATE.md
@@ -34,7 +34,7 @@
 - [ ] [Nice-to-have tool]
 
 **Check everything:**
-```bash
+```
 # Run this to verify prerequisites
 [verification command]
 ```
@@ -44,17 +44,17 @@
 ## 1. Installation (2 min)
 
 ### Step 1.1: [First action]
-```bash
+```
 [command]
 ```
 
 ### Step 1.2: [Second action]
-```bash
+```
 [command]
 ```
 
 ### Verify installation:
-```bash
+```
 [verification command]
 # Expected output: [what they should see]
 ```
@@ -64,7 +64,7 @@
 ## 2. First Use (3 min)
 
 ### Try it now:
-```bash
+```
 # Your first [action]
 [command]
 ```
@@ -72,7 +72,7 @@
 **What happened:** [Brief explanation of what they just did]
 
 ### Try another:
-```bash
+```
 # [Second basic action]
 [command]
 ```
@@ -90,17 +90,17 @@ The typical workflow is:
 ### Practice the workflow:
 
 **Step 1:** [Action]
-```bash
+```
 [command]
 ```
 
 **Step 2:** [Action]
-```bash
+```
 [command]
 ```
 
 **Step 3:** [Action]
-```bash
+```
 [command]
 ```
 
@@ -114,7 +114,7 @@ Complete these tasks to verify you understand the basics:
 <details>
 <summary>Hint</summary>
 
-```bash
+```
 [hint command]
 ```
 </details>
@@ -122,7 +122,7 @@ Complete these tasks to verify you understand the basics:
 <details>
 <summary>Solution</summary>
 
-```bash
+```
 [solution command]
 ```
 </details>
@@ -137,7 +137,7 @@ Complete these tasks to verify you understand the basics:
 <details>
 <summary>Solution</summary>
 
-```bash
+```
 [solution command]
 ```
 </details>
@@ -146,7 +146,7 @@ Complete these tasks to verify you understand the basics:
 <details>
 <summary>Solution</summary>
 
-```bash
+```
 [solution command]
 ```
 </details>
@@ -165,7 +165,7 @@ Complete these tasks to verify you understand the basics:
 
 ### Common Patterns
 
-```bash
+```
 # Pattern 1: [name]
 [command pattern]
 
@@ -180,14 +180,14 @@ Complete these tasks to verify you understand the basics:
 ### "[Error message 1]"
 **Cause:** [why this happens]
 **Fix:**
-```bash
+```
 [fix command]
 ```
 
 ### "[Error message 2]"
 **Cause:** [why this happens]
 **Fix:**
-```bash
+```
 [fix command]
 ```
 

--- a/docs/internal/conventions/adhd/GIF-GUIDELINES.md
+++ b/docs/internal/conventions/adhd/GIF-GUIDELINES.md
@@ -42,7 +42,7 @@ Height: Auto (maintain aspect ratio)
 FPS: 10-15 (not 30+)
 Colors: 64-128 palette
 Loop: Infinite
-```text
+```
 
 ---
 
@@ -52,7 +52,7 @@ Loop: Infinite
 
 ```text
 <feature>-<action>-<variant>.gif
-```diff
+```
 
 ### Examples
 
@@ -101,7 +101,7 @@ docs/
 │       └── tutorials/         # Tutorial companion GIFs
 │           ├── 01-*.gif
 │           └── 10-*.gif
-```text
+```
 
 ### Linking in Docs
 
@@ -110,7 +110,7 @@ docs/
 ![Pick basic usage](../../assets/gifs/commands/pick-basic-usage.gif)
 
 *Using `pick` to navigate between projects*
-```diff
+```
 
 ---
 
@@ -142,7 +142,7 @@ export PS1="$ "  # Simple prompt
 
 # 4. Choose high-contrast theme
 # Recommended: Solarized Light (better GIF compression)
-```bash
+```
 
 ### Recording Process
 
@@ -185,7 +185,7 @@ gifsicle -O3 --lossy=80 --colors 128 input.gif -o output.gif
 for gif in docs/assets/gifs/**/*.gif; do
     gifsicle -O3 --colors 128 "$gif" -o "${gif%.gif}-optimized.gif"
 done
-```bash
+```
 
 ### Using ffmpeg
 
@@ -198,7 +198,7 @@ ffmpeg -i input.mov -vf "fps=10,scale=1200:-1:flags=lanczos" \
 ffmpeg -i input.mov -vf \
   "fps=10,scale=1200:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" \
   output.gif
-```diff
+```
 
 ### Optimization Targets
 
@@ -278,7 +278,7 @@ The GIF demonstrates:
 2. Filtering projects by typing
 3. Selecting with Enter key
 4. Changing directory to selected project
-```diff
+```
 
 ---
 
@@ -391,7 +391,7 @@ Demonstrates the complete teaching + git integration workflow including:
 
 The teaching system integrates with Git to provide automated commit
 workflows, branch-aware deployment, and interactive cleanup prompts.
-```text
+```
 
 ### Example 2: DOT Dispatcher Demo
 
@@ -411,7 +411,7 @@ Demonstrates the dots/sec dispatcher functionality for managing dotfiles and sec
 
 The dots and sec dispatchers provide streamlined access to dotfile management
 and secret storage using macOS Keychain integration.
-```yaml
+```
 
 ---
 
@@ -445,7 +445,7 @@ git commit -m "docs: update pick GIF for v4.8 UI changes
 
 - New GIF reflects unified grammar
 - Old GIF archived for reference"
-```diff
+```
 
 ---
 
@@ -470,7 +470,7 @@ git commit -m "docs: update pick GIF for v4.8 UI changes
   src="https://asciinema.org/a/123456.js"
   async>
 </script>
-```diff
+```
 
 ### Interactive Demos
 
@@ -497,7 +497,7 @@ brew install --cask kap
 
 # Install peek alternative (optional)
 brew install --cask licecap
-```bash
+```
 
 ### Linux
 
@@ -510,7 +510,7 @@ sudo apt install ffmpeg
 
 # Install peek
 sudo apt install peek
-```text
+```
 
 ---
 

--- a/docs/internal/conventions/adhd/README.md
+++ b/docs/internal/conventions/adhd/README.md
@@ -31,7 +31,7 @@ What are you documenting?
 │
 └─ Creating visual demonstration?
    └─ Use: GIF-GUIDELINES.md
-```yaml
+```
 
 ---
 
@@ -338,7 +338,7 @@ All templates follow these principles:
 01-first-session.md
 02-multiple-projects.md
 10-cc-dispatcher.md
-```diff
+```
 
 **Numbering:**
 - 01-09: Core workflow (beginner)
@@ -353,7 +353,7 @@ All templates follow these principles:
 git-feature-workflow.md
 r-package-workflow.md
 worktree-workflow.md
-```text
+```
 
 ### Reference Cards
 
@@ -363,7 +363,7 @@ worktree-workflow.md
 COMMAND-QUICK-REFERENCE.md
 CC-DISPATCHER-REFERENCE.md
 WORKFLOW-QUICK-REFERENCE.md
-```text
+```
 
 ### GIFs
 

--- a/docs/internal/conventions/adhd/REFCARD-TEMPLATE.md
+++ b/docs/internal/conventions/adhd/REFCARD-TEMPLATE.md
@@ -32,7 +32,7 @@
 ````markdown
 # [Tool Name] Reference Card
 
-```text
+```
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │  [TOOL NAME] REFERENCE CARD                                        v[X.X]  │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -58,13 +58,13 @@
 │  TIPS: [tip 1] • [tip 2] • [tip 3]                                          │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```diff
-````diff
+```
 
 ---
 
 ## Template: Markdown Table Style
 
-````markdown
+````
 # [Tool Name] Reference Card
 
 > **Version:** X.X | **Last Updated:** YYYY-MM-DD
@@ -99,13 +99,13 @@
 
 ## Common Patterns
 
-```bash
+```
 # [Pattern name]
 [command pattern]
 
 # [Pattern name]
 [command pattern]
-```diff
+```
 
 ---
 
@@ -114,13 +114,13 @@
 - [Tip 1]
 - [Tip 2]
 - [Tip 3]
-````bash
+```
 
 ---
 
 ## Template: Compact Grid Style
 
-````markdown
+````
 # [Tool Name] Refcard
 
 | Essential | Navigation | Editing |
@@ -169,7 +169,7 @@
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  TIPS: Use aliases (f, wk, dh, rh) • All hubs have same subcommands         │
 └─────────────────────────────────────────────────────────────────────────────┘
-```bash
+```
 
 ---
 
@@ -192,7 +192,7 @@
 | `gbl` blame | `gstl` list | `grs file` |
 
 **Patterns:** `ga . && gc "msg" && gp` • `gf && gm origin/main`
-```text
+```
 
 ---
 
@@ -204,7 +204,7 @@
 SHORT (≤6 chars)     Align descriptions at column 20
 MEDIUM (7-12 chars)  Align descriptions at column 25
 LONG (>12 chars)     Put description on next line or use table
-```diff
+```
 
 ### Descriptions
 

--- a/docs/internal/conventions/adhd/TUTORIAL-TEMPLATE.md
+++ b/docs/internal/conventions/adhd/TUTORIAL-TEMPLATE.md
@@ -34,7 +34,7 @@ Before starting, you should:
 - [ ] Completed: [Link to prior tutorial if part of series]
 
 **Verify your setup:**
-```bash
+```
 [verification command]
 ```
 
@@ -67,7 +67,7 @@ By the end of this tutorial, you will:
 
 [Brief explanation of what we're doing and why]
 
-```bash
+```
 [command or code]
 ```
 
@@ -77,7 +77,7 @@ By the end of this tutorial, you will:
 
 [Explanation]
 
-```bash
+```
 [command or code]
 ```
 
@@ -90,7 +90,7 @@ At this point, you should have:
 - [x] [What they've accomplished]
 
 **Verify:**
-```bash
+```
 [verification command]
 # Expected: [what they should see]
 ```
@@ -103,7 +103,7 @@ At this point, you should have:
 
 [Explanation]
 
-```bash
+```
 [command or code]
 ```
 
@@ -111,7 +111,7 @@ At this point, you should have:
 
 [Explanation]
 
-```bash
+```
 [command or code]
 ```
 
@@ -120,7 +120,7 @@ At this point, you should have:
 ### Checkpoint
 
 **Verify:**
-```bash
+```
 [verification command]
 ```
 
@@ -132,7 +132,7 @@ At this point, you should have:
 
 [Explanation]
 
-```bash
+```
 [command or code]
 ```
 
@@ -149,14 +149,14 @@ At this point, you should have:
 
 [Explanation]
 
-```bash
+```
 [command or code]
 ```
 
 ### Checkpoint
 
 **Verify:**
-```bash
+```
 [verification command]
 ```
 
@@ -166,7 +166,7 @@ At this point, you should have:
 
 Now let's use everything we learned:
 
-```bash
+```
 # Complete workflow
 [full example combining all parts]
 ```
@@ -191,7 +191,7 @@ Practice what you learned with these challenges:
 <details>
 <summary>Solution</summary>
 
-```bash
+```
 [solution]
 ```
 </details>
@@ -202,7 +202,7 @@ Practice what you learned with these challenges:
 <details>
 <summary>Solution</summary>
 
-```bash
+```
 [solution]
 ```
 </details>
@@ -213,7 +213,7 @@ Practice what you learned with these challenges:
 <details>
 <summary>Solution</summary>
 
-```bash
+```
 [solution]
 ```
 </details>
@@ -227,7 +227,7 @@ Practice what you learned with these challenges:
 **Cause:** [Why this happens]
 
 **Fix:**
-```bash
+```
 [fix command]
 ```
 
@@ -236,7 +236,7 @@ Practice what you learned with these challenges:
 **Cause:** [Why]
 
 **Fix:**
-```bash
+```
 [fix]
 ```
 
@@ -253,7 +253,7 @@ In this tutorial, you learned:
 | [Concept 3] | [Brief description] |
 
 **Key commands:**
-```bash
+```
 [cmd1]    # [what it does]
 [cmd2]    # [what it does]
 [cmd3]    # [what it does]

--- a/docs/internal/conventions/code/COMMIT-MESSAGES.md
+++ b/docs/internal/conventions/code/COMMIT-MESSAGES.md
@@ -10,7 +10,7 @@
 [optional body]
 
 [optional footer]
-```bash
+```
 
 ## Types
 
@@ -53,7 +53,7 @@ docs: update installation instructions
 feat(mediation): Added sensitivity analysis function.   # Past tense, period
 FIX: Bootstrap zero variance                           # Caps, unclear
 updated docs                                           # Past tense, no type
-```diff
+```
 
 ## Body (When Needed)
 
@@ -69,7 +69,7 @@ zero (constant values). Now returns NA with a warning instead of
 crashing.
 
 Fixes #42
-```text
+```
 
 ## Breaking Changes
 
@@ -80,7 +80,7 @@ feat(api)!: change return type to list
 
 BREAKING CHANGE: indirect_effect() now returns a list with
 $estimate and $ci instead of a numeric vector.
-```bash
+```
 
 ---
 
@@ -104,7 +104,7 @@ git commit -m "refactor(scope): improve code structure"
 
 # Chore
 git commit -m "chore(deps): update dependencies"
-```bash
+```
 
 ## R Package Examples
 
@@ -126,7 +126,7 @@ test(nde): add tests for binary mediator
 
 # CRAN submission prep
 chore: prepare for CRAN submission
-```bash
+```
 
 ## Research Project Examples
 
@@ -141,7 +141,7 @@ fix(analysis): correct standard error calculation
 
 # Data
 chore(data): add cleaned dataset
-```bash
+```
 
 ---
 
@@ -159,7 +159,7 @@ if ! grep -qE "^(feat|fix|docs|style|refactor|test|chore|perf)(\(.+\))?!?: .{1,5
     echo "Use: type(scope): subject"
     exit 1
 fi
-```bash
+```
 
 ### Aliases
 

--- a/docs/internal/conventions/code/R-STYLE-GUIDE.md
+++ b/docs/internal/conventions/code/R-STYLE-GUIDE.md
@@ -16,7 +16,7 @@ styler::style_pkg()
 
 # Check for issues
 lintr::lint_package()
-```r
+```
 
 ## The Rules
 
@@ -43,7 +43,7 @@ z <- function(a, b) a + b
 x<-5
 y<-c(1,2,3)
 z<-function(a,b) a+b
-```diff
+```
 
 ### Line Length
 
@@ -61,7 +61,7 @@ result <- very_long_function_name(
 
 # BAD
 result <- very_long_function_name(argument_one = value_one, argument_two = value_two, argument_three = value_three)
-```r
+```
 
 ### Functions
 
@@ -84,7 +84,7 @@ calculate_indirect_effect <- function(a, b,
 
   effect
 }
-```bash
+```
 
 ### Comments
 
@@ -96,7 +96,7 @@ ci <- bootstrap_ci(effect, n_boot = 1000)
 # BAD: States the obvious
 # Calculate the confidence interval
 ci <- bootstrap_ci(effect, n_boot = 1000)
-```bash
+```
 
 ### roxygen2 Documentation
 
@@ -121,7 +121,7 @@ ci <- bootstrap_ci(effect, n_boot = 1000)
 calculate_indirect_effect <- function(a, b, bootstrap = TRUE, n_boot = 1000) {
   # ...
 }
-```text
+```
 
 ### Package Structure
 
@@ -141,7 +141,7 @@ mypackage/
 │       └── helper-test_utils.R
 ├── vignettes/
 └── inst/
-```bash
+```
 
 ### Testing with testthat
 
@@ -162,7 +162,7 @@ test_that("bootstrap CI has expected length", {
   result <- calculate_indirect_effect(0.5, 0.4, bootstrap = TRUE)
   expect_length(result$ci, 2)
 })
-```bash
+```
 
 ---
 

--- a/docs/internal/conventions/code/ZSH-COMMANDS-HELP.md
+++ b/docs/internal/conventions/code/ZSH-COMMANDS-HELP.md
@@ -15,7 +15,7 @@ mycommand help        # Subcommand style (for dispatchers)
 # Every function should show usage on:
 myfunction            # No args (if args required)
 myfunction --help     # Explicit help request
-```text
+```
 
 ---
 
@@ -31,7 +31,7 @@ Description of what the command does.
 Options:
   -h, --help    Show this help
   -v, --verbose Verbose output
-```text
+```
 
 ### Full (Complex Commands)
 
@@ -56,7 +56,7 @@ Examples:
   command delete myfile      # Delete a file
 
 See also: related-command, other-command
-```yaml
+```
 
 ---
 
@@ -85,7 +85,7 @@ EOF
     local name="$1"
     # ... actual implementation
 }
-```zsh
+```
 
 ### Pattern 2: With Subcommands
 
@@ -130,7 +130,7 @@ EOF
             ;;
     esac
 }
-```zsh
+```
 
 ### Pattern 3: Dispatcher Function
 
@@ -174,7 +174,7 @@ Examples:
 Aliases: d1 → d sub1, d2 → d sub2
 EOF
 }
-```zsh
+```
 
 ### Pattern 4: With Options Parsing
 
@@ -240,7 +240,7 @@ Examples:
   mycommand -v -o out.txt input.txt
 EOF
 }
-```diff
+```
 
 ---
 
@@ -289,7 +289,7 @@ return 1
 echo "mycommand: unknown command '$cmd'" >&2
 echo "Run 'mycommand help' for available commands" >&2
 return 1
-```bash
+```
 
 ### Pattern: Validation Function
 
@@ -311,7 +311,7 @@ mycommand() {
     _require_arg "mycommand" "file" "$1" || return 1
     # ...
 }
-```bash
+```
 
 ---
 
@@ -326,7 +326,7 @@ mycommand -h              # Same as --help
 mycommand help            # For dispatcher-style
 mycommand                 # Shows help if args required, OR works if no args needed
 mycommand --invalid       # Shows error + hint, exits 1
-```bash
+```
 
 ### Automated Test Pattern
 
@@ -344,7 +344,7 @@ test_help_output() {
 
     echo "PASS: $cmd --help"
 }
-```yaml
+```
 
 ---
 

--- a/docs/internal/conventions/documentation/WEBSITE-DESIGN-GUIDE.md
+++ b/docs/internal/conventions/documentation/WEBSITE-DESIGN-GUIDE.md
@@ -107,7 +107,7 @@ extra:
 
 extra_css:
   - stylesheets/extra.css
-```yaml
+```
 
 ---
 
@@ -222,7 +222,7 @@ html {
     font-size: 0.85rem;
   }
 }
-```diff
+```
 
 **Key Features:**
 - **Border radius:** 12px for blocks, 6-10px for smaller elements
@@ -245,7 +245,7 @@ html {
 ```bash
 mkdir -p docs/stylesheets
 # Copy template above to docs/stylesheets/extra.css
-```diff
+```
 
 **When to use custom CSS:**
 - Want modern depth (shadows) without being flashy
@@ -279,7 +279,7 @@ nav:
     - Contributing: dev/contributing.md
   - Reference:
     - Complete Index: reference/index.md
-```diff
+```
 
 ### Rules
 
@@ -350,7 +350,7 @@ Brief explanation of approach/principles.
 **Last updated:** 2026-01-16
 **Maintainer:** Data-Wise
 **Repository:** [GitHub](https://github.com/Data-Wise/flow-cli)
-```text
+```
 
 ### Key Elements
 
@@ -374,7 +374,7 @@ Use sparingly in headers for quick scanning:
 ## 🎯 Key Concepts
 ## 🚀 Deployment
 ## 🛠️ Troubleshooting
-```text
+```
 
 **Rule:** Max 1 emoji per major section. Use consistently across pages.
 
@@ -391,7 +391,7 @@ Draw attention to important information:
 
 !!! info "For Existing Users"
     Migration guide available here.
-```diff
+```
 
 **Types to use:**
 - `tip` - Helpful shortcuts, recommendations
@@ -412,7 +412,7 @@ Draw attention to important information:
 |----------|-------|-------------|
 | Item 1 | 10 | Use X instead |
 | Item 2 | 5 | Use Y instead |
-```diff
+```
 
 **Use tables for:**
 - Comparisons (before/after)
@@ -427,7 +427,7 @@ Add at top of long pages:
 > **TL;DR:** One-sentence summary of entire page.
 
 ## Full Content Below
-```text
+```
 
 ### 5. Code Examples First
 
@@ -440,7 +440,7 @@ command here
 \`\`\`
 
 **Explanation:** What this does and why.
-```diff
+```
 
 Lead with action, explain after.
 
@@ -499,7 +499,7 @@ command
 ## What's Next?
 - [Command Reference](reference/command-quick-reference.md)
 - [Tutorials](tutorials/index.md)
-```bash
+```
 
 ### Reference Page
 
@@ -518,7 +518,7 @@ All commands organized by category.
 ## Category 2
 
 ...
-```bash
+```
 
 ### Migration Guide
 
@@ -544,7 +544,7 @@ command
 | Old | New |
 |-----|-----|
 | `old-cmd` | `new-cmd` |
-```yaml
+```
 
 ---
 
@@ -568,7 +568,7 @@ theme:
     - scheme: default
       primary: custom-color
       accent: custom-color
-```yaml
+```
 
 ---
 
@@ -593,7 +593,7 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material
       - run: mkdocs gh-deploy --force
-```diff
+```
 
 Push to main → Docs automatically deploy to `https://username.github.io/repo-name/`
 
@@ -653,7 +653,7 @@ rtest    # Run tests
 
 !!! tip "Start Here"
     Read [Alias Reference](reference/alias-reference-card.md) first!
-```bash
+```
 
 ### Bad Home Page
 
@@ -663,7 +663,7 @@ rtest    # Run tests
 Welcome to the comprehensive documentation portal for our advanced shell configuration...
 
 [Long paragraph about history and philosophy without actionable content]
-```yaml
+```
 
 ---
 
@@ -679,7 +679,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-```yaml
+```
 
 ### Tabs
 
@@ -689,18 +689,18 @@ For multiple code examples:
 markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
-```diff
+```
 
 Usage:
 
 ````markdown
 === "macOS"
-    ```bash
+    ```
     brew install tool
     ```
 
 === "Linux"
-    ```bash
+    ```
     apt install tool
     ```
 ````
@@ -778,7 +778,7 @@ project/
 │       └── index.md
 └── .github/workflows/
     └── deploy-docs.yml  # Auto-deploy
-```text
+```
 
 ### Commands
 
@@ -786,7 +786,7 @@ project/
 mkdocs serve           # Preview at localhost:8000
 mkdocs build           # Build to site/
 mkdocs gh-deploy       # Deploy to GitHub Pages
-```bash
+```
 
 ### Common Fixes
 
@@ -794,7 +794,7 @@ mkdocs gh-deploy       # Deploy to GitHub Pages
 
 ```bash
 mkdocs build 2>&1 | grep WARNING
-```text
+```
 
 **Port in use:**
 

--- a/docs/internal/conventions/project/COORDINATION-GUIDE.md
+++ b/docs/internal/conventions/project/COORDINATION-GUIDE.md
@@ -103,7 +103,7 @@ MediationVerse (meta-package)
 Teaching projects
     ↓
     └──→ stat-440, causal-inference
-```bash
+```
 
 ### Dependency Rules
 
@@ -121,7 +121,7 @@ grep -r "ALIAS-REFERENCE-CARD" ~/projects/*/README.md
 
 # Update all referencing projects
 # Update .planning/NOW.md with coordination note
-```yaml
+```
 
 ---
 
@@ -311,7 +311,7 @@ A breaking change is ANY change that:
 
 ```bash
 ~/projects/dev-tools/zsh-configuration/scripts/sync-standards.sh
-```bash
+```
 
 **Check Sync Status:**
 
@@ -320,7 +320,7 @@ A breaking change is ANY change that:
 cat ~/projects/project-hub/standards/.version
 cat ~/projects/r-packages/mediation-planning/standards/.version
 cat ~/projects/dev-tools/dev-planning/standards/.version
-```diff
+```
 
 **When to Sync:**
 - After updating any standard document
@@ -418,7 +418,7 @@ git commit -m "chore: initial commit with templates"
 
 # 5. Set up in dashboard
 dash  # Should now show new project
-```diff
+```
 
 ### Coordinating Cross-Project Change
 
@@ -461,7 +461,7 @@ echo "- Commit message standard update in progress" >> ~/projects/.planning/NOW.
 # 5. Propagate gradually
 # Don't try to update all at once
 # Update 3-5 projects per day
-```bash
+```
 
 ### Weekly Cross-Project Review
 

--- a/docs/internal/conventions/project/PROJECT-MANAGEMENT-STANDARDS.md
+++ b/docs/internal/conventions/project/PROJECT-MANAGEMENT-STANDARDS.md
@@ -153,7 +153,7 @@ B) [Alternative task] 🟡 [est. time]
 🎉 WINS
 
 [Recent accomplishments - celebrate progress!]
-```text
+```
 
 ### Visual Elements
 
@@ -163,7 +163,7 @@ B) [Alternative task] 🟡 [est. time]
 Full:     ████████████████████ 100%
 Partial:  ██████████░░░░░░░░░░  50%
 Empty:    ░░░░░░░░░░░░░░░░░░░░   0%
-```diff
+```
 
 **Status Indicators:**
 - ✅ Complete
@@ -238,7 +238,7 @@ Empty:    ░░░░░░░░░░░░░░░░░░░░   0%
 
 ## 📊 Overall Progress
 
-```text
+```
 
 P0: [Phase Name]         ████████████████████ 100% ✅ (date)
 P1: [Phase Name]         ████████████████████ 100% ✅ (date)
@@ -290,7 +290,7 @@ Brief summary of completed phases for reference.
 
 **Created:** [Date]
 **Maintainer:** [Name/Team]
-```diff
+```
 
 ### Sections Explained
 
@@ -379,7 +379,7 @@ newstatus
 
 # Show next action item
 next
-```bash
+```
 
 ### Project Hub Management
 
@@ -392,7 +392,7 @@ edithub
 
 # Create new PROJECT-HUB.md from template
 newhub
-```bash
+```
 
 ### ADHD Helpers
 
@@ -423,7 +423,7 @@ crumbs               # alias: bcs
 
 # Get AI task suggestion
 what-next            # alias: wn
-```bash
+```
 
 ### Focus Timers
 
@@ -443,7 +443,7 @@ time-check           # alias: tc
 
 # Stop timer early
 focus-stop           # alias: fs
-```bash
+```
 
 ---
 
@@ -460,7 +460,7 @@ dash teaching
 dash research
 dash packages
 dash dev
-```text
+```
 
 **Output:**
 
@@ -477,7 +477,7 @@ dash dev
 📋 READY TO START (2):
   📦 medfit [P1] 0% - Add vignette
   📊 product-of-three [P1] 60% - Review simulations
-```bash
+```
 
 ### Work Session Management
 
@@ -496,7 +496,7 @@ wt <project>         # Terminal only
 # Morning routine
 morning              # alias: gm
 # Shows: dashboard → picks project → starts work
-```bash
+```
 
 ### Status Updates
 
@@ -512,7 +512,7 @@ status <project> --create
 
 # Show status
 status <project> --show
-```bash
+```
 
 ---
 
@@ -531,7 +531,7 @@ just-start           # or: js
 
 # 3. Start working
 work .               # Opens current project
-```bash
+```
 
 **During Work:**
 
@@ -544,7 +544,7 @@ bc "Debugging auth flow, suspect issue in line 42"
 
 # Log quick wins
 win "Fixed authentication bug"
-```bash
+```
 
 **End of Session (< 30 seconds):**
 
@@ -556,7 +556,7 @@ editstatus           # Add to "JUST COMPLETED"
 
 # View wins
 wins                 # Celebrate progress!
-```bash
+```
 
 **Weekly Review (5-10 minutes):**
 
@@ -568,7 +568,7 @@ dash
 edithub              # Update progress bars
                     # Move items to "Recent Completions"
                     # Plan next week
-```yaml
+```
 
 ---
 
@@ -582,13 +582,13 @@ Location: `~/.STATUS-template-enhanced`
 
 ```bash
 newstatus
-```bash
+```
 
 **Or manually:**
 
 ```bash
 cp ~/.STATUS-template-enhanced ~/projects/my-project/.STATUS
-```yaml
+```
 
 ### PROJECT-HUB Template
 
@@ -598,13 +598,13 @@ Location: `~/.PROJECT-HUB-template`
 
 ```bash
 newhub
-```bash
+```
 
 **Or manually:**
 
 ```bash
 cp ~/.PROJECT-HUB-template ~/projects/my-project/PROJECT-HUB.md
-```diff
+```
 
 ---
 
@@ -644,7 +644,7 @@ why                  # Shows current location, git status, .STATUS excerpt
 # Or
 status .             # View .STATUS for current project
 next                 # Show next action
-```bash
+```
 
 ### "I don't know what to work on"
 
@@ -654,7 +654,7 @@ just-start           # Auto-picks based on priority
 
 # Or see all options
 dash                 # View all projects
-```bash
+```
 
 ### "I'm stuck on current task"
 
@@ -662,7 +662,7 @@ dash                 # View all projects
 # Leave note and switch
 bc "Blocked waiting for X, need to research Y"
 just-start           # Pick different task
-```bash
+```
 
 ### "Lost track of progress"
 

--- a/docs/internal/conventions/project/PROJECT-STRUCTURE.md
+++ b/docs/internal/conventions/project/PROJECT-STRUCTURE.md
@@ -12,7 +12,7 @@ project/
 ├── .STATUS            # Machine-readable status
 ├── .gitignore         # Git ignores
 └── CHANGELOG.md       # Version history (for packages/releases)
-```text
+```
 
 ## .STATUS File Format
 
@@ -22,7 +22,7 @@ progress: 75            # 0-100 (optional)
 next: Write discussion  # Next action item
 target: JASA            # Target journal/milestone (optional)
 updated: 2025-12-17     # Last update date
-```text
+```
 
 **Valid statuses:**
 
@@ -76,7 +76,7 @@ mypackage/
 └── .github/
     └── workflows/
         └── R-CMD-check.yaml
-```text
+```
 
 ---
 
@@ -113,7 +113,7 @@ my-research/
 └── docs/                  # Notes, drafts, reviews
     ├── notes.md
     └── reviews/
-```text
+```
 
 ---
 
@@ -149,7 +149,7 @@ STAT-440/
 ├── data/                  # Course datasets
 │
 └── resources/             # Supplementary materials
-```text
+```
 
 ---
 
@@ -176,7 +176,7 @@ my-manuscript/
 │
 └── supplementary/
     └── appendix.qmd
-```text
+```
 
 ---
 
@@ -201,7 +201,7 @@ my-tool/
 │
 └── .github/
     └── workflows/
-```diff
+```
 
 ---
 

--- a/docs/planning/V4.3-ROADMAP.md
+++ b/docs/planning/V4.3-ROADMAP.md
@@ -71,7 +71,7 @@ _cc_worktree_status() {
         fi
     done
 }
-```diff
+```
 
 **Tests to add:**
 - `test_cc_wt_status_shows_worktrees`
@@ -121,7 +121,7 @@ _cc_worktree_clean() {
         g feature prune
     fi
 }
-```bash
+```
 
 **Integration:** Combines with `g feature prune` for complete cleanup.
 
@@ -166,7 +166,7 @@ _g_feature_prune() {
 
     # ... delete logic ...
 }
-```diff
+```
 
 **Tests:**
 - `test_g_feature_prune_force_skips_confirmation`
@@ -221,7 +221,7 @@ _g_feature_prune() {
         fi
     done
 }
-```text
+```
 
 **Usage:**
 
@@ -229,7 +229,7 @@ _g_feature_prune() {
 g feature prune --older-than 30d  # Only branches > 30 days old
 g feature prune --older-than 1w   # Only branches > 1 week old
 g feature prune --older-than 2m   # Only branches > 2 months old
-```bash
+```
 
 ---
 
@@ -272,7 +272,7 @@ _g_feature_status() {
     echo ""
     echo "💡 Tip: Run 'g feature prune' to clean up merged branches"
 }
-```text
+```
 
 **Output example:**
 
@@ -289,7 +289,7 @@ _g_feature_status() {
   feature/new-feature                      3 commits ahead (1 day ago)
 
 💡 Tip: Run 'g feature prune' to clean up merged branches
-```bash
+```
 
 ---
 
@@ -347,7 +347,7 @@ _wt_prune() {
     echo ""
     echo "✅ Cleanup complete"
 }
-```text
+```
 
 **Usage:**
 
@@ -356,7 +356,7 @@ wt prune                  # Clean both worktrees and branches
 wt prune --branches-only  # Only clean branches
 wt prune --worktrees-only # Only clean worktrees
 wt prune -n               # Dry run
-```bash
+```
 
 ---
 

--- a/docs/plans/2026-01-31-teach-validate-lint.md
+++ b/docs/plans/2026-01-31-teach-validate-lint.md
@@ -89,13 +89,13 @@ test_lint_flag_parsing() {
     fi
   fi
 }
-```text
+```
 
 **Step 2: Run test to verify it fails**
 
 ```bash
 zsh tests/test-teach-validate-unit.zsh
-```text
+```
 
 Expected: FAIL -- `--lint` hits the `*) Unknown option` case at line 118
 
@@ -112,7 +112,7 @@ In `commands/teach-validate.zsh`, add to the argument parser (after line 88, bef
                 custom_validators="lint-shared"
                 shift
                 ;;
-```bash
+```
 
 In the dispatch section (after line 146, the `custom` elif), add:
 
@@ -128,7 +128,7 @@ In the dispatch section (after line 146, the `custom` elif), add:
         fi
         [[ $skip_external -eq 1 ]] && args+=(--skip-external)
         _run_custom_validators "${args[@]}" "${files[@]}"
-```text
+```
 
 **Step 4: Run test to verify it passes**
 
@@ -139,14 +139,14 @@ In `_teach_validate_help()` (around line 704), add:
 ```text
     --lint              Run Quarto-aware lint rules (.teach/validators/lint-*.zsh)
     --quick-checks      Run fast lint subset only (Phase 1 rules)
-```bash
+```
 
 **Step 6: Commit**
 
 ```bash
 git add commands/teach-validate.zsh tests/test-teach-validate-unit.zsh
 git commit -m "feat(teach): add --lint flag to teach validate command"
-```yaml
+```
 
 ---
 
@@ -166,26 +166,26 @@ title: "Test"
 
 # Heading
 
-```text
+```
 
 bare code with no language
 
 ```text
 
-```{r}
+```
 #| label: good-chunk
 x <- 1
 ```text
 
-```text
+```
 this is fine
 ```text
 
-```text
+```
 another bare block
 ```text
 
-```diff
+```
 
 **Step 2: Write the test file `tests/test-lint-shared-unit.zsh`**
 
@@ -225,11 +225,11 @@ test_all_tagged_passes() {
 title: "Good"
 ---
 
-```{r}
+```
 x <- 1
 ```text
 
-```text
+```
 plain text
 ```bash
 
@@ -246,7 +246,7 @@ test_all_tagged_passes
 echo ""; echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
 [[ $TESTS_FAILED -eq 0 ]]
 
-```diff
+```
 
 **Step 3: Run test -- should fail (validator doesn't exist)**
 
@@ -270,7 +270,7 @@ See the plan file at `~/.claude/plans/velvet-swimming-hippo.md` for the complete
 ```bash
 git add .teach/validators/lint-shared.zsh tests/test-lint-shared-unit.zsh tests/fixtures/lint/
 git commit -m "feat(teach): add lint-shared.zsh with 4 Phase 1 lint rules"
-```diff
+```
 
 ---
 
@@ -291,7 +291,7 @@ See the plan file for complete test code.
 ```bash
 git add tests/
 git commit -m "test(teach): add comprehensive tests for all 4 Phase 1 lint rules"
-```diff
+```
 
 ---
 
@@ -307,7 +307,7 @@ Runs `lint-shared.zsh` against real `~/projects/teaching/stat-545/slides/week-02
 ```bash
 git add tests/test-lint-integration.zsh
 git commit -m "test(teach): add lint integration test against real stat-545 files"
-```diff
+```
 
 ---
 
@@ -328,7 +328,7 @@ if command -v teach &>/dev/null; then
         echo "$LINT_OUTPUT" | head -20
     fi
 fi
-```bash
+```
 
 ---
 

--- a/docs/reference/API-DOT-SAFETY.md
+++ b/docs/reference/API-DOT-SAFETY.md
@@ -29,7 +29,7 @@ _flow_get_file_size() {
   local file="$1"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -58,7 +58,7 @@ size=$(_flow_get_file_size vault.sqlite)
 if (( size > 51200 )); then
   echo "Large file detected"
 fi
-```diff
+```
 
 **Exit Codes:**
 
@@ -85,7 +85,7 @@ _flow_human_size() {
   local bytes="$1"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -116,7 +116,7 @@ for file in *.log; do
   ((total_bytes += size))
 done
 echo "Total: $(_flow_human_size $total_bytes)"
-```diff
+```
 
 **Output Format:**
 
@@ -147,7 +147,7 @@ _flow_timeout() {
   shift
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -180,7 +180,7 @@ fi
 
 # Capture output with timeout
 large_files=$(_flow_timeout 3 find . -size +100k)
-```diff
+```
 
 **Exit Codes:**
 
@@ -212,7 +212,7 @@ _dot_is_cache_valid() {
   local ttl="${2:-$_DOT_CACHE_TTL}"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -238,7 +238,7 @@ fi
 if _dot_is_cache_valid "$timestamp" 1800; then
   echo "Valid for 30 min"
 fi
-```text
+```
 
 **Cache Logic:**
 
@@ -246,7 +246,7 @@ fi
 current_time - cache_time < TTL  →  Valid (return 0)
 current_time - cache_time >= TTL  →  Invalid (return 1)
 cache_time is empty  →  Invalid (return 1)
-```diff
+```
 
 **Exit Codes:**
 
@@ -267,7 +267,7 @@ cache_time is empty  →  Invalid (return 1)
 _dot_get_cached_size() {
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -290,7 +290,7 @@ else
   _dot_cache_size "$size"
   echo "Total: $size"
 fi
-```diff
+```
 
 **Exit Codes:**
 
@@ -311,7 +311,7 @@ _dot_cache_size() {
   local size="$1"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -335,7 +335,7 @@ _dot_cache_size "$size"
 
 # Later retrieval
 cached=$(_dot_get_cached_size)
-```diff
+```
 
 **Exit Codes:**
 
@@ -358,7 +358,7 @@ _dot_preview_add() {
   local target="$1"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -406,7 +406,7 @@ _dot_add() {
   # Execute
   chezmoi add "$target"
 }
-```text
+```
 
 **Output Format:**
 
@@ -425,7 +425,7 @@ Total size: 301K
 💡 Consider excluding: *.log, *.sqlite
 
 Auto-add ignore patterns? (Y/n):
-```diff
+```
 
 **Exit Codes:**
 
@@ -454,7 +454,7 @@ _dot_check_git_in_path() {
   local target="$1"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -491,7 +491,7 @@ if git_dirs=$(_dot_check_git_in_path "$target"); then
   git_count=$(echo "$git_dirs" | wc -w)
   _dot_warn "$git_count git metadata files detected"
 fi
-```diff
+```
 
 **Performance:**
 
@@ -525,7 +525,7 @@ _dot_suggest_ignore_patterns() {
   local patterns=("$@")
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -557,7 +557,7 @@ if [[ -n "$generated_files" ]]; then
   patterns=("*.log" "*.sqlite" "*.cache")
   _dot_suggest_ignore_patterns "${patterns[@]}"
 fi
-```text
+```
 
 **Output:**
 
@@ -566,7 +566,7 @@ fi
 ✓ Added *.log to .chezmoiignore
 ✓ Added *.sqlite to .chezmoiignore
 ℹ *.db already in .chezmoiignore
-```diff
+```
 
 **Exit Codes:**
 
@@ -590,7 +590,7 @@ _dot_warn() {
   local message="$1"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -605,13 +605,13 @@ _dot_warn() {
 ```zsh
 _dot_warn "Large file detected: config.db"
 _dot_warn "Repository size exceeds 5MB"
-```text
+```
 
 **Output:**
 
 ```text
 ⚠️  Large file detected: config.db
-```zsh
+```
 
 ---
 
@@ -628,7 +628,7 @@ _dot_info() {
   local message="$1"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -643,13 +643,13 @@ _dot_info() {
 ```zsh
 _dot_info "Scanning directory..."
 _dot_info "These will be skipped (covered by .chezmoiignore)"
-```text
+```
 
 **Output:**
 
 ```text
 ℹ Scanning directory...
-```zsh
+```
 
 ---
 
@@ -666,7 +666,7 @@ _dot_success() {
   local message="$1"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -681,13 +681,13 @@ _dot_success() {
 ```zsh
 _dot_success "Added 3 files to chezmoi"
 _dot_success "Repository health check passed"
-```text
+```
 
 **Output:**
 
 ```text
 ✓ Added 3 files to chezmoi
-```zsh
+```
 
 ---
 
@@ -704,7 +704,7 @@ _dot_header() {
   local text="$1"
   # Implementation
 }
-```diff
+```
 
 **Arguments:**
 
@@ -719,7 +719,7 @@ _dot_header() {
 ```zsh
 _dot_header "Preview: dots add ~/.config"
 _dot_header "Repository Health Check"
-```text
+```
 
 **Output:**
 
@@ -727,7 +727,7 @@ _dot_header "Repository Health Check"
 
 Preview: dots add ~/.config
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```zsh
+```
 
 ---
 
@@ -741,7 +741,7 @@ typeset -g _DOT_SIZE_CACHE_TIME     # Timestamp (Unix epoch)
 typeset -g _DOT_IGNORE_CACHE        # Cached ignore patterns
 typeset -g _DOT_IGNORE_CACHE_TIME   # Timestamp
 typeset -g _DOT_CACHE_TTL=300       # 5 minutes (default)
-```bash
+```
 
 **Environment Variables:**
 
@@ -769,7 +769,7 @@ LARGE_DIR_COUNT=1000            # Files in directory
 # Timeouts
 GIT_FIND_TIMEOUT=2              # Seconds
 LARGE_DIR_TIMEOUT=5             # Seconds
-```text
+```
 
 ---
 
@@ -786,7 +786,7 @@ GENERATED_PATTERNS=(
   "*.tmp"
   "*.swp"
 )
-```text
+```
 
 **Ignore Patterns (Default):**
 
@@ -798,7 +798,7 @@ DEFAULT_IGNORE=(
   "*.tmp"
   ".DS_Store"
 )
-```diff
+```
 
 ---
 
@@ -845,7 +845,7 @@ _dot_add_safe() {
   chezmoi add "$target"
   _dot_success "Added successfully"
 }
-```bash
+```
 
 ### Pattern 2: Cached Size Calculation
 
@@ -864,7 +864,7 @@ _dot_get_size_with_cache() {
   _dot_cache_size "$size"
   echo "Total: $size"
 }
-```zsh
+```
 
 ### Pattern 3: Batch Ignore Addition
 

--- a/docs/reference/MASTER-ARCHITECTURE.md
+++ b/docs/reference/MASTER-ARCHITECTURE.md
@@ -70,7 +70,7 @@ graph TD
     TEACH --> Scholar[Scholar CLI]
     MCP --> MCPServers[MCP Servers]
     EM --> Himalaya[himalaya CLI]
-```text
+```
 
 ---
 
@@ -117,7 +117,7 @@ flow-cli follows a layered architecture:
 │  - MCP Servers                                               │
 │  - himalaya CLI (IMAP/SMTP email)                            │
 └─────────────────────────────────────────────────────────────┘
-```diff
+```
 
 **Benefits:**
 - **Separation of concerns:** Each layer has single responsibility
@@ -175,7 +175,7 @@ echo "$(_flow_color_green 'SUCCESS:')" "Operation complete"
 
 # Dopamine
 win "Implemented feature X"  # Tracks progress + streak
-```diff
+```
 
 ---
 
@@ -206,7 +206,7 @@ g() {
 _g_status() {
     git status "$@"
 }
-```diff
+```
 
 **Benefits:**
 - **Unified interface:** All dispatchers work the same way
@@ -234,7 +234,7 @@ else
     # Use local state
     _flow_local_state
 fi
-```text
+```
 
 ---
 
@@ -269,7 +269,7 @@ graph LR
     Cache --> CacheGet[_flow_cache_get]
     Cache --> CacheSet[_flow_cache_set]
     Cache --> CacheClear[_flow_cache_clear]
-```diff
+```
 
 **Design Decisions:**
 
@@ -339,7 +339,7 @@ Usage:
 See: g help for full list
 EOF
 }
-```diff
+```
 
 **Benefits:**
 - Consistent UX across all dispatchers
@@ -403,7 +403,7 @@ graph TB
     HML --> HIMALAYA
     SEND --> EDITOR
     REPLY --> EDITOR
-```text
+```
 
 **Key Decisions:**
 
@@ -432,7 +432,7 @@ graph TD
     TTL[TTL Check] --> L1
     TTL --> L2
     TTL -->|Expired| Invalidate[Invalidate]
-```diff
+```
 
 **Cache Types:**
 
@@ -499,7 +499,7 @@ teach doctor                    teach doctor --full
 ┌──────────────┐
 │ Health Dot   │  Green/Yellow/Red on `teach` startup
 └──────────────┘
-```diff
+```
 
 **Key design decisions:**
 
@@ -541,7 +541,7 @@ sequenceDiagram
     work->>Core: Git commit
     Core-->>work: Committed
     work->>User: ✅ Session complete
-```bash
+```
 
 ---
 
@@ -574,7 +574,7 @@ sequenceDiagram
     g->>GitHub: git push
     GitHub-->>g: Success
     g-->>User: ✅ Pushed to origin/dev
-```bash
+```
 
 ---
 
@@ -606,7 +606,7 @@ sequenceDiagram
     ConceptExtract-->>teach: All concepts
     teach->>Report: Generate report
     Report-->>User: ✅ Analysis complete
-```zsh
+```
 
 ---
 
@@ -631,7 +631,7 @@ graph LR
     Init --> Dispatchers[Load Dispatchers]
     Init --> Commands[Load Commands]
     Init --> Completions[Setup Completions]
-```zsh
+```
 
 **Loading Sequence:**
 
@@ -667,7 +667,7 @@ graph TD
 
     FZF --> pick[pick command]
     Z --> hop[hop command]
-```text
+```
 
 **Design:** flow-cli doesn't require OMZ, but enhances workflow if plugins present.
 
@@ -693,7 +693,7 @@ graph TD
     TouchID2 -->|Denied| Error2[❌ Access Denied]
     Keychain --> Decrypt[Decrypt]
     Decrypt --> App
-```bash
+```
 
 **Security Features:**
 
@@ -732,7 +732,7 @@ export GITHUB_TOKEN="ghp_hardcoded_in_zshrc"  # ❌ Plain text
 # After (secure):
 # Token stored in keychain via Touch ID
 g push  # ✅ Retrieves token from keychain, validates, uses, discards
-```diff
+```
 
 **Benefits:**
 - Tokens never in plain text files
@@ -758,7 +758,7 @@ _flow_cache_get "projects" || {
     result=$(_flow_scan_projects)
     _flow_cache_set "projects" "$result" 3600
 }
-```zsh
+```
 
 **2. Lazy Loading:**
 
@@ -772,14 +772,14 @@ g() {
     fi
     _g_dispatch "$@"
 }
-```zsh
+```
 
 **3. Background Processes:**
 
 ```zsh
 # Slow operations in background
 _flow_update_cache &!  # zsh disown syntax
-```bash
+```
 
 **4. Minimal External Calls:**
 
@@ -789,7 +789,7 @@ result=$(git status | grep modified | wc -l)  # 3 processes
 
 # Prefer:
 result=$(git status --porcelain | awk '/^ M/ {count++} END {print count}')  # 2 processes
-```diff
+```
 
 ---
 
@@ -826,7 +826,7 @@ result=$(git status --porcelain | awk '/^ M/ {count++} END {print count}')  # 2 
       ┌─────────────────┐
       │      Unit       │  70% - Function-level tests
       └─────────────────┘
-```diff
+```
 
 **423 Total Tests:**
 - **70% Unit:** Function-level (296 tests)
@@ -849,7 +849,7 @@ tests/
 ├── e2e-teach-analyze.zsh           # E2E: 29 tests
 ├── interactive-dog-teaching.zsh    # Interactive: 10 tasks
 └── run-all.sh                      # Test runner
-```bash
+```
 
 ---
 
@@ -878,7 +878,7 @@ test_project_detection() {
 teardown_test() {
     rm -rf "$TEST_DIR"
 }
-```zsh
+```
 
 **Integration Test Pattern:**
 
@@ -891,7 +891,7 @@ test_full_workflow() {
     assert_git_clean
     assert_session_complete
 }
-```text
+```
 
 ---
 
@@ -908,7 +908,7 @@ graph LR
     Cloud --> Device1[Device 1]
     Cloud --> Device2[Device 2]
     Cloud --> Device3[Device 3]
-```diff
+```
 
 **Features:**
 - Multi-device sync
@@ -928,7 +928,7 @@ graph TD
 
     API --> Registry[Plugin Registry]
     Registry --> Install[Install Plugins]
-```diff
+```
 
 **Features:**
 - Third-party plugin support

--- a/docs/reference/REFCARD-DATES.md
+++ b/docs/reference/REFCARD-DATES.md
@@ -47,7 +47,7 @@ teach dates validate
 
 # Verbose output
 teach dates sync --verbose
-```bash
+```
 
 ## sync Options
 
@@ -74,7 +74,7 @@ deadline_hw1: "2026-02-03"
 # Invalid
 start_date: "01/13/2026"
 deadline_hw1: "Feb 3, 2026"
-```yaml
+```
 
 ## Configuration Structure
 
@@ -102,7 +102,7 @@ semester_info:
   holidays:
     - date: "2026-03-16"
       name: "Spring Break"
-```text
+```
 
 ## Workflow
 
@@ -116,7 +116,7 @@ teach dates sync --dry-run    # Step 3: Preview changes
 teach dates sync              # Step 4: Apply changes interactively
   ↓
 teach dates validate          # Step 5: Verify configuration
-```text
+```
 
 ## Sync Behavior
 
@@ -131,7 +131,7 @@ File: assignments/hw1.qmd
 │   due: 2026-01-30 → 2026-02-03
 ├─────────────────────────────────────────────────────────────┤
 Apply changes? [y/n/d/q]
-```diff
+```
 
 Options:
 - `y` - Apply changes
@@ -162,7 +162,7 @@ assignments/*.qmd
 assignments/*.md
 syllabus.qmd
 schedule.qmd
-```text
+```
 
 ## Status Output
 
@@ -174,7 +174,7 @@ teach dates status
 
 Config Dates Loaded: 17
 Teaching Files Found: 12
-```text
+```
 
 ## init Wizard
 
@@ -189,7 +189,7 @@ Generating 15 weeks starting from 2026-01-13...
   Start: 2026-01-13
   End:   2026-04-28
   Weeks: 15
-```text
+```
 
 ## Validation Checks
 
@@ -202,7 +202,7 @@ teach dates validate
 ✓ Course name: STAT-101
 ✓ Semester: Spring 2026
 ✓ Dates configured (2026-01-13 - 2026-04-28)
-```bash
+```
 
 ## STAT-101 Demo Example
 
@@ -224,7 +224,7 @@ teach dates sync --force
 
 # Verify
 teach dates validate
-```bash
+```
 
 ## Integration
 

--- a/docs/reference/REFCARD-DEPLOY-V2.md
+++ b/docs/reference/REFCARD-DEPLOY-V2.md
@@ -54,13 +54,13 @@ assignments/*.qmd     → "content: assignment 3"
 _quarto.yml           → "config: quarto settings"
 styles/*.css          → "style: theme update"
 Mixed files           → "deploy: STAT-101 update"
-```text
+```
 
 Override with custom message:
 
 ```bash
 teach deploy -d -m "Week 5 lecture + lab"
-```yaml
+```
 
 ## Deploy History
 
@@ -75,14 +75,14 @@ deploys:
     branch_to: 'main'
     file_count: 15
     commit_message: 'content: week-05 lecture'
-```text
+```
 
 View history:
 
 ```bash
 teach deploy --history      # Last 10 deploys
 teach deploy --history 20   # Last 20 deploys
-```text
+```
 
 ## Rollback
 
@@ -90,7 +90,7 @@ teach deploy --history 20   # Last 20 deploys
 teach deploy --rollback        # Interactive picker
 teach deploy --rollback 1      # Most recent deploy
 teach deploy --rollback 2 --ci # 2nd most recent, non-interactive
-```text
+```
 
 Uses `git revert` (forward rollback, not destructive reset). Merge commits are detected automatically and reverted with `-m 1` (parent specification). Rollback is recorded in history with `mode: "rollback"`.
 
@@ -104,7 +104,7 @@ Scans changed `.qmd` files for blank lines and unclosed `$$` blocks (both break 
   [ok] Display math blocks valid          ← all clean
   [!!] Blank lines in display math        ← blank line inside $$
   [!!] Unclosed $$ block (breaks render)  ← missing closing $$
-```text
+```
 
 **CI mode:** Math issues block deployment. **Interactive:** Warns only.
 
@@ -118,7 +118,7 @@ With a dirty working tree, deploy prompts to commit instead of blocking:
   Uncommitted changes detected
   Suggested: content: week-05 lecture
   Commit and continue? [Y/n]:
-```text
+```
 
 Press Enter (or Y) to auto-commit with the smart message. Press N to cancel.
 
@@ -137,7 +137,7 @@ If a commit fails (e.g., Quarto pre-commit hook), you get 3 actionable options:
     3. Force commit: git commit --no-verify -m "message"
 
   Your changes are still staged. Nothing was lost.
-```text
+```
 
 ### Trap Handler (Branch Safety)
 
@@ -156,7 +156,7 @@ The deployment summary box now includes a direct link to GitHub Actions:
 │  🌐 URL:      https://example.github.io/stat-545/    │
 │  ⚙  Actions:  https://github.com/user/stat-545/actions│  ← NEW
 ╰──────────────────────────────────────────────────────╯
-```bash
+```
 
 Automatically detected from `remote.origin.url`. Skipped for non-GitHub remotes.
 
@@ -173,7 +173,7 @@ Auto-detected when no TTY (`[[ ! -t 0 ]]`), or forced with `--ci`:
 ```bash
 teach deploy --ci -d           # Direct merge, no prompts
 echo | teach deploy            # Auto-detected (piped input)
-```diff
+```
 
 **CI behavior for safety features:**
 
@@ -225,7 +225,7 @@ Skips if `.STATUS` absent.
 │  🌐 URL:      https://example.github.io/stat-545/    │
 │  ⚙  Actions:  https://github.com/user/stat-545/actions│
 ╰──────────────────────────────────────────────────────╯
-```yaml
+```
 
 ## Configuration
 
@@ -237,7 +237,7 @@ git:
   production_branch: main     # Default: "main"
   auto_pr: true               # Default: true
   require_clean: true         # Default: true
-```bash
+```
 
 ## Workflows
 
@@ -247,7 +247,7 @@ git:
 # Make changes on draft branch
 teach deploy -d
 # 8-15 seconds → live
-```bash
+```
 
 ### Deploy via PR (default)
 
@@ -255,21 +255,21 @@ teach deploy -d
 # Make changes on draft branch
 teach deploy
 # Opens PR → review → merge → live
-```text
+```
 
 ### Partial deploy (specific files)
 
 ```bash
 teach deploy lectures/week-05.qmd
 teach deploy lectures/ assignments/hw-03.qmd
-```bash
+```
 
 ### Preview before deploying
 
 ```bash
 teach deploy --dry-run
 # Shows what would happen without executing
-```bash
+```
 
 ### Rollback to previous version
 
@@ -277,7 +277,7 @@ teach deploy --dry-run
 teach deploy --rollback
 # Interactive picker shows recent deploys
 # Select deployment to revert
-```text
+```
 
 ### Non-interactive (CI/CD)
 

--- a/docs/reference/REFCARD-DOCTOR.md
+++ b/docs/reference/REFCARD-DOCTOR.md
@@ -39,7 +39,7 @@ teach doctor --json
 
 # Combine flags
 teach doctor --full --verbose
-```diff
+```
 
 ## teach doctor Options
 
@@ -180,7 +180,7 @@ Interactive menu when running `--fix`:
 │  0. Exit without fixing                          │
 │                                                  │
 ╰──────────────────────────────────────────────────╯
-```text
+```
 
 ## Exit Codes
 
@@ -214,7 +214,7 @@ Interactive menu when running `--fix`:
     }
   ]
 }
-```bash
+```
 
 ## Token Checks (--dot)
 
@@ -226,7 +226,7 @@ flow doctor --dot
 
 # Specific token
 flow doctor --dot=github
-```text
+```
 
 Output:
 
@@ -234,7 +234,7 @@ Output:
 🔑 DOT TOKENS
   ✓ Valid (@username)
   ⚠  Expiring in 7 days
-```bash
+```
 
 ## teach doctor Performance
 
@@ -262,7 +262,7 @@ teach doctor --fix
 
 # CI pipeline
 teach doctor --ci --full
-```bash
+```
 
 ## Common Workflows
 

--- a/docs/reference/REFCARD-DOT-SAFETY.md
+++ b/docs/reference/REFCARD-DOT-SAFETY.md
@@ -59,7 +59,7 @@ Total size: 301K
 💡 Consider excluding: *.log, *.sqlite
 
 Auto-add ignore patterns? (Y/n):
-```bash
+```
 
 ---
 
@@ -100,7 +100,7 @@ build/
 # Git metadata
 **/.git
 **/.git/**
-```diff
+```
 
 ---
 
@@ -165,7 +165,7 @@ unset _DOT_SIZE_CACHE_TIME
 
 # Adjust TTL (in ~/.zshrc)
 export _DOT_CACHE_TTL=1800  # 30 minutes
-```diff
+```
 
 ---
 
@@ -199,7 +199,7 @@ dots ignore add "*.log"
 dots ignore add "*.sqlite"
 dots ignore add "node_modules"
 dots ignore add ".DS_Store"
-```bash
+```
 
 ### Adding Files Safely
 
@@ -211,7 +211,7 @@ dots add ~/.zshrc
 dots add ~/.config/nvim
 
 # Accept auto-ignore suggestions when prompted
-```bash
+```
 
 ### Repository Maintenance
 
@@ -225,7 +225,7 @@ dots size
 # Clean up if too large
 dots ignore add "large-file.db"
 chezmoi remove large-file.db
-```bash
+```
 
 ### Batch Ignore Operations
 
@@ -235,7 +235,7 @@ patterns=("*.log" "*.sqlite" "*.db" "*.cache")
 for pattern in "${patterns[@]}"; do
   dots ignore add "$pattern"
 done
-```diff
+```
 
 ---
 
@@ -260,7 +260,7 @@ export _DOT_CACHE_TTL=600
 
 # Skip preview (not recommended)
 export DOT_SKIP_PREVIEW=1
-```diff
+```
 
 ---
 
@@ -302,7 +302,7 @@ else
   echo "❌ Add cancelled"
   exit 1
 fi
-```bash
+```
 
 ### CI/CD Integration
 
@@ -315,7 +315,7 @@ if [[ $exit_code -ne 0 ]]; then
   echo "❌ Health check failed"
   exit 1
 fi
-```bash
+```
 
 ### Batch File Addition
 
@@ -330,7 +330,7 @@ configs=(
 for config in "${configs[@]}"; do
   dots add "$config"
 done
-```diff
+```
 
 ---
 

--- a/docs/reference/REFCARD-LINT.md
+++ b/docs/reference/REFCARD-LINT.md
@@ -21,7 +21,7 @@ teach validate --lint
 
 # Run only Phase 1 quick checks
 teach validate --quick-checks file.qmd
-```bash
+```
 
 ### Combined Flags
 
@@ -34,7 +34,7 @@ teach validate --quick-checks
 
 # Skip external validators
 teach validate --lint --skip-external file.qmd
-```diff
+```
 
 ---
 
@@ -60,7 +60,7 @@ teach validate --lint --skip-external file.qmd
 
 ::: {.callout-info}        ❌ Invalid
 ::: {.callout-danger}      ❌ Invalid
-```text
+```
 
 ---
 
@@ -69,29 +69,29 @@ teach validate --lint --skip-external file.qmd
 ### ✅ Valid (with language tag)
 
 ```markdown
-```{r}
+```
 x <- 1
 ```text
 
-```python
+```
 print("Hello")
 ```text
 
-```text
+```
 Plain text
 ```text
 
-```text
+```
 
 ### ❌ Invalid (bare blocks)
 
 ```markdown
-```text
+```
 
 no language tag
 
 ```text
-```diff
+```
 
 ---
 
@@ -118,7 +118,7 @@ no language tag
   Files checked: 3
   Validators run: 1
   Time: 0s
-```text
+```
 
 ### With Errors
 
@@ -134,7 +134,7 @@ no language tag
   Files checked: 1
   Validators run: 1
   Time: 0s
-```bash
+```
 
 ---
 
@@ -151,7 +151,7 @@ if command -v teach &>/dev/null; then
         echo "$LINT_OUTPUT" | head -20
     fi
 fi
-```diff
+```
 
 **Note:** Lint runs automatically on commit but never blocks (warn-only mode).
 
@@ -175,21 +175,21 @@ fi
 **Before:**
 
 ```markdown
-```text
+```
 
 x <- 1
 
 ```text
-```text
+```
 
 **After:**
 
 ```markdown
-```{r}
+```
 x <- 1
 ```text
 
-```text
+```
 
 ### Fix Unbalanced Divs
 
@@ -197,7 +197,7 @@ x <- 1
 ```markdown
 ::: {.callout-note}
 Content
-```text
+```
 
 **After:**
 
@@ -205,7 +205,7 @@ Content
 ::: {.callout-note}
 Content
 :::
-```bash
+```
 
 ### Fix Skipped Headings
 
@@ -214,7 +214,7 @@ Content
 ```markdown
 # Section
 ### Subsection (skipped h2)
-```bash
+```
 
 **After:**
 

--- a/docs/reference/REFCARD-MACROS.md
+++ b/docs/reference/REFCARD-MACROS.md
@@ -29,7 +29,7 @@ teach macros export --format json
 
 # Export as MathJax config
 teach macros export --format mathjax > mathjax-config.js
-```yaml
+```
 
 ## Configuration
 
@@ -50,7 +50,7 @@ scholar:
     export:
       format: "json"
       include_in_prompts: true
-```text
+```
 
 ## Source File Formats
 
@@ -63,13 +63,13 @@ scholar:
 ### QMD Example (`_macros.qmd`)
 
 ```markdown
-```{=tex}
+```
 \newcommand{\E}{\mathbb{E}}
 \newcommand{\Var}{\operatorname{Var}}
 \DeclareMathOperator{\Cov}{Cov}
 ```text
 
-```text
+```
 
 ### LaTeX Example (`macros.tex`)
 
@@ -77,7 +77,7 @@ scholar:
 \newcommand{\E}{\mathbb{E}}
 \newcommand{\Var}{\operatorname{Var}}
 \DeclareMathOperator{\Cov}{Cov}
-```bash
+```
 
 ## Common Macro Categories
 
@@ -109,7 +109,7 @@ teach macros export --format mathjax > _includes/mathjax-macros.js
 
 # LaTeX preamble
 teach macros export --format latex > _macros.tex
-```text
+```
 
 ## teach doctor Integration
 

--- a/docs/reference/REFCARD-PROMPTS.md
+++ b/docs/reference/REFCARD-PROMPTS.md
@@ -24,7 +24,7 @@ Priority 2: User
 
 Priority 3 (lowest): Plugin
   lib/templates/teaching/claude-prompts/<name>.md
-```text
+```
 
 First match wins. Course overrides User overrides Plugin.
 
@@ -39,7 +39,7 @@ Available Teaching Prompts
   derivations-appendix   [P]  Mathematical Derivations Appendix
 
 Legend: [C] Course  [U] User  [P] Plugin  * = overrides lower tier
-```diff
+```
 
 ## Flags
 
@@ -98,7 +98,7 @@ variables:
 
 ## Purpose
 Generate content for {{COURSE}} on {{TOPIC}}...
-```bash
+```
 
 ## Variables
 
@@ -138,21 +138,21 @@ Generate content for {{COURSE}} on {{TOPIC}}...
 teach prompt edit lecture-notes
 # Creates .flow/templates/prompts/lecture-notes.md from plugin default
 # Opens in $EDITOR
-```bash
+```
 
 ### Validate all prompts
 
 ```bash
 teach prompt validate
 # Checks all prompts across all tiers
-```bash
+```
 
 ### Export rendered prompt
 
 ```bash
 teach prompt export lecture-notes --macros
 # Renders with variables from teach-config.yml + LaTeX macros
-```bash
+```
 
 ### Scholar auto-resolve
 

--- a/docs/reference/REFCARD-SCHOLAR-FLAGS.md
+++ b/docs/reference/REFCARD-SCHOLAR-FLAGS.md
@@ -70,7 +70,7 @@ teach lecture "ANOVA" --style computational
 
 # Use preset + override specific flags
 teach lecture "ANOVA" --style computational --no-practice-problems --diagrams
-```bash
+```
 
 **Overriding Examples:**
 
@@ -83,7 +83,7 @@ teach lecture "Regression" --style computational --no-code
 
 # Rigorous lecture with code (add to preset)
 teach lecture "Measure Theory" --style rigorous --code
-```text
+```
 
 ---
 
@@ -106,7 +106,7 @@ Generate lecture notes in Quarto (.qmd) format.
 ```bash
 teach lecture "Neural Networks" --week 10 --template quarto \
   --difficulty hard --examples 5 --math --code
-```sql
+```
 
 ---
 
@@ -148,7 +148,7 @@ teach slides --week 5 --optimize --preview-breaks
 
 # Auto-apply + emphasize key concepts
 teach slides --week 5 --optimize --apply-suggestions --key-concepts
-```text
+```
 
 ---
 
@@ -169,7 +169,7 @@ Generate comprehensive exams with multiple question types.
 ```text
 "mc:3,sa:2,problem:3"  # 3 multiple choice, 2 short answer, 3 problems
 "short answer:5,problem:3"  # 5 short answer, 3 problems
-```bash
+```
 
 **Examples:**
 
@@ -182,7 +182,7 @@ teach exam "ANOVA" --questions 8 --duration 60 --types "short answer:5,problem:3
 
 # QTI format for LMS import
 teach exam "Final Exam" --questions 30 --format qti
-```text
+```
 
 **LaTeX Macro Integration:**
 
@@ -191,7 +191,7 @@ When `teach macros` is configured, exams automatically inject consistent notatio
 ```bash
 teach macros sync  # Ensure macros are up-to-date
 teach exam "Linear Regression" --math  # Auto-uses \E{Y}, \Var{Y}, etc.
-```sql
+```
 
 ---
 
@@ -214,7 +214,7 @@ teach quiz "Correlation" --questions 5
 
 # Timed QTI quiz
 teach quiz "ANOVA" --time-limit 20 --format qti
-```bash
+```
 
 ---
 
@@ -236,7 +236,7 @@ teach assignment "Data Wrangling" --code --practice-problems --points 50
 
 # With due date
 teach assignment "ML Intro" --due-date "2026-02-20" --points 50 --explanation
-```text
+```
 
 ---
 
@@ -252,7 +252,7 @@ Generate course syllabus with schedule and policies.
 
 ```bash
 teach syllabus --format pdf
-```sql
+```
 
 ---
 
@@ -269,7 +269,7 @@ Create grading rubrics for assignments/projects.
 
 ```bash
 teach rubric "Research Paper" --criteria 6 --explanation
-```text
+```
 
 ---
 
@@ -285,7 +285,7 @@ Generate personalized student feedback on assignments.
 
 ```bash
 teach feedback "Assignment 3 - Student Name" --format text
-```sql
+```
 
 ---
 
@@ -321,7 +321,7 @@ teach exam "Final Exam" --questions 30 --verbose
 
 # Custom output
 teach slides "Regression" --output custom-slides.qmd
-```bash
+```
 
 ---
 
@@ -332,49 +332,49 @@ teach slides "Regression" --output custom-slides.qmd
 ```bash
 # Theory-focused intro lecture
 teach lecture "Introduction to Statistics" --week 1 --style conceptual
-```bash
+```
 
 ### Computational Lab
 
 ```bash
 # Code-heavy data visualization lab
 teach lecture "Data Visualization" --week 2 --style computational --code
-```bash
+```
 
 ### Rigorous Math Lecture
 
 ```bash
 # Proof-based probability lecture
 teach lecture "Probability Foundations" --week 3 --style rigorous --proof --math
-```bash
+```
 
 ### Slides from Lecture
 
 ```bash
 # Convert lecture to optimized slides
 teach slides --from-lecture lectures/week-05-regression.qmd --optimize --apply-suggestions
-```bash
+```
 
 ### Math-Heavy Exam
 
 ```bash
 # Rigorous exam with consistent notation
 teach exam "Linear Regression" --questions 12 --math --style rigorous
-```bash
+```
 
 ### Quick Quiz
 
 ```bash
 # 5-question formative quiz
 teach quiz "Correlation" --questions 5 --time-limit 15
-```bash
+```
 
 ### Hands-On Assignment
 
 ```bash
 # Computational assignment with code
 teach assignment "Data Wrangling" --week 4 --code --practice-problems --points 50
-```bash
+```
 
 ---
 
@@ -390,7 +390,7 @@ teach lecture "Statistical Thinking" --week 1 --style conceptual --examples
 
 # Week 2: Add some rigor
 teach lecture "Probability Basics" --week 2 --style conceptual --math --definitions
-```bash
+```
 
 ### Computational Course (R/Python)
 
@@ -400,7 +400,7 @@ teach lecture "Data Manipulation" --week 3 --style computational --code --practi
 
 # No practice problems (lecture only)
 teach lecture "Advanced Plotting" --week 4 --style computational --no-practice-problems
-```bash
+```
 
 ### Theory Course (Math-Heavy)
 
@@ -410,7 +410,7 @@ teach lecture "Measure Theory" --week 5 --style rigorous --proof --math --no-exa
 
 # Rigorous with computational examples
 teach lecture "Asymptotic Theory" --week 6 --style rigorous --code --examples
-```bash
+```
 
 ### Applied Course (Real-World)
 
@@ -420,7 +420,7 @@ teach lecture "A/B Testing" --week 7 --style applied --code --diagrams
 
 # No code (conceptual case study)
 teach lecture "Experimental Design" --week 8 --style applied --no-code --examples
-```bash
+```
 
 ### Exam Preparation
 
@@ -433,7 +433,7 @@ teach exam "R Programming Exam" --questions 8 --code --examples --duration 60
 
 # Rigorous exam (proofs + math)
 teach exam "Probability Theory" --questions 6 --math --proof --duration 120 --style rigorous
-```bash
+```
 
 ### Slide Optimization Workflows
 
@@ -446,7 +446,7 @@ teach slides --from-lecture week-09.qmd --optimize
 
 # Auto-apply all suggestions
 teach slides --from-lecture week-09.qmd --apply-suggestions --key-concepts
-```text
+```
 
 ---
 
@@ -456,7 +456,7 @@ When `--interactive` is specified, the wrapper launches a step-by-step wizard:
 
 ```bash
 teach lecture --interactive
-```diff
+```
 
 **Wizard Steps:**
 1. **Week Selection** - Choose from lesson plan weeks (or enter manually)
@@ -513,7 +513,7 @@ Generate lecture? [Y/n]
 > y
 
 🎓 Generating lecture for "Linear Regression" (Week 5)...
-```text
+```
 
 ---
 
@@ -526,7 +526,7 @@ Using both a flag and its negation triggers an error:
 ```bash
 $ teach lecture "ANOVA" --math --no-math
 ❌ Conflicting flags: --math and --no-math
-```text
+```
 
 ### Invalid Style
 
@@ -536,7 +536,7 @@ Unknown style preset:
 $ teach lecture "ANOVA" --style advanced
 ❌ Unknown style preset: advanced
 Valid styles: conceptual, computational, rigorous, applied
-```text
+```
 
 ### Missing Required Arguments
 
@@ -546,7 +546,7 @@ Week without topic (and no lesson plan):
 $ teach lecture --week 99
 ❌ Week 99 not found in lesson plans
 Hint: Run 'teach plan create 99 --topic "Your Topic"' first
-```bash
+```
 
 ---
 
@@ -559,7 +559,7 @@ Override default template with `--template`:
 ```bash
 # Use custom template from .flow/templates/content/
 teach lecture "ANOVA" --template detailed --week 8
-```bash
+```
 
 **Template Resolution:**
 1. `.flow/templates/content/<type>/<name>.qmd` (project-local)
@@ -578,7 +578,7 @@ teach lecture "Regression" --week 5
 # 1. .flow/prompts/lecture.md (course-specific)
 # 2. ~/.flow/prompts/lecture.md (user default)
 # 3. Plugin default prompt
-```diff
+```
 
 **Prompt Variables:**
 - `{{TOPIC}}` - Current topic
@@ -600,7 +600,7 @@ teach plan create 8 --topic "ANOVA" --style computational
 
 # Auto-uses plan data (no need to specify topic/style)
 teach lecture --week 8
-```diff
+```
 
 **Data Pulled from Plans:**
 - `topic` - Week topic
@@ -619,7 +619,7 @@ teach macros sync
 
 # Generate exam (auto-injects _macros.qmd)
 teach exam "Linear Models" --math --week 5
-```diff
+```
 
 **Ensures:**
 - `\E{Y}` instead of `E[Y]` or `\mathbb{E}[Y]`
@@ -639,7 +639,7 @@ teach templates new lecture week-05  # Creates from template
 
 # Generate uses same template style
 teach lecture --week 5  # Matches template format
-```bash
+```
 
 ### Prompts
 
@@ -654,7 +654,7 @@ teach prompt edit lecture
 
 # Export for Scholar integration (automatic)
 teach prompt export
-```diff
+```
 
 ---
 
@@ -688,7 +688,7 @@ All commands run preflight validation before Scholar invocation:
 $ teach lecture --week 99
 ❌ Week 99 not found in lesson plans
    (exits immediately, no API call)
-```text
+```
 
 ---
 
@@ -710,7 +710,7 @@ Enable verbose mode for detailed execution info:
 
 ```bash
 teach lecture "ANOVA" --verbose
-```diff
+```
 
 **Output includes:**
 - Resolved flags and style

--- a/docs/reference/REFCARD-TEACH-PLAN.md
+++ b/docs/reference/REFCARD-TEACH-PLAN.md
@@ -50,7 +50,7 @@ teach plan delete 3 --force
 
 # Overwrite existing week
 teach plan create 3 --topic "Updated" --force
-```yaml
+```
 
 ## Options
 
@@ -87,7 +87,7 @@ weeks:
       - "Conditional probability"
     key_concepts: []
     prerequisites: []
-```yaml
+```
 
 ## Auto-Populate from Config
 
@@ -99,7 +99,7 @@ semester_info:
   weeks:
     - number: 5
       topic: "Polynomial Regression"   # ← auto-used
-```text
+```
 
 ## Integration
 
@@ -122,7 +122,7 @@ teach plan create N           # Step 3: Add missing weeks
 teach plan edit N             # Step 4: Refine details
   ↓
 teach slides --week N         # Step 5: Generate content
-```text
+```
 
 ## Gap Detection
 

--- a/docs/reference/REFCARD-TOKEN-SECRETS.md
+++ b/docs/reference/REFCARD-TOKEN-SECRETS.md
@@ -27,7 +27,7 @@ export FLOW_SECRET_BACKEND=both       # Cloud backup enabled
 
 # Check current status
 sec status
-```diff
+```
 
 ---
 
@@ -70,7 +70,7 @@ tok github
 #    - both: Keychain + Bitwarden
 
 # ✅ Token ready to use instantly
-```bash
+```
 
 ### Use Token in Scripts
 
@@ -84,7 +84,7 @@ gh auth login --with-token <<< $(sec github-token)
 # Use in scripts (no echo to terminal)
 curl -H "Authorization: token $(sec github-token)" \
   https://api.github.com/user/repos
-```bash
+```
 
 ### Check Token Expiration
 
@@ -95,7 +95,7 @@ tok expiring
 # Output shows tokens expiring in next 7 days:
 # ⚠️  github-token expires in 5 days
 # ✅  npm-token expires in 67 days
-```bash
+```
 
 ### Rotate Expiring Token
 
@@ -110,7 +110,7 @@ tok rotate
 # 4. Paste new token
 # 5. Updates both Bitwarden & Keychain
 # 6. Old token backed up for 7 days
-```bash
+```
 
 ### Delete Old Token
 
@@ -125,7 +125,7 @@ sec list
 
 # Delete backup
 sec delete old-github-token-backup-20260117
-```text
+```
 
 ---
 
@@ -149,7 +149,7 @@ User runs: tok github
 User runs: sec github-token
     ↓
 Retrieves from Keychain (< 50ms, Touch ID supported)
-```text
+```
 
 ### Why Both Backends?
 
@@ -176,7 +176,7 @@ Each token stores metadata in JSON format (v2.1):
   "expires": "2026-04-24",
   "github_user": "username"
 }
-```diff
+```
 
 **Metadata fields:**
 - `dot_version`: Format version (current: 2.1)
@@ -200,7 +200,7 @@ Security add-generic-password command:
   -j "$metadata"       ← JSON ATTRS: Searchable, not password-protected
   -a "$token_name"     ← ACCOUNT: Searchable identifier
   -s "flow-cli"        ← SERVICE: Namespace for flow-cli secrets
-```diff
+```
 
 **Key Points:**
 - ✅ Token value encrypted in Keychain (requires Touch ID/password)
@@ -270,7 +270,7 @@ Security add-generic-password command:
 
 # Verify Keychain unlocked
 security unlock-keychain login.keychain-db
-```bash
+```
 
 ### Token Validation Failed
 
@@ -284,7 +284,7 @@ npm whoami --registry https://registry.npmjs.org/
 
 # PyPI token validation
 pip install keyring  # Test with pip
-```bash
+```
 
 ### Bitwarden Sync Issues
 
@@ -297,7 +297,7 @@ bw status
 
 # Re-login if needed
 bw login
-```diff
+```
 
 ---
 

--- a/docs/reports/IMPLEMENTATION-COMPLETE.md
+++ b/docs/reports/IMPLEMENTATION-COMPLETE.md
@@ -105,7 +105,7 @@ Successfully implemented Phases 1-2 of the WT Workflow Enhancement specification
 Unit Tests:       22/23 PASS (95.7%)
 E2E Tests:        Not run (requires full setup)
 Interactive:      Awaiting manual execution
-```sql
+```
 
 ### Coverage Mapping
 
@@ -258,7 +258,7 @@ $ wt
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 💡 Tip: wt <project> to filter | pick wt for interactive
-```text
+```
 
 ### Filtered View
 
@@ -274,7 +274,7 @@ $ wt flow
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 💡 Tip: wt <project> to filter | pick wt for interactive
-```bash
+```
 
 ### Interactive Delete
 
@@ -284,7 +284,7 @@ $ pick wt
 # Use Tab to select multiple worktrees
 # Press Ctrl-X to delete
 # Confirmation prompts appear for each
-```bash
+```
 
 ### Refresh Cache
 
@@ -297,7 +297,7 @@ $ pick wt
 
 🌳 Worktrees (4 total)
 # (updated overview displays)
-```yaml
+```
 
 ---
 

--- a/docs/reports/IMPLEMENTATION-PHASES-3-4.md
+++ b/docs/reports/IMPLEMENTATION-PHASES-3-4.md
@@ -54,7 +54,7 @@ TEACH_PLAN_SUBTOPICS       # Pipe-separated subtopics
 TEACH_PLAN_KEY_CONCEPTS    # Pipe-separated key concepts
 TEACH_PLAN_PREREQUISITES   # Pipe-separated prerequisites
 TEACH_RESOLVED_STYLE       # Final style (plan or override)
-```yaml
+```
 
 ---
 
@@ -113,7 +113,7 @@ What style should this content use?
   [4] applied       Explanation + examples + code + practice
 
 Your choice [1-4]: _
-```bash
+```
 
 ---
 
@@ -143,7 +143,7 @@ teach slides -w 12
 teach slides -w 15
 # → Error: "No topic found for Week 15"
 # → Suggests adding to config or creating lesson plan
-```bash
+```
 
 ### Phase 4: Interactive Mode
 
@@ -165,7 +165,7 @@ teach slides -i --style computational
 # → Shows week selection
 # → Skips style selection
 # → Uses specified style
-```yaml
+```
 
 ---
 
@@ -202,7 +202,7 @@ key_concepts:
 prerequisites:
   - "Simple linear regression (Week 6)"
   - "Matrix notation basics (Week 7)"
-```diff
+```
 
 ### Required Fields
 
@@ -238,7 +238,7 @@ lib/dispatchers/teach-dispatcher.zsh    +320 lines
     - Phase 4 integration                (10 lines)
 
 Total: +320 lines
-```bash
+```
 
 ---
 
@@ -255,7 +255,7 @@ TEACH_PLAN_SUBTOPICS      # Set by _teach_load_lesson_plan()
 TEACH_PLAN_KEY_CONCEPTS   # Set by _teach_load_lesson_plan()
 TEACH_PLAN_PREREQUISITES  # Set by _teach_load_lesson_plan()
 TEACH_RESOLVED_STYLE      # Set by _teach_integrate_lesson_plan()
-```bash
+```
 
 ### New Functions (Public API)
 
@@ -270,7 +270,7 @@ _teach_integrate_lesson_plan <week> <style># Main integration
 _teach_select_style_interactive            # Style selection menu
 _teach_select_topic_interactive            # Topic selection menu
 _teach_interactive_wizard <cmd> <topic> <style>  # Main wizard
-```bash
+```
 
 ### Enhanced Functions
 
@@ -281,7 +281,7 @@ _teach_scholar_wrapper <subcommand> [args...]
   # - Interactive mode (-i, --interactive)
   # - Style from lesson plan
   # - Topic from lesson plan
-```diff
+```
 
 ---
 
@@ -363,7 +363,7 @@ _teach_scholar_wrapper <subcommand> [args...]
 ```text
 Lesson plan globals:    ~3KB  (6 variables)
 Interactive functions:  ~12KB (3 functions)
-```diff
+```
 
 **Total:** ~15KB additional memory
 **Assessment:** ✅ Minimal impact
@@ -471,7 +471,7 @@ $ teach slides -w 8
 # 4. Proceeds to content generation
 
 → Generates slides for "Multiple Regression" with computational style
-```yaml
+```
 
 ### Example 2: Week without Lesson Plan
 
@@ -492,7 +492,7 @@ Continue with this topic? [Y/n]: y
 Hint: Create a lesson plan with: teach plan create 12
 
 → Proceeds with "Time Series"
-```bash
+```
 
 ### Example 3: Interactive Mode
 

--- a/docs/reports/IMPLEMENTATION-PHASES-5-6.md
+++ b/docs/reports/IMPLEMENTATION-PHASES-5-6.md
@@ -57,7 +57,7 @@
 TEACH_REVISE_MODE          # Always "improve" for now
 TEACH_REVISE_FILE          # Path to file being revised
 TEACH_REVISE_INSTRUCTIONS  # User-selected revision instructions
-```yaml
+```
 
 ---
 
@@ -120,7 +120,7 @@ TEACH_REVISE_INSTRUCTIONS  # User-selected revision instructions
 
 ```zsh
 TEACH_CONTEXT   # Course context from materials
-```bash
+```
 
 ---
 
@@ -145,7 +145,7 @@ teach exam --revise exams/midterm.qmd --math --examples
 teach lecture --revise lecture-notes.md
 # → Select option 2
 # → Scholar improves organization and clarity
-```text
+```
 
 **Revision Menu:**
 
@@ -162,7 +162,7 @@ What would you like to improve?
   [6] Custom instructions          Your own guidance
 
 Your choice [1-6]:
-```bash
+```
 
 ### Phase 6: Context Integration
 
@@ -183,7 +183,7 @@ teach exam "Multiple Regression" --context --rigorous
 teach lecture --revise lecture.md --context
 # → Revises with awareness of course structure
 # → Maintains consistency with other materials
-```text
+```
 
 ---
 
@@ -208,7 +208,7 @@ tests/test-teach-integration-phases-1-6.zsh  +412 lines (new file)
   - 38 integration tests for Phases 1-6
 
 Total: +707 lines across all phases 5-6
-```bash
+```
 
 ---
 
@@ -224,7 +224,7 @@ TEACH_REVISE_INSTRUCTIONS # Set by _teach_revision_menu()
 
 # Phase 6: Context Integration
 TEACH_CONTEXT             # Set by _teach_build_context()
-```bash
+```
 
 ### New Functions (Public API)
 
@@ -237,7 +237,7 @@ _teach_revise_workflow <file>                 # Main revision orchestrator
 
 # Phase 6
 _teach_build_context                          # Gather course context
-```bash
+```
 
 ### Enhanced Functions
 
@@ -254,7 +254,7 @@ _teach_scholar_help <command>
   # - Universal flags section (all Phase 1-6 flags)
   # - Color-coded sections
   # - Complete flag documentation
-```diff
+```
 
 ---
 
@@ -327,7 +327,7 @@ Revision functions:     ~15KB (4 functions)
 Context functions:      ~5KB  (1 function)
 Help updates:           ~3KB  (enhanced help)
 Completion updates:     ~2KB  (enhanced completions)
-```diff
+```
 
 **Total:** ~28KB additional memory (Phases 5-6)
 **Assessment:** ✅ Minimal impact
@@ -479,7 +479,7 @@ Your choice: 2
 # Phase 2: Applies computational preset
 # Phase 1: Validates flags
 # → Generates slides with Scholar
-```bash
+```
 
 ### Example 2: Revision (Phases 1-2, 5)
 
@@ -500,7 +500,7 @@ Your choice: 1
 # Phase 2: Adds --diagrams to content
 # Phase 1: Validates flags
 # → Improves slides with Scholar (adds missing content + diagrams)
-```bash
+```
 
 ### Example 3: Context-Aware Generation (All Phases)
 

--- a/docs/reports/SCHOLAR-ENHANCEMENT-COMPLETE.md
+++ b/docs/reports/SCHOLAR-ENHANCEMENT-COMPLETE.md
@@ -42,7 +42,7 @@ The Scholar Enhancement is a comprehensive 6-phase system that extends the teach
 ```bash
 teach slides -w 8 --style computational --diagrams --no-practice-problems
 # → explanation, examples, code, diagrams (no practice-problems)
-```diff
+```
 
 ### Phase 3-4: Lesson Plan Integration + Interactive Mode
 
@@ -64,7 +64,7 @@ teach slides -i
 # → Shows topic menu → User selects Week 8
 # → Shows style menu → User selects computational
 # → Generates slides
-```diff
+```
 
 ### Phase 5-6: Revision Workflow + Context & Polish
 
@@ -88,7 +88,7 @@ teach slides --revise slides/week-08.qmd --context --diagrams
 # → Presents 6 improvement options
 # → Uses course context + adds diagrams
 # → Generates improved version
-```diff
+```
 
 ---
 
@@ -156,7 +156,7 @@ Scholar wrapper regression: 28/28 ✅ (100%)
 Integration tests:          38/38 ✅ (100%)
 ─────────────────────────────────────────
 Total:                     111/111 ✅ (100%)
-```diff
+```
 
 ### Test Files
 
@@ -217,7 +217,7 @@ Flag arrays:           ~2KB
 Global variables:      ~3KB
 Functions:            ~20KB
 Total overhead:       ~25KB  (Negligible)
-```diff
+```
 
 ---
 
@@ -290,42 +290,42 @@ Total overhead:       ~25KB  (Negligible)
 ```bash
 teach slides "Topic"
 teach exam "Topic"
-```text
+```
 
 **Level 2: Style Presets**
 
 ```bash
 teach slides "Topic" --style computational
 teach exam "Topic" --style rigorous
-```text
+```
 
 **Level 3: Content Customization**
 
 ```bash
 teach slides "Topic" --style computational --diagrams
 teach exam "Topic" --style rigorous --no-proof
-```text
+```
 
 **Level 4: Week-based (Lesson Plans)**
 
 ```bash
 teach slides -w 8
 teach exam -w 8 --style rigorous
-```text
+```
 
 **Level 5: Interactive**
 
 ```bash
 teach slides -i
 teach exam -i --context
-```text
+```
 
 **Level 6: Revision**
 
 ```bash
 teach slides --revise slides/week-08.qmd
 teach exam --revise exam.qmd --math --examples
-```text
+```
 
 **Level 7: Advanced Combinations**
 

--- a/docs/reports/TEST-ANALYSIS-PHASES-1-2.md
+++ b/docs/reports/TEST-ANALYSIS-PHASES-1-2.md
@@ -33,7 +33,7 @@
 ✓ Conflicting flags should fail
 ✓ Short form flags should pass
 ✓ Mixed long/short forms should pass
-```diff
+```
 
 **Analysis:**
 - ✅ Correctly detects `--math --no-math` conflicts
@@ -48,7 +48,7 @@
 ✓ Short flags (-t, -w)
 ✓ Both specified (precedence: topic > week)
 ✓ Neither specified (graceful handling)
-```diff
+```
 
 **Analysis:**
 - ✅ Correctly parses `--topic "Linear Regression"`
@@ -66,7 +66,7 @@
 ✓ Rigorous preset (definitions, explanation, math, proof)
 ✓ Applied preset (explanation, examples, code, practice-problems)
 ✓ Invalid preset detection
-```diff
+```
 
 **Analysis:**
 - ✅ All 4 presets correctly defined
@@ -80,7 +80,7 @@
 ✓ Preset + removals (--style rigorous --no-proof)
 ✓ Multiple overrides (add 2, remove 1)
 ✓ No preset, individual flags only
-```diff
+```
 
 **Analysis:**
 - ✅ Additions correctly merged into preset
@@ -93,7 +93,7 @@
 ```text
 ✓ Instruction building from resolved content
 ✓ Empty content handling (no instructions)
-```diff
+```
 
 **Analysis:**
 - ✅ Maps content flags to human-readable instructions
@@ -117,7 +117,7 @@
 ✓ Dispatcher routing (teach → _teach_scholar_wrapper)   [4 tests]
 ✓ Shortcuts (e, q, sl, lec, hw, etc)                    [1 test]
 ✓ Help system integration                               [3 tests]
-```diff
+```
 
 **Critical Finding:**
 - ✅ **Zero breaking changes** - All existing functionality intact
@@ -143,7 +143,7 @@
 ✓ Error handling                        [1 test]
 ✓ Interactive prompts                   [2 tests]
 ✓ Help system                           [4 tests]
-```diff
+```
 
 **Analysis:**
 - ✅ Teaching dates functionality unaffected by Phase 1-2 changes
@@ -161,7 +161,7 @@
 ```zsh
 _teach_validate_content_flags()    # 45 lines - manageable
 _teach_parse_topic_week()          # 48 lines - manageable
-```text
+```
 
 **Phase 2 Functions:**
 
@@ -169,7 +169,7 @@ _teach_parse_topic_week()          # 48 lines - manageable
 TEACH_STYLE_PRESETS               # 10 lines - simple map
 _teach_resolve_content()          # 67 lines - moderate complexity
 _teach_build_content_instructions() # 27 lines - simple
-```diff
+```
 
 **Assessment:**
 - ✅ All functions under 100 lines (ZSH best practice)
@@ -187,7 +187,7 @@ Topic/week parsing:          100% (all edge cases)
 Style presets:               100% (all 4 presets + invalid)
 Content resolution:          100% (all combinations)
 Content instructions:        100% (empty + populated)
-```diff
+```
 
 **Edge Cases Tested:**
 - ✅ Conflicting flags (--X and --no-X)
@@ -209,7 +209,7 @@ Content instructions:        100% (empty + populated)
 Fix: Keep one or the other
   teach slides -w 8 --math        # Include math
   teach slides -w 8 --no-math     # Exclude math
-```diff
+```
 
 **Assessment:**
 - ✅ Clear error messages
@@ -250,7 +250,7 @@ TEACH_CONTENT_FLAGS:      ~2KB  (9 flags × 3 forms)
 TEACH_SELECTION_FLAGS:    ~1KB  (6 flags)
 TEACH_STYLE_PRESETS:      ~512B (4 presets)
 Functions (code):         ~8KB  (5 new functions)
-```diff
+```
 
 **Total:** ~12KB additional memory
 **Assessment:** ✅ Minimal impact
@@ -338,7 +338,7 @@ Functions (code):         ~8KB  (5 new functions)
 # Plugin load test
 source flow.plugin.zsh
 # Result: ✅ Plugin loaded successfully
-```text
+```
 
 ### Total Test Coverage
 
@@ -352,7 +352,7 @@ Total:                    106 ✅
 Pass rate:               100%
 Failures:                  0
 Breaking changes:          0
-```diff
+```
 
 ---
 
@@ -409,7 +409,7 @@ Fix: Keep one or the other
   teach slides -w 8 --math        # Include math
   teach slides -w 8 --no-math     # Exclude math
   ✓ Conflicting flags should fail
-```text
+```
 
 ### B. Style Preset Resolution
 
@@ -419,7 +419,7 @@ Fix: Keep one or the other
   ✓ Should include examples
   ✓ Should include code
   ✓ Should include practice-problems
-```text
+```
 
 ### C. Content Resolution with Overrides
 

--- a/docs/reports/TUTORIAL-CREATION-SUMMARY.md
+++ b/docs/reports/TUTORIAL-CREATION-SUMMARY.md
@@ -92,7 +92,7 @@ teach slides --help
 teach slides "Topic" --style computational
 teach slides "Topic" --diagrams
 teach exam "Topic" --no-proof
-```diff
+```
 
 **Concepts Covered:**
 - 4 style presets (conceptual, computational, rigorous, applied)
@@ -118,7 +118,7 @@ teach exam "Topic" --no-proof
 teach slides -w 8
 teach slides -i
 teach exam -i -w 8 --style rigorous
-```diff
+```
 
 **Concepts Covered:**
 - YAML lesson plan structure
@@ -145,7 +145,7 @@ teach exam -i -w 8 --style rigorous
 teach slides --revise file.qmd
 teach slides -w 8 --context
 teach slides --revise file.qmd --context --diagrams
-```diff
+```
 
 **Concepts Covered:**
 - 6 revision menu options

--- a/docs/specs/BRAINSTORM-em-cache-management-2026-02-11.md
+++ b/docs/specs/BRAINSTORM-em-cache-management-2026-02-11.md
@@ -86,7 +86,7 @@ Current locations:
 
 ```bash
 $XDG_CACHE_HOME/flow-cli/email/  (defaults to ~/.cache/flow-cli/email/)
-```text
+```
 
 ### Option C: Split by Expendability
 

--- a/docs/specs/BRAINSTORM-em-doctor-flow-integration-2026-02-12.md
+++ b/docs/specs/BRAINSTORM-em-doctor-flow-integration-2026-02-12.md
@@ -32,7 +32,7 @@ Integrate email health checking into `flow doctor` so himalaya and email depende
 
 ```text
 SHELL → REQUIRED → RECOMMENDED → OPTIONAL → INTEGRATIONS → EMAIL → DOTFILES → ...
-```zsh
+```
 
 ### Conditional Gate
 

--- a/docs/specs/BRAINSTORM-himalaya-ai-commands-2026-02-11.md
+++ b/docs/specs/BRAINSTORM-himalaya-ai-commands-2026-02-11.md
@@ -46,7 +46,7 @@ Prompts (4):
   extract_todos "Extract all action items from this..."
   draft_reply   "Draft a professional reply to this..."
   tldr          "You are an executive assistant tri..."
-```diff
+```
 
 **Design decisions:**
 - Shows `[OK]` or `[MISSING]` next to backend binary (via `vim.fn.executable()`)
@@ -69,7 +69,7 @@ Prompts
   tldr           You are an executive assistant triaging email. Ana...
 
   [e] edit config   [v] validate prompt   [q] close
-```diff
+```
 
 Keybinds in the prompts buffer:
 - `e` — opens config.lua for editing (same as `:HimalayaAi edit`)
@@ -123,7 +123,7 @@ Also, the budget was approved at the higher band ($95-105k).
 
 Thanks,
 Sarah
-```diff
+```
 
 **Why this works:** Short enough to be fast, complex enough to test all 4 prompts (has action items, needs reply, has deadline, needs summary).
 
@@ -185,7 +185,7 @@ return {
     -- add custom prompts here
   },
 }
-```text
+```
 
 **Loading priority:** config.lua `prompts` table merges over built-in defaults (via `tbl_deep_extend`). If a user deletes a prompt from config, the built-in default is used.
 

--- a/docs/specs/BRAINSTORM-interactive-ai-prompts.md
+++ b/docs/specs/BRAINSTORM-interactive-ai-prompts.md
@@ -12,14 +12,14 @@ Make AI actions prompt for user instructions before running, so the user's inten
 ```text
 <leader>ms → static prompt → AI → result split
 <leader>mr → static prompt → AI → result split
-```text
+```
 
 ## Proposed Flow
 
 ```text
 <leader>ms → vim.ui.input("Instructions (Enter=default):") → merge with prompt → AI → result split
 <leader>mr → vim.ui.input("Reply tone/instructions:") → merge with prompt → AI → result split
-```bash
+```
 
 ## Options
 
@@ -36,7 +36,7 @@ if instructions ~= "" then
 else
   prompt = base
 end
-```text
+```
 
 **Pros:** Minimal code change (~15 lines), works immediately
 **Cons:** No structured guidance to the AI, user input just tacked on
@@ -53,7 +53,7 @@ draft_reply = table.concat({
   "{instructions}",          -- replaced or removed
   "Format as markdown."
 }, "\n"),
-```text
+```
 
 When user provides input: slot filled. When empty: slot removed.
 
@@ -69,7 +69,7 @@ First prompt analyzes the email, second prompt uses analysis + user instructions
 ```text
 Phase 1: "Analyze this email: key points, sender intent, required response"
 Phase 2: "Given this analysis + user instructions, draft reply"
-```text
+```
 
 **Pros:** Best quality output, AI has full context
 **Cons:** 2x API calls, slower, more complex
@@ -103,7 +103,7 @@ ask_before = {
   extract_todos = false,
   tldr = false,
 },
-```bash
+```
 
 User can toggle via `:HimalayaAi set ask_before.summarize true`
 
@@ -129,7 +129,7 @@ local function run_ai_with_input(prompt_key, title, hint)
     run_ai(prompt_key, title, nil)
   end
 end
-```bash
+```
 
 ### Prompt Merge in `run_ai()`
 
@@ -144,7 +144,7 @@ local function run_ai(prompt_key, title, instructions)
   end
   -- ... rest of existing code ...
 end
-```text
+```
 
 ### Per-Action Hints
 
@@ -156,7 +156,7 @@ local input_hints = {
   extract_todos = "Filter (Enter=all): ",
   tldr = "Context (Enter=default): ",
 }
-```bash
+```
 
 ### New Compose Action
 
@@ -173,7 +173,7 @@ function M.compose()
     M._run_ai_custom(prompt, get_buffer_text(), "Compose", {})
   end)
 end
-```text
+```
 
 ## Quick Wins
 

--- a/docs/specs/BRAINSTORM-teach-deploy-enhancements-2026-02-08.md
+++ b/docs/specs/BRAINSTORM-teach-deploy-enhancements-2026-02-08.md
@@ -26,7 +26,7 @@
 
 ```bash
 trap return_to_draft EXIT
-```bash
+```
 
 **What teach deploy should do:**
 
@@ -35,7 +35,7 @@ trap return_to_draft EXIT
 trap "git checkout '$draft_branch' 2>/dev/null" EXIT INT TERM
 # ... do work ...
 trap - EXIT INT TERM  # Clear trap before normal return
-```bash
+```
 
 **Effort:** 15 min | **Risk:** Low (additive, no behavior change on happy path)
 **Where:** `_deploy_direct_merge()` (line ~162) and PR mode section (line ~854)
@@ -55,7 +55,7 @@ Options:
   1. Fix the issues reported above, then run deploy again
   2. Skip validation: QUARTO_PRE_COMMIT_RENDER=0 ./scripts/quick-deploy.sh
   3. Force commit: git commit --no-verify -m "message"
-```bash
+```
 
 **What teach deploy should do:**
 Add hook failure detection after `git commit` calls in partial deploy mode (line ~670, ~683):
@@ -72,7 +72,7 @@ if ! git commit -m "$commit_msg"; then
     echo "  Your changes are still staged."
     return 1
 fi
-```bash
+```
 
 **Effort:** 20 min | **Risk:** Low
 **Where:** `_teach_deploy_enhanced()` partial deploy commit blocks (lines ~664-686)
@@ -106,7 +106,7 @@ if ! git merge-base --is-ancestor "$prod_branch" "origin/$prod_branch" &&
         [[ "$reset_confirm" == [yY] ]] && git reset --hard "origin/$prod_branch"
     fi
 fi
-```bash
+```
 
 **Effort:** 30 min | **Risk:** Medium (destructive operation, needs careful prompt)
 **Where:** `_deploy_direct_merge()` (line ~208, after ff-only pull fails)
@@ -122,7 +122,7 @@ fi
 ```bash
 echo "Tip: Check deployment status at:"
 echo "   https://github.com/<owner>/<repo>/actions"
-```bash
+```
 
 **What teach deploy should add:**
 In `_deploy_summary_box()`, add an optional actions URL:
@@ -133,7 +133,7 @@ repo_slug=$(git config --get remote.origin.url 2>/dev/null | sed 's/.*github.com
 if [[ -n "$repo_slug" ]]; then
     printf "│  🔗 %-8s %-42s│\n" "Actions:" "https://github.com/${repo_slug}/actions"
 fi
-```bash
+```
 
 **Effort:** 10 min | **Risk:** None
 **Where:** `_deploy_summary_box()` (line ~125)
@@ -150,7 +150,7 @@ fi
 teach deploy -d
   [!!] Working tree dirty
   → FAILS
-```bash
+```
 
 **Desired behavior (matching quick-deploy.sh):**
 
@@ -160,7 +160,7 @@ teach deploy -d
   Smart commit: content: week-05 lecture
   Commit and continue? [Y/n]:
   → auto-commits, then proceeds with deploy
-```bash
+```
 
 **Implementation:**
 Move the uncommitted-change handling from partial deploy mode into the main `_teach_deploy_enhanced()` flow, before the mode dispatch:

--- a/docs/specs/BRAINSTORM-teach-map-2026-02-08.md
+++ b/docs/specs/BRAINSTORM-teach-map-2026-02-08.md
@@ -92,7 +92,7 @@ The teaching ecosystem spans 3 tools (flow-cli, Scholar, Craft) with 35+ command
 
  TIP: /craft and /scholar commands run inside Claude Code
  TIP: teach help -- usage details for any teach subcommand
-```bash
+```
 
 ---
 
@@ -107,7 +107,7 @@ command -v claude &>/dev/null && {
     [[ -d "${HOME}/.claude/plugins/scholar" ]] && has_scholar=true
     [[ -d "${HOME}/.claude/plugins/craft" ]] && has_craft=true
 }
-```diff
+```
 
 ### 2. Dimming Unavailable Commands
 

--- a/docs/specs/BRAINSTORM-teach-prompt-v2-2026-01-29.md
+++ b/docs/specs/BRAINSTORM-teach-prompt-v2-2026-01-29.md
@@ -108,7 +108,7 @@ teach prompt
 ├── create     [Phase 2] Create new prompt from scratch/template
 ├── diff       [Phase 2] Compare override against default
 └── promote    [Phase 2] Copy course prompt to user tier
-```text
+```
 
 ### Zero-Friction Scholar Integration
 

--- a/docs/specs/DOTFILE-INTEGRATION-SUMMARY.md
+++ b/docs/specs/DOTFILE-INTEGRATION-SUMMARY.md
@@ -32,7 +32,7 @@ df diff             # Preview changes
 df secret list      # Manage secrets
 df doctor           # Troubleshoot
 df help             # Full help
-```diff
+```
 
 **Why dispatcher pattern:**
 - ✅ Consistent with flow-cli architecture (g, mcp, cc, wt, tm, obs, qu, r)
@@ -54,7 +54,7 @@ df edit .zshrc
 # → Auto-preview on save
 # → Prompt: Apply changes? [Y/n]
 # → Apply with backup
-```diff
+```
 
 **Smart features:**
 - Fuzzy path matching: `dot edit zshrc` → `~/.config/zsh/.zshrc`
@@ -71,7 +71,7 @@ df sync
 # → Show diff
 # → Prompt: Apply? [Y/n]
 # → Apply changes
-```diff
+```
 
 **Safety features:**
 - Preview before applying
@@ -89,7 +89,7 @@ df
 # → Show secret status
 # → Show modified files
 # → Suggest next action
-```text
+```
 
 **Output:**
 
@@ -98,7 +98,7 @@ df
 🔐 Secrets: ✓ 3 injected
 📝 Modified: 0 files
 💡 Next: df sync (to pull latest)
-```text
+```
 
 ---
 
@@ -113,7 +113,7 @@ $ df edit .zshrc
 🔑 Enter master password: ********
 ✓ Unlocked
 ✓ Opening ~/.zshrc...
-```yaml
+```
 
 **Auto-recovery:** Detects + prompts + resumes
 
@@ -131,7 +131,7 @@ Options:
 
 Choice [1-4]: 3
 ✓ Opening merge editor...
-```yaml
+```
 
 **Guided resolution:** Clear options, no guessing
 
@@ -147,7 +147,7 @@ Fix:
   3) df doctor (diagnose)
 
 Proceed without? [y/N] n
-```text
+```
 
 **Actionable errors:** Clear next steps
 
@@ -171,7 +171,7 @@ $ dash
 📦 Dotfiles: 🟢 Synced (2h ago)        ← NEW!
   3 secrets active • 0 pending changes
   💡 df sync to update
-```text
+```
 
 **Integration point:** Add `_dash_dotfiles()` section
 
@@ -183,7 +183,7 @@ $ work flow-cli
 📦 Checking dotfiles...               ← NEW!
   ⚠ Behind remote by 2 commits
   💡 Run 'df sync'? [Y/n]
-```bash
+```
 
 **Integration point:** Add check to `work()` function
 
@@ -191,7 +191,7 @@ $ work flow-cli
 
 ```bash
 export FLOW_DF_CHECK_ON_WORK=0  # Disable
-```bash
+```
 
 ### `flow doctor` - Include dotfile health
 
@@ -205,7 +205,7 @@ $ flow doctor
   ✓ Repository connected
   ✓ Secrets configured
   ✓ Synced with remote
-```bash
+```
 
 **Integration point:** Add `_flow_doctor_dotfiles()` check
 
@@ -219,14 +219,14 @@ $ flow doctor
 $ df
 # Shows status + 3 quick actions at bottom
 💡 df edit .zshrc | df sync | df push
-```bash
+```
 
 ### Level 2: Full help
 
 ```bash
 $ df help
 # Complete reference with examples
-```bash
+```
 
 ### Level 3: Inline context
 
@@ -234,14 +234,14 @@ $ df help
 $ df diff
 # Shows changes...
 💡 Next: df apply (to apply) | df edit (to modify)
-```bash
+```
 
 ### Level 4: Dashboard integration
 
 ```bash
 $ dash
 # Shows dotfile status + suggested action
-```diff
+```
 
 ---
 

--- a/docs/specs/IMPLEMENTATION-prompt-dispatcher-v5.7.0.md
+++ b/docs/specs/IMPLEMENTATION-prompt-dispatcher-v5.7.0.md
@@ -145,7 +145,7 @@ declare -gA PROMPT_ENGINES=(
     [engine_description]="Description"
     [engine_binary]="binary_name"
 )
-```text
+```
 
 ### Function Organization
 
@@ -163,7 +163,7 @@ prompt (main dispatcher)
 ├── _prompt_validate_p10k()
 ├── _prompt_validate_starship()
 └── _prompt_validate_ohmyposh()
-```diff
+```
 
 ### Environment Integration
 
@@ -265,7 +265,7 @@ flow-cli/
 ├── .STATUS                               [UPDATED]
 ├── flow.plugin.zsh                       [UNCHANGED] Auto-loads dispatcher
 └── [other files unchanged]
-```diff
+```
 
 ## Design Decisions
 

--- a/docs/specs/PLAN-teaching-workflow-increment-3.md
+++ b/docs/specs/PLAN-teaching-workflow-increment-3.md
@@ -83,7 +83,7 @@ Next steps:
   1. Edit: $EDITOR exams/midterm1.md
   2. Convert: ./scripts/exam-to-qti.sh exams/midterm1.md
   3. Upload: exams/midterm1.qti → Canvas
-```bash
+```
 
 ### 2. Convert to Canvas QTI
 
@@ -104,7 +104,7 @@ Upload to Canvas:
   1. Go to: [course] → Quizzes → Import
   2. Select: QTI 1.2 format
   3. Upload: exams/midterm1.qti
-```text
+```
 
 ### 3. Reuse Questions
 
@@ -122,7 +122,7 @@ exams/
     ├── regression.md     # Topic-based
     ├── anova.md
     └── inference.md
-```yaml
+```
 
 ---
 
@@ -157,7 +157,7 @@ examark:
   question_bank: "exams/questions"
   default_duration: 120
   default_points: 100
-```diff
+```
 
 #### 1.2 Create Exam Template (1 hour)
 
@@ -218,7 +218,7 @@ instructions: |
 1. C
 2. [Expected answer]
 3. [Expected solution with rubric]
-```yaml
+```
 
 #### 1.3 Update Config Template (1 hour)
 
@@ -234,7 +234,7 @@ examark:
   question_bank: "exams/questions"
   default_duration: 120       # Minutes
   default_points: 100
-```bash
+```
 
 ---
 
@@ -295,7 +295,7 @@ else
   echo "Check exam format: https://github.com/daveagp/examark"
   exit 1
 fi
-```bash
+```
 
 #### 2.2 Add Script to teach-init (30 min)
 
@@ -309,7 +309,7 @@ cp "$template_dir/quick-deploy.sh" scripts/
 cp "$template_dir/semester-archive.sh" scripts/
 cp "$template_dir/exam-to-qti.sh" scripts/      # NEW
 chmod +x scripts/*.sh
-```bash
+```
 
 #### 2.3 Update Next Steps Message (30 min)
 
@@ -321,7 +321,7 @@ chmod +x scripts/*.sh
 echo "  5. (Optional) Enable exam workflow:"
 echo "     npm install -g examark"
 echo "     yq -i '.examark.enabled = true' .flow/teach-config.yml"
-```diff
+```
 
 ---
 
@@ -350,7 +350,7 @@ echo "     yq -i '.examark.enabled = true' .flow/teach-config.yml"
 |---------|---------|---------|
 | `teach-exam <topic>` | Create exam template | `teach-exam "Midterm 1"` |
 | `./scripts/exam-to-qti.sh <file>` | Convert to Canvas QTI | `./scripts/exam-to-qti.sh exams/midterm1.md` |
-```diff
+```
 
 #### 3.3 Update README.md (30 min)
 

--- a/docs/specs/PROPOSAL-email-dispatcher-2026-02-10.md
+++ b/docs/specs/PROPOSAL-email-dispatcher-2026-02-10.md
@@ -33,7 +33,7 @@ em() {
         *) _em_help ;;
     esac
 }
-```diff
+```
 
 **Pros:** Ships fast, establishes pattern, zero optional deps
 **Cons:** Not much value over raw himalaya
@@ -148,7 +148,7 @@ Ship Option B as v1, then incrementally add Option C features.
 │ │                   │ │ glow    │ bat   │
 │ └───────────────────┘ └─────────┘       │
 └─────────────────────────────────────────┘
-```zsh
+```
 
 ### fzf Picker Design
 
@@ -166,7 +166,7 @@ _em_pick() {
               --bind='ctrl-r:execute(himalaya message reply {1})' \
               --bind='ctrl-d:execute(himalaya envelope flag add {1} Deleted)'
 }
-```yaml
+```
 
 ### Config Integration
 
@@ -178,7 +178,7 @@ email:
   render_html: true      # auto-detect and render HTML
   notifications: false   # IMAP IDLE watch
   color_theme: tokyo     # tokyo | default | minimal
-```text
+```
 
 ### Doctor Integration
 
@@ -193,7 +193,7 @@ Email Dependencies:
   ✓ fzf (interactive picker)
   ✗ glow (Markdown rendering — optional)
   ✗ terminal-notifier (notifications — optional)
-```ini
+```
 
 ---
 

--- a/docs/specs/RESEARCH-himalaya-editor-integration-2026-02-10.md
+++ b/docs/specs/RESEARCH-himalaya-editor-integration-2026-02-10.md
@@ -59,7 +59,7 @@ himalaya provides two mechanisms for editor integration that our spec should lev
 himalaya message write
 himalaya message reply <ID>
 himalaya message forward <ID>
-```diff
+```
 
 These commands:
 - Generate an MML (MIME Meta Language) template with headers pre-filled
@@ -72,7 +72,7 @@ These commands:
 # Pre-fill the body text BEFORE opening $EDITOR
 himalaya message write "Dear Dr. Smith," "Thank you for your email."
 himalaya message reply <ID> "Thank you for reaching out."
-```diff
+```
 
 The `[BODY]...` argument accepts one or more strings that get injected into the template body before `$EDITOR` opens. This means:
 
@@ -91,7 +91,7 @@ himalaya template forward <ID>       # Returns forward template to stdout
 
 # Send template from stdin WITHOUT $EDITOR
 himalaya template send < draft.mml   # Sends MML from stdin directly
-```text
+```
 
 The `template` subsystem is the **scripting API** that separates template generation from the interactive `$EDITOR` step. This enables:
 
@@ -109,7 +109,7 @@ The `template` subsystem is the **scripting API** that separates template genera
 
 ```text
 AI generates draft -> write to temp file -> open $EDITOR -> read back -> himalaya send < file
-```text
+```
 
 **NEW approach (using native himalaya features):**
 
@@ -122,7 +122,7 @@ em reply <ID>
      (himalaya opens $EDITOR with draft pre-populated)
   -> user edits, saves, quits (:wq)
   -> himalaya sends automatically
-```text
+```
 
 #### Non-interactive Reply (AI sends directly after confirmation)
 
@@ -133,7 +133,7 @@ em respond --send <ID>
   -> show preview to user
   -> _flow_confirm "Send this reply? [y/N]"
   -> himalaya template send < modified.mml
-```text
+```
 
 ### 4.2 Updated Adapter Functions
 
@@ -155,7 +155,7 @@ The `em reply` command should support both paths:
 em reply <ID>              # Interactive: AI draft -> $EDITOR -> send
 em reply <ID> --no-ai      # Interactive: blank body -> $EDITOR -> send
 em reply <ID> --batch      # Non-interactive: AI draft -> confirm -> send
-```text
+```
 
 ---
 

--- a/docs/specs/RFC-scholar-config-flag.md
+++ b/docs/specs/RFC-scholar-config-flag.md
@@ -26,7 +26,7 @@ teach exam "Hypothesis Testing" --format quarto --output exams/
 
 # Translates to:
 claude --print "/teaching:exam 'Hypothesis Testing' --format quarto --output exams/"
-```diff
+```
 
 **Limitations:**
 - ❌ Scholar has no access to full course context (name, semester, grading, etc.)
@@ -44,7 +44,7 @@ teach exam "Hypothesis Testing"
 
 # Translates to:
 claude --print "/teaching:exam 'Hypothesis Testing' --config teach-config.yml"
-```diff
+```
 
 **Benefits:**
 - ✅ Scholar reads course name, semester, grading policy, style preferences
@@ -79,7 +79,7 @@ All Scholar teaching skills accept an optional `--config` flag:
     }
   ]
 }
-```diff
+```
 
 **Affected Commands:**
 - `/teaching:exam`
@@ -115,7 +115,7 @@ def validate_config(config_path):
         validate_scholar_section(config['scholar'])
 
     return config
-```diff
+```
 
 **Error Handling:**
 - Invalid config → Show clear error with field name and expected format
@@ -161,7 +161,7 @@ scholar:
     homework: 30
     project: 20
     participation: 10
-```diff
+```
 
 **Protocol:**
 - Scholar can READ `course.*` for context (course name, semester, instructor)
@@ -177,7 +177,7 @@ With config access, Scholar generates more contextually aware content:
 
 ```bash
 teach exam "Hypothesis Testing"
-```bash
+```
 
 Scholar reads config and generates:
 
@@ -192,13 +192,13 @@ Scholar reads config and generates:
 [Exam follows course grading policy: 40% exams]
 [Notation style: Statistical (as configured)]
 [Difficulty: Intermediate (as configured)]
-```text
+```
 
 **Example 2: Syllabus Generation**
 
 ```bash
 teach syllabus
-```diff
+```
 
 Scholar reads ENTIRE config (course, semester_info, grading) and generates complete syllabus with correct dates, grading breakdown, course info.
 
@@ -257,7 +257,7 @@ Scholar reads ENTIRE config (course, semester_info, grading) and generates compl
 
 ```bash
 claude --print "/teaching:exam 'Topic' --format quarto --difficulty intermediate"
-```bash
+```
 
 **After (with config):**
 
@@ -267,7 +267,7 @@ teach init "STAT 440"
 
 # Scholar reads course context automatically
 teach exam "Topic"
-```diff
+```
 
 **Backward Compatibility:**
 - Commands work without `--config` flag (use defaults)
@@ -292,7 +292,7 @@ Example:
 teach exam "Topic" --config teach-config.yml --tone conversational
 
 # Result: Uses "conversational" (flag overrides config)
-```text
+```
 
 ### Error Messages
 
@@ -305,7 +305,7 @@ teach exam "Topic" --config teach-config.yml --tone conversational
   • course.semester must be one of: Spring, Summer, Fall, Winter (got: "spring")
 
 Fix the config file and try again.
-```text
+```
 
 **Missing Scholar Section:**
 

--- a/docs/specs/SPEC-Flow-CLI-Documentation-Enhancement - Complete-Implementation.md
+++ b/docs/specs/SPEC-Flow-CLI-Documentation-Enhancement - Complete-Implementation.md
@@ -122,7 +122,7 @@ description: Quick solutions when Flow CLI isn't working as expected
 # 🆘 I'm Stuck
 
 !!! tldr "TL;DR - Try These First (30 seconds)"
-```bash
+```
     source ~/.zshrc              # Reload shell
     flow doctor                  # Run diagnostics
     ls ~/.config/zsh/functions/  # Check installation
@@ -139,7 +139,7 @@ Try these in order - most common solutions first:
 **What this means:** Flow CLI commands aren't loaded in your shell.
 
 **Fix it:**
-```bash
+```
 # Option 1: Reload your shell config
 source ~/.zshrc
 
@@ -159,7 +159,7 @@ brew reinstall flow-cli  # If using Homebrew
 **What this means:** Flow CLI can't find any projects with `.STATUS` files.
 
 **Fix it:**
-```bash
+```
 # Check your projects directory
 ls ~/projects/
 
@@ -180,7 +180,7 @@ status your-project ready P2 "Initial setup"
 **What this means:** Project type not detected or editor not in PATH.
 
 **Fix it:**
-```bash
+```
 # Check what's in your project
 cd ~/projects/your-project
 ls -la
@@ -203,7 +203,7 @@ which code    # Should show path to executable
 **What this means:** Timer functions not loaded or tmux not installed.
 
 **Fix it:**
-```bash
+```
 # Check if tmux is installed
 which tmux
 
@@ -221,7 +221,7 @@ source ~/.zshrc
 **What this means:** Worklog file permissions or path issue.
 
 **Fix it:**
-```bash
+```
 # Check worklog file
 ls -la ~/.config/zsh/.worklog
 
@@ -238,7 +238,7 @@ win "Test win"
 ## 🔍 Still Stuck?
 
 ### Run Full Diagnostics
-```bash
+```
 flow doctor
 ```
 
@@ -250,7 +250,7 @@ This checks:
 - ✓ Common issues
 
 ### Check Your Setup
-```bash
+```
 # Verify installation
 echo $PATH | grep flow-cli
 
@@ -344,7 +344,7 @@ description: Find the right starting point for your goals
 
 === "Track my work sessions"
     **Solution:** [Session Tracking Workflow](../guides/WORKFLOWS-QUICK-WINS.md#quick-test-cycle)
-```bash
+```
     work my-project
     win "Completed feature X"
     finish
@@ -352,7 +352,7 @@ description: Find the right starting point for your goals
 
 === "Manage multiple projects"
     **Solution:** [Project Management Guide](../tutorials/02-multiple-projects.md)
-```bash
+```
     dash              # See all projects
     pick              # Choose one
     hop other-project # Quick switch
@@ -360,7 +360,7 @@ description: Find the right starting point for your goals
 
 === "See my progress/stats"
     **Solution:** [Dopamine Features Guide](../guides/DOPAMINE-FEATURES-GUIDE.md)
-```bash
+```
     wins              # Today's wins
     yay --week        # Weekly summary
     flow goal         # Progress tracking
@@ -368,7 +368,7 @@ description: Find the right starting point for your goals
 
 === "Set up dotfile management"
     **Solution:** [Dotfile Workflow](../guides/DOT-WORKFLOW.md)
-```bash
+```
     dot status        # Check dotfiles
     dot link          # Create symlinks
     dot push          # Backup to git
@@ -376,7 +376,7 @@ description: Find the right starting point for your goals
 
 === "Integrate with git workflow"
     **Solution:** [Git Feature Workflow](../tutorials/08-git-feature-workflow.md)
-```bash
+```
     g new feature-x   # Start feature
     g push            # Safe push with checks
     g done            # Merge and cleanup
@@ -472,7 +472,7 @@ description: Essential commands on one page - print friendly
 ## ⚡ Quick Workflows
 
 ### Start Your Day
-```bash
+```
 dash              # See all projects
 just-start        # Auto-pick high priority
 work .            # Open in editor
@@ -480,14 +480,14 @@ f25               # Start 25-min timer
 ```
 
 ### During Work
-```bash
+```
 why               # Where am I?
 win "did thing"   # Log progress
 hop other         # Switch project
 ```
 
 ### End of Day
-```bash
+```
 status .          # Update progress
 wins              # See today's wins
 finish            # Close session
@@ -510,7 +510,7 @@ finish            # Close session
 ## 🔌 Smart Dispatchers
 
 ### R Package Development: `r`
-```bash
+```
 r load            # Load package
 r test            # Run tests
 r doc             # Generate docs
@@ -518,7 +518,7 @@ r help            # Show all commands
 ```
 
 ### Git with Safety: `g`
-```bash
+```
 g status          # Safe git status
 g push            # Push with checks
 g new feature-x   # Start feature branch
@@ -526,7 +526,7 @@ g help            # Show all commands
 ```
 
 ### Claude Code: `cc`
-```bash
+```
 cc pick           # Open project in Claude
 cc ask "query"    # Ask Claude
 cc help           # Show all commands
@@ -562,7 +562,7 @@ cc help           # Show all commands
 **Priority:** `P0` (urgent) → `P4` (someday)
 
 **Update status:**
-```bash
+```
 status my-project active P0 "Next task description"
 ```
 
@@ -878,7 +878,7 @@ details[open] {
 
 ````markdown
 !!! tldr "⚡ TL;DR - Get Started in 30 Seconds"
-```bash
+```
     brew tap data-wise/tap && brew install flow-cli
     dash                    # See your projects
     work my-project         # Start working

--- a/docs/specs/SPEC-code-workspace-2026-02-13.md
+++ b/docs/specs/SPEC-code-workspace-2026-02-13.md
@@ -87,7 +87,7 @@ flowchart TD
         E2["Positron installed → Positron (default)"]
         E3["Positron not installed → VS Code (fallback)"]
     end
-```zsh
+```
 
 ## API Design
 
@@ -101,7 +101,7 @@ code() {
         *)  command code "$@" ;;
     esac
 }
-```text
+```
 
 ### Subcommand Table
 
@@ -137,7 +137,7 @@ lib/templates/ws/
 ├── python.json         # Python/uv template
 ├── node.json           # Node/Bun template
 └── generic.json        # Minimal template
-```text
+```
 
 ### Template Structure
 
@@ -153,7 +153,7 @@ lib/templates/ws/
     "recommendations": []
   }
 }
-```zsh
+```
 
 ### Template Cascade Resolution
 
@@ -174,7 +174,7 @@ _code_ws_resolve_template() {
         echo "$builtin_tmpl"  # fallback to generic
     fi
 }
-```bash
+```
 
 ### Editor Selection Logic
 
@@ -198,7 +198,7 @@ _code_ws_select_editor() {
     # 3. Fall back to VS Code
     echo "code"
 }
-```text
+```
 
 **Rationale:** Positron handles R, Python, AND Node projects equally well (same extension marketplace, same workspace format). Its native data science features (variables pane, plots viewer, connections pane) benefit all project types. No reason to split by project type — just use the better editor when available.
 
@@ -236,7 +236,7 @@ $ code ws                          # (Positron not installed)
 → Template: node (built-in)
 → Created: myproject.code-workspace
 → Opening in VS Code... (Positron not found, using fallback)
-```text
+```
 
 ### User Flow: `code ws create --type python --editor cursor`
 
@@ -245,7 +245,7 @@ $ code ws create --type python --editor cursor
 → Template: python (built-in)
 → Created: myproject.code-workspace
 → Opening in Cursor...
-```text
+```
 
 ### User Flow: `code ws add ../shared-lib`
 
@@ -254,7 +254,7 @@ $ code ws add ../shared-lib
 → Updated: myproject.code-workspace
 → Added folder: ../shared-lib (shared-lib)
 → Workspace now has 2 folders
-```text
+```
 
 ### User Flow: `code ws list`
 
@@ -272,7 +272,7 @@ Templates:
 
   Local (.flow/templates/ws/):
     (none)
-```text
+```
 
 ### Help Output
 
@@ -307,7 +307,7 @@ $ code ws help
     code ws create --type python
     code ws add ../shared-lib
     code ws --editor code       # Force VS Code
-```diff
+```
 
 ### Accessibility
 

--- a/docs/specs/SPEC-dot-chezmoi-safety-2026-01-30.md
+++ b/docs/specs/SPEC-dot-chezmoi-safety-2026-01-30.md
@@ -110,7 +110,7 @@ Auto-create ignore rule? (Y/n): y
 
 Adding .config/ghostty to chezmoi...
 ✓ Added 12 files (skipped 45 .git files)
-```diff
+```
 
 **Acceptance:**
 - Detects both `path/.git` and nested `path/subdir/.git`
@@ -147,7 +147,7 @@ $ dot ignore remove "*.log"
 # Edit directly (fallback)
 $ dot ignore edit
 # Opens .chezmoiignore in $EDITOR
-```diff
+```
 
 **Acceptance:**
 - `add` creates .chezmoiignore if missing
@@ -185,7 +185,7 @@ Top 10 largest files:
 
 ⚠ Found 1 nested .git directory (should be ignored)
   Run 'dot ignore add "**/.git"' to fix
-```diff
+```
 
 **Acceptance:**
 - Shows total repository size (human-readable)
@@ -224,7 +224,7 @@ Auto-add ignore patterns? (Y/n): y
 
 Proceed with add? (Y/n): y
 ✓ Added 2 files (skipped 2 generated files)
-```diff
+```
 
 **Acceptance:**
 - Shows file count and total size before adding
@@ -260,7 +260,7 @@ Dotfile Management:
      Consider: dot ignore add "nvim/lazy-lock.json"
   ✓ No nested .git directories tracked
   ✓ Last sync: 2 hours ago (synced)
-```diff
+```
 
 **Acceptance:**
 - Checks chezmoi installation and version
@@ -306,7 +306,7 @@ Total size: 12 KB
 
 Proceed with add? (Y/n): y
 ✓ Added 6 files (skipped 2 cache files)
-```diff
+```
 
 **Acceptance:**
 - Detects patterns automatically during preview
@@ -337,7 +337,7 @@ lib/dispatchers/dot-dispatcher.zsh:
   - dot ignore [add|list|remove|edit]  # Ignore management
   - dot size                            # Repository analysis
   - _dot_doctor_check_chezmoi_health() # Doctor integration
-```text
+```
 
 **Modified Commands:**
 
@@ -348,7 +348,7 @@ dot add <path>:
   3. Run _dot_suggest_ignore_patterns() - auto-suggest ignores
   4. Prompt for confirmation
   5. Execute chezmoi add with filtered paths
-```text
+```
 
 ### Performance Targets
 
@@ -375,7 +375,7 @@ flow-cli/
 └── docs/specs/
     ├── dot-dispatcher-refcard.md         # Update with new commands
     └── SPEC-dot-chezmoi-safety-2026-01-30.md  # This spec
-```bash
+```
 
 ---
 
@@ -392,7 +392,7 @@ flow-cli/
 ```zsh
 # Line 473 uses BSD-specific stat
 local size=$(stat -f%z "$file" 2>/dev/null || echo 0)
-```zsh
+```
 
 **Solution:** Add cross-platform helper in `lib/core.zsh`:
 
@@ -410,14 +410,14 @@ _flow_get_file_size() {
         stat -f%z "$file" 2>/dev/null || echo 0
     fi
 }
-```bash
+```
 
 **Usage:**
 
 ```zsh
 # In _dot_preview_add()
 local size=$(_flow_get_file_size "$file")
-```bash
+```
 
 #### 2. Ignore Pattern Removal
 
@@ -426,7 +426,7 @@ local size=$(_flow_get_file_size "$file")
 ```zsh
 # Line 669 uses sed -i.bak (works differently on BSD vs GNU)
 sed -i.bak "/^${escaped}$/d" "$ignore_file"
-```bash
+```
 
 **Solution:** Use temp file approach (portable):
 
@@ -436,7 +436,7 @@ local temp_file=$(mktemp)
 grep -vF "$3" "$ignore_file" > "$temp_file"
 mv "$temp_file" "$ignore_file"
 _dot_success "Removed pattern from .chezmoiignore: $3"
-```bash
+```
 
 #### 3. Human-Readable Sizes
 
@@ -445,7 +445,7 @@ _dot_success "Removed pattern from .chezmoiignore: $3"
 ```zsh
 # Line 498 assumes numfmt is available
 echo "Total size: $(numfmt --to=iec $total_size)"
-```zsh
+```
 
 **Solution:** Add fallback helper in `lib/core.zsh`:
 
@@ -469,7 +469,7 @@ _flow_human_size() {
         fi
     fi
 }
-```bash
+```
 
 ---
 
@@ -483,7 +483,7 @@ _flow_human_size() {
 while IFS= read -r gitdir; do
     git_dirs+=("$gitdir")
 done < <(find "$target" -name ".git" -type d -maxdepth 5 2>/dev/null)
-```zsh
+```
 
 **Impact:** Could take 10+ seconds on directories like `~/.config` with 10,000+ files.
 
@@ -528,7 +528,7 @@ _dot_check_git_in_path() {
     fi
     return 1
 }
-```bash
+```
 
 ### Solution 2: Optimize for Git Repos
 
@@ -550,7 +550,7 @@ else
     # Not a git repo - use find with timeout
     # ... (timeout logic from Solution 1)
 fi
-```zsh
+```
 
 ### Performance Targets (Updated)
 
@@ -576,7 +576,7 @@ fi
 # Existing cache variables
 typeset -g _DOT_CHEZMOI_CACHE
 typeset -g _DOT_CHEZMOI_CACHE_TIME
-```zsh
+```
 
 **Add New Cache Variables:**
 
@@ -589,7 +589,7 @@ typeset -g _DOT_IGNORE_CACHE_TIME
 
 # Cache TTL (5 minutes)
 typeset -g _DOT_CACHE_TTL=300
-```zsh
+```
 
 **Cache Helper Functions:**
 
@@ -622,7 +622,7 @@ _dot_cache_size() {
     _DOT_SIZE_CACHE="$1"
     _DOT_SIZE_CACHE_TIME=$(date +%s)
 }
-```zsh
+```
 
 #### 2. Doctor Integration Point
 
@@ -647,7 +647,7 @@ else
     _flow_log_info "Dotfile Management: chezmoi not installed (optional)"
     _flow_log_info "Install with: brew install chezmoi"
 fi
-```zsh
+```
 
 #### 3. Update `dot status` Command
 
@@ -690,7 +690,7 @@ if [[ -d "$HOME/.local/share/chezmoi/.git" ]]; then
         _flow_log_info "  Fix with: dot ignore add '**/.git'"
     fi
 fi
-```bash
+```
 
 #### 4. Edge Case: Symlink Handling
 
@@ -722,7 +722,7 @@ if [[ -L "$target" ]]; then
         return 0
     fi
 fi
-```bash
+```
 
 #### 5. Integration with `.gitignore`
 
@@ -764,7 +764,7 @@ _dot_suggest_from_gitignore() {
         fi
     fi
 }
-```zsh
+```
 
 ---
 
@@ -1166,7 +1166,7 @@ main() {
 if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
     main "$@"
 fi
-```bash
+```
 
 ### Integration with `./tests/run-all.sh`
 
@@ -1176,7 +1176,7 @@ Add to `tests/run-all.sh`:
 # Add after existing test suites
 echo "Running dot chezmoi safety tests..."
 ./tests/test-dot-chezmoi-safety.zsh || FAILED=$((FAILED + 1))
-```yaml
+```
 
 ---
 
@@ -1206,7 +1206,7 @@ Top 10 largest files:
 
 ⚠ Found 1 nested .git directory (should be ignored)
   Run 'dot ignore add "**/.git"' to fix
-```bash
+```
 
 Alternatively, check manually:
 
@@ -1218,7 +1218,7 @@ find . -name ".git" -type d -not -path "./.git"
 
 # Check specific config directories
 ls -la ~/.local/share/chezmoi/dot_config/*/dot_git
-```bash
+```
 
 #### Step 2: Add Ignore Patterns
 
@@ -1240,7 +1240,7 @@ dot ignore list
    2  **/.git/**
    3  **/dot_git
    4  **/dot_git/**
-```bash
+```
 
 #### Step 3: Remove Tracked `.git` Files
 
@@ -1265,7 +1265,7 @@ find . -name "dot_git" -type d | while read -r gitdir; do
         rm -rf "$gitdir"
     fi
 done
-```diff
+```
 
 #### Step 4: Commit Changes
 
@@ -1286,7 +1286,7 @@ git commit -m "chore: remove tracked .git directories
 
 # Push to remote
 git push
-```bash
+```
 
 #### Step 5: Verify Cleanup
 
@@ -1307,7 +1307,7 @@ Total: 1.2 MB  (was 1.4 MB)
 flow doctor
 
 # Expected: All chezmoi checks should pass
-```yaml
+```
 
 #### Step 6: Re-add Directories (Clean)
 
@@ -1332,7 +1332,7 @@ Total size: 24 KB
 
 Proceed with add? (Y/n): y
 ✓ Added /Users/dt/.config/nvim to chezmoi
-```bash
+```
 
 ### Common Patterns to Add to `.chezmoiignore`
 
@@ -1365,7 +1365,7 @@ dot ignore add ".idea/"
 
 # Lazy.nvim state (changes frequently)
 dot ignore add "nvim/lazy-lock.json"
-```bash
+```
 
 ### Troubleshooting Migration
 
@@ -1377,7 +1377,7 @@ dot ignore add "nvim/lazy-lock.json"
 cd ~/.local/share/chezmoi
 git rm -r dot_config/nvim/dot_git
 git commit -m "remove: nvim git metadata"
-```bash
+```
 
 **Issue:** Files keep reappearing
 
@@ -1391,7 +1391,7 @@ dot ignore list
 cd ~/.local/share/chezmoi
 chezmoi ignored ~/.config/nvim/.git
 # Should output: true
-```bash
+```
 
 **Issue:** Repository still large after cleanup
 
@@ -1412,7 +1412,7 @@ git push origin --force --all
 rm -rf .git/refs/original/
 git reflog expire --expire=now --all
 git gc --prune=now --aggressive
-```zsh
+```
 
 ---
 
@@ -1472,7 +1472,7 @@ _flow_timeout() {
         "$@"
     fi
 }
-```zsh
+```
 
 **Testing:**
 
@@ -1485,7 +1485,7 @@ _flow_get_file_size ~/.zshrc
 
 # Test human sizes
 _flow_human_size 1048576  # Should show 1 MB
-```zsh
+```
 
 #### 0.2 Cache Infrastructure
 
@@ -1518,7 +1518,7 @@ _dot_cache_size() {
     _DOT_SIZE_CACHE="$1"
     _DOT_SIZE_CACHE_TIME=$(date +%s)
 }
-```bash
+```
 
 ### Phase 1: Safety Features (Week 1, Days 3-5)
 
@@ -1582,7 +1582,7 @@ _dot_check_git_in_path() {
     fi
     return 1
 }
-```bash
+```
 
 **Modify:** `dot add` command in `dot-dispatcher.zsh`
 
@@ -1636,7 +1636,7 @@ _dot_check_git_in_path() {
     chezmoi add "$target"
     _dot_success "Added $target to chezmoi"
     ;;
-```bash
+```
 
 #### 1.2 Preview Before Add
 
@@ -1775,7 +1775,7 @@ _dot_suggest_ignore_patterns() {
         fi
     done
 }
-```bash
+```
 
 **Testing:**
 
@@ -1795,7 +1795,7 @@ mkdir -p /tmp/test-gen
 touch /tmp/test-gen/app.log /tmp/test-gen/db.sqlite
 dot add /tmp/test-gen
 # Expected: Preview warns about .log/.sqlite, suggests ignoring
-```bash
+```
 
 #### 1.3 Ignore Management Commands
 
@@ -1887,7 +1887,7 @@ dot add /tmp/test-gen
             ;;
     esac
     ;;
-```bash
+```
 
 **Testing:**
 
@@ -1904,7 +1904,7 @@ dot ignore list
 
 dot ignore edit
 # Expected: Opens .chezmoiignore in $EDITOR
-```bash
+```
 
 ### Phase 2: Health & Visibility (Week 2, Days 6-8)
 
@@ -1974,14 +1974,14 @@ dot ignore edit
         _dot_info "Consider reviewing with: find ~/.local/share/chezmoi -type f -size +100k"
     fi
     ;;
-```bash
+```
 
 **Testing:**
 
 ```bash
 dot size
 # Expected: Shows total size, top 10 files, warnings for .git dirs
-```bash
+```
 
 #### 2.2 Doctor Integration
 
@@ -2120,7 +2120,7 @@ _dot_doctor_check_chezmoi_health() {
             ;;
     esac
 }
-```bash
+```
 
 **Integration:** Add call to existing `flow doctor` command
 
@@ -2129,7 +2129,7 @@ _dot_doctor_check_chezmoi_health() {
 ```bash
 flow doctor
 # Expected: Includes "Dotfile Management" section with all checks
-```zsh
+```
 
 ### Phase 3: Integration & Architecture (Week 2, Days 9-10)
 
@@ -2159,14 +2159,14 @@ else
     _flow_log_info "Dotfile Management: chezmoi not installed (optional)"
     _flow_log_info "Install with: brew install chezmoi"
 fi
-```bash
+```
 
 **Testing:**
 
 ```bash
 flow doctor
 # Expected: Chezmoi health section appears after token checks
-```zsh
+```
 
 #### 3.2 Update `dot status` Command
 
@@ -2210,7 +2210,7 @@ if [[ -d "$HOME/.local/share/chezmoi/.git" ]]; then
         _flow_log_info "  Fix with: dot ignore add '**/.git'"
     fi
 fi
-```bash
+```
 
 #### 3.3 `.gitignore` Integration
 
@@ -2254,7 +2254,7 @@ _dot_suggest_from_gitignore() {
 }
 
 # Call from _dot_preview_add() after git detection
-```sql
+```
 
 ### Phase 4: Testing & Documentation (Week 2, Days 11-14)
 
@@ -2272,7 +2272,7 @@ chmod +x tests/test-dot-chezmoi-safety.zsh
 
 # Add to tests/run-all.sh
 echo "./tests/test-dot-chezmoi-safety.zsh || FAILED=\$((FAILED + 1))" >> tests/run-all.sh
-```bash
+```
 
 See "Test Infrastructure" section above for complete test implementation.
 
@@ -2286,7 +2286,7 @@ See "Test Infrastructure" section above for complete test implementation.
 ./tests/test-dot-chezmoi-safety.zsh
 
 # Expected: All tests pass
-```zsh
+```
 
 #### 4.2 Completions & Documentation
 
@@ -2316,7 +2316,7 @@ case $state in
         _describe -t commands 'ignore commands' ignore_cmds
         ;;
 esac
-```diff
+```
 
 #### 3.2 Update Documentation
 
@@ -2385,7 +2385,7 @@ test_git_detection
 test_ignore_management
 test_preview_calculation
 echo "Tests complete"
-```diff
+```
 
 ### Integration Tests
 
@@ -2452,7 +2452,7 @@ echo "Tests complete"
 - [ ] Run `dot size` with no chezmoi repo - verify error
 - [ ] Run with empty .chezmoiignore - verify works
 - [ ] Run with missing .chezmoiignore - verify creates
-```diff
+```
 
 ---
 
@@ -2487,7 +2487,7 @@ Add sections:
 - **Preview**: Shows file count/size before adding
 - **Auto-suggestions**: Intelligent ignore pattern suggestions
 - **Large file warnings**: Alerts for files >50KB
-```sql
+```
 
 ### Help Text
 
@@ -2538,7 +2538,7 @@ Update `dot` help command:
     echo "  dot ignore add '**/.git'"
     echo "  dot size"
     ;;
-```yaml
+```
 
 ---
 
@@ -2615,7 +2615,7 @@ A: Yes. Use the `--no-preview` flag:
 
 ```bash
 dot add ~/.config/nvim --no-preview
-```yaml
+```
 
 **Q: What if I accidentally added .git files before this update?**
 
@@ -2630,7 +2630,7 @@ chezmoi forget '.config/nvim/.git'
 
 # 3. Verify
 dot size
-```yaml
+```
 
 **Q: How do I know if I have .git directories tracked?**
 
@@ -2638,14 +2638,14 @@ A: Run the new size analysis command:
 
 ```bash
 dot size
-```bash
+```
 
 Look for warnings about git directories. Or check manually:
 
 ```bash
 cd ~/.local/share/chezmoi
 find . -name "dot_git" -type d
-```yaml
+```
 
 **Q: Will this slow down my workflow?**
 
@@ -2693,7 +2693,7 @@ A: Verify patterns are in `.chezmoiignore`:
 
 ```bash
 dot ignore list
-```bash
+```
 
 Test if pattern matches:
 
@@ -2701,7 +2701,7 @@ Test if pattern matches:
 cd ~/.local/share/chezmoi
 chezmoi ignored ~/.config/nvim/.git
 # Should output: true
-```diff
+```
 
 **Q: Preview shows wrong file count**
 
@@ -2754,7 +2754,7 @@ Total size: 24 KB
 
 Proceed with add? (Y/n): y
 ✓ Added /Users/dt/.config/ghostty to chezmoi
-```text
+```
 
 #### `dot size` output
 
@@ -2778,7 +2778,7 @@ Top 10 largest files:
       0.4 KB  dot_zshrc
 
 ✓ No nested git directories tracked
-```text
+```
 
 #### `flow doctor` with chezmoi checks
 

--- a/docs/specs/SPEC-dot-rename-split-2026-02-14.md
+++ b/docs/specs/SPEC-dot-rename-split-2026-02-14.md
@@ -55,7 +55,7 @@ dot() ─── 4,395 lines
 ├── Dotfile mgmt (status, edit, sync, push, diff, apply, ignore, init, undo, env, doctor)
 ├── Secret mgmt (secret, secrets, unlock, lock, sync, bw integration)
 └── Token mgmt (token github, token npm, token pypi, token rotate, token refresh)
-```text
+```
 
 ### Target (3 Dispatchers)
 
@@ -101,7 +101,7 @@ tok() ─── ~1,300 lines
 ├── sync           # Sync to GitHub secrets
 ├── doctor/dr      # Token-specific diagnostics
 └── help           # Help
-```text
+```
 
 ### Mermaid Diagram
 
@@ -124,7 +124,7 @@ graph LR
     SEC -.->|keychain-helpers.zsh| SHARED[Shared Helpers]
     TOK -.->|keychain-helpers.zsh| SHARED
     DOTS -.->|dotfile-helpers.zsh| SHARED
-```yaml
+```
 
 ---
 
@@ -236,7 +236,7 @@ Each dispatcher gets a modernized help screen following the existing color schem
 │    $ dots doctor                                            │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
-```text
+```
 
 Cross-references between dispatchers in help output (RELATED section).
 

--- a/docs/specs/SPEC-em-ai-improvements-2026-02-18.md
+++ b/docs/specs/SPEC-em-ai-improvements-2026-02-18.md
@@ -91,7 +91,7 @@ _em_ai_status() {
     echo ""
     echo -e "  ${_C_DIM}Switch: em ai claude | em ai gemini | em ai toggle${_C_NC}"
 }
-```diff
+```
 
 **Acceptance:**
 - `em ai` shows current backend
@@ -129,7 +129,7 @@ typeset -gA _EM_AI_BACKENDS=(
     [claude_extra_args]=""             # None needed
     ...
 )
-```bash
+```
 
 **Code change (`_em_ai_execute`):**
 
@@ -143,7 +143,7 @@ gemini)
         gemini ${=extra} "$prompt" 2>/dev/null
     # ... (rest unchanged)
     ;;
-```diff
+```
 
 **Config file override:** `email.conf` can set `FLOW_EMAIL_GEMINI_EXTRA_ARGS="-e none"`.
 
@@ -218,14 +218,14 @@ _em_catch() {
         echo -e "${_C_DIM}(catch command not available — copy manually)${_C_NC}"
     fi
 }
-```text
+```
 
 **fzf integration (em pick):**
 Add to existing `_em_pick()` fzf `--bind`:
 
 ```text
 --bind "ctrl-c:execute-silent(_em_catch {1})+reload(...)"
-```diff
+```
 
 **Acceptance:**
 - `em catch 42` produces summary and logs to catch
@@ -265,7 +265,7 @@ _em_ai_switch()      │   ├── _em_ai_query("summarize")
     ├── validate          │
     ├── export FLOW_EMAIL_AI
     └── update _EM_AI_BACKENDS[default]
-```text
+```
 
 ## API Design
 
@@ -297,13 +297,13 @@ Email AI Backend
   Timeout:   30s
 
   Switch: em ai claude | em ai gemini | em ai toggle
-```text
+```
 
 ### `em ai toggle` Notification
 
 ```text
 ✓ AI backend → gemini
-```text
+```
 
 ### `em catch` Output
 

--- a/docs/specs/SPEC-em-delete-actions-2026-02-20.md
+++ b/docs/specs/SPEC-em-delete-actions-2026-02-20.md
@@ -93,7 +93,7 @@ em delete --folder X --purge   PERMANENT delete all in folder
 
 Aliases: em del, em rm
 Safety: All deletes confirm [y/N] (default No). --purge requires typing "yes".
-```text
+```
 
 ### em move
 
@@ -103,14 +103,14 @@ em move --from <SOURCE> <FOLDER> <ID>   Move from non-default source folder
 em move --pick <ID> [<ID>...]           fzf folder picker -> move to selected folder
 
 Aliases: em mv
-```text
+```
 
 ### em restore
 
 ```text
 em restore <ID> [<ID>...]       Move from $FLOW_EMAIL_TRASH_FOLDER (default: Trash) to INBOX
 em restore <ID> --to <FOLDER>   Move from Trash to specific folder
-```text
+```
 
 ### em todo
 
@@ -119,7 +119,7 @@ em todo <ID> [<ID>...]   Extract action items via AI, capture to flow + Reminder
 
 Flow: read email -> AI extract action items -> catch command -> Reminders.app (per-email confirm)
 Fallback: Uses email subject if AI unavailable
-```text
+```
 
 ### em event
 
@@ -128,7 +128,7 @@ em event <ID> [<ID>...]   Extract dates/times via AI, capture to flow + Calendar
 
 Flow: read email -> AI extract events (JSON) -> display -> catch -> Calendar.app (per-email confirm)
 Returns: title, date, time, duration, location for each extracted event
-```text
+```
 
 ### em flag / em unflag
 
@@ -136,7 +136,7 @@ Returns: title, date, time, duration, location for each extracted event
 em flag <ID> [<ID>...]     Star email for follow-up (IMAP Flagged)
 em unflag <ID> [<ID>...]   Remove star
 Aliases: em fl
-```text
+```
 
 ### em pick (updated)
 
@@ -155,7 +155,7 @@ Keybinds:
   Ctrl+E           Extract events from selected email(s)
   Ctrl+F           Flag selected email(s) for follow-up
   Esc              Exit picker
-```text
+```
 
 ---
 
@@ -169,7 +169,7 @@ Three new functions isolate all himalaya CLI specifics:
 _em_hml_delete(folder, IDs...)   -> himalaya message delete -f <folder> <ID>...
 _em_hml_move(src, dst, IDs...)   -> himalaya message move -f <src> <dst> <ID>...
 _em_hml_expunge(folder)          -> himalaya folder expunge <folder>
-```text
+```
 
 ### AI Layer (`lib/em-ai.zsh`)
 
@@ -178,7 +178,7 @@ One new prompt function + timeout entry:
 ```bash
 _em_ai_todo_prompt()   -> Extract action items (1 per line, max 5, plain text)
 [todo]=15              -> Added to _EM_AI_OP_TIMEOUT map
-```text
+```
 
 Reuse existing `_em_ai_schedule_prompt` for event extraction (already returns JSON with events array).
 
@@ -235,7 +235,7 @@ Shows count + first 5 subjects from the target set. Returns 0 if user confirms, 
     5. "Limited time deal"
     ... and 7 more
   Confirm delete? [y/N]
-```yaml
+```
 
 ---
 
@@ -261,7 +261,7 @@ Shows count + first 5 subjects from the target set. Returns 0 if user confirms, 
 Folder: INBOX  |  Unread: 5
 Tab=select  Enter=read  Ctrl-D=delete  Ctrl-R=reply  Ctrl-A=archive
 Ctrl-S=summarize  Ctrl-T=catch  Ctrl-O=todo  Ctrl-E=event  Ctrl-F=flag
-```text
+```
 
 ### Action Router
 
@@ -269,7 +269,7 @@ Ctrl-S=summarize  Ctrl-T=catch  Ctrl-O=todo  Ctrl-E=event  Ctrl-F=flag
 Parse selected -> extract action prefix + IDs
 Single-item actions (read, reply, summarize): process first ID only
 Multi-item actions (delete, archive, catch, todo, event, flag): process all IDs
-```zsh
+```
 
 ---
 
@@ -293,7 +293,7 @@ _em_create_calendar_event() {
         end tell
 APPLESCRIPT
 }
-```zsh
+```
 
 ### Reminders.app (`_em_create_reminder`)
 
@@ -305,7 +305,7 @@ _em_create_reminder() {
     [[ "$(uname)" != "Darwin" ]] && return 1
     osascript -e "tell application \"Reminders\" to make new reminder with properties {name:\"$title\"}"
 }
-```diff
+```
 
 Both gated behind `[[ "$(uname)" == "Darwin" ]]`. Non-macOS gracefully skips.
 
@@ -390,7 +390,7 @@ MANAGE:
   em restore <ID>      Restore from Trash to INBOX
   em flag <ID>         Star for follow-up
   em unflag <ID>       Remove star
-```text
+```
 
 ### Enhanced AI FEATURES Section
 
@@ -402,7 +402,7 @@ AI FEATURES:
   em catch <ID>        Capture email as task
   em todo <ID>         Extract action items -> flow + Reminders.app
   em event <ID>        Extract events -> flow + Calendar.app
-```diff
+```
 
 ### Per-Command Help
 
@@ -441,7 +441,7 @@ Office 365/Exchange uses "Deleted Items", Gmail IMAP uses "[Gmail]/Trash", stand
 
 ```zsh
 : ${FLOW_EMAIL_TRASH_FOLDER:=Trash}
-```diff
+```
 
 `em restore` reads from this variable as the source folder.
 

--- a/docs/specs/SPEC-em-dispatcher-2026-02-10.md
+++ b/docs/specs/SPEC-em-dispatcher-2026-02-10.md
@@ -53,7 +53,7 @@ The `em` dispatcher is a pure ZSH email command dispatcher that wraps himalaya C
          | w3m/bat |
          | /glow   |
          +---------+
-```text
+```
 
 ### 1.3 Layer Responsibilities
 
@@ -87,7 +87,7 @@ flow-cli/
     em-doctor.zsh                # Dependency health check
   completions/
     _em                          # ZSH completions for em
-```text
+```
 
 **Per-project configuration (optional):**
 
@@ -104,7 +104,7 @@ flow-cli/
       classifications/           # msg-id -> category
       drafts/                    # msg-id -> draft response
       schedules/                 # msg-id -> extracted dates
-```text
+```
 
 **Global configuration:**
 
@@ -114,7 +114,7 @@ flow-cli/
     config.yml                   # Global email settings
     templates/                   # Global templates
     backends.yml                 # AI backend preferences per operation
-```zsh
+```
 
 ---
 
@@ -251,7 +251,7 @@ _em_hml_flags() {
         *)      himalaya flag list "$msg_id" ;;
     esac
 }
-```zsh
+```
 
 ### 3.3 Error Handling
 
@@ -274,7 +274,7 @@ _em_hml_check() {
     fi
     return 0
 }
-```yaml
+```
 
 ---
 
@@ -320,7 +320,7 @@ backends:
   mcp:
     server: email-ai               # MCP server name
     tool: process_email             # Tool name to invoke
-```zsh
+```
 
 ### 4.3 Core AI Function
 
@@ -488,7 +488,7 @@ _em_ai_available() {
     command -v gemini &>/dev/null && available+=(gemini)
     echo "${available[*]}"
 }
-```diff
+```
 
 ### 4.4 Operation-Specific Prompts
 
@@ -578,7 +578,7 @@ Return JSON (and ONLY JSON, no markdown fences) in this format:
 If no dates/times found, return: {"events": []}
 PROMPT
 }
-```text
+```
 
 ---
 
@@ -599,7 +599,7 @@ AI results are expensive (2-30 seconds per call). Cache aggressively.
   schedules/
     <message-id-hash>.json       # extracted dates
   metadata.json                  # cache stats, last cleanup timestamp
-```zsh
+```
 
 ### 5.2 Cache Implementation
 
@@ -707,7 +707,7 @@ _em_cache_stats() {
     done
     echo ""
 }
-```bash
+```
 
 ### 5.3 Cache Warming Strategy
 
@@ -736,7 +736,7 @@ _em_cache_warm() {
 
     # Don't wait -- let it run in background
 }
-```text
+```
 
 ---
 
@@ -793,7 +793,7 @@ _em_inbox(25)
                   [Q] john@uni.edu    Assignment 3 help       Needs extension for Q3   2h
                   [!] dean@uni.edu    Budget deadline          FY27 due Friday          4h
                   [N] nature.com      Weekly digest            Top papers this week     1d
-```text
+```
 
 ### 6.2 Flow: `em respond` Draft Workflow
 
@@ -862,7 +862,7 @@ _em_respond_review()
     |                   _em_cache_invalidate(msg_id)
     |
     +---> _flow_log_success "5 replies sent"
-```text
+```
 
 ### 6.3 Flow: Scheduling Extraction
 
@@ -899,7 +899,7 @@ _em_read(42)
                         |       +--[none]----------> Generate .ics file
                         |
                         +---> _flow_log_success "Added to Calendar.app"
-```zsh
+```
 
 ---
 
@@ -953,7 +953,7 @@ em() {
         *)              himalaya "$@" ;;
     esac
 }
-```bash
+```
 
 ### 7.2 Key Command Implementations
 
@@ -1097,7 +1097,7 @@ _em_pick() {
         _em_read "$selected_id"
     fi
 }
-```bash
+```
 
 ### 7.3 Reply with AI Draft Pre-population
 
@@ -1193,7 +1193,7 @@ _em_mml_inject_body() {
         { print }
     '
 }
-```zsh
+```
 
 ### 7.4 Category Icons
 
@@ -1213,7 +1213,7 @@ _em_category_icon() {
         *)                 echo " " ;;
     esac
 }
-```bash
+```
 
 ---
 
@@ -1278,7 +1278,7 @@ _em_render_with() {
             ;;
     esac
 }
-```zsh
+```
 
 ---
 
@@ -1427,7 +1427,7 @@ _em_respond_review() {
     echo ""
     _flow_log_info "Reviewed: ${#approved[@]} approved, $skipped skipped"
 }
-```bash
+```
 
 ---
 
@@ -1539,7 +1539,7 @@ ICS
     _flow_log_success "Generated: $ics_file"
     _flow_log_info "Open with: open $ics_file"
 }
-```bash
+```
 
 ---
 
@@ -1603,7 +1603,7 @@ _em_urgency_level() {
     # Normal: everything else
     echo "normal"
 }
-```yaml
+```
 
 ---
 
@@ -1638,7 +1638,7 @@ ai:
   draft_tone: "friendly-professional"
   sign_off: "Best,\nDT"
   include_office_hours: true
-```yaml
+```
 
 ### 12.2 Email Templates
 
@@ -1661,7 +1661,7 @@ structure: |
 variables:
   office_hours: "from .flow/office-hours.md"
   instructor_name: "from .flow/course-info.yml"
-```bash
+```
 
 ### 12.3 Context Injection
 
@@ -1693,7 +1693,7 @@ _em_project_context_file() {
         echo "$tmp"
     fi
 }
-```zsh
+```
 
 ---
 
@@ -1786,7 +1786,7 @@ _em_doc_check() {
         return 0
     fi
 }
-```yaml
+```
 
 ---
 
@@ -1983,7 +1983,7 @@ ${_C_DIM}See also:${_C_NC}
   ${_C_CYAN}em respond --review${_C_NC} -- Never sends without your approval
 "
 }
-```zsh
+```
 
 ---
 

--- a/docs/specs/SPEC-em-doctor-flow-integration-2026-02-12.md
+++ b/docs/specs/SPEC-em-doctor-flow-integration-2026-02-12.md
@@ -84,7 +84,7 @@ flowchart TD
 
     style Email fill:#e1f5fe
     style Fix fill:#fff3e0
-```text
+```
 
 ### Section Placement in flow doctor
 
@@ -92,7 +92,7 @@ flowchart TD
 SHELL → REQUIRED → RECOMMENDED → OPTIONAL → INTEGRATIONS
 → 📧 EMAIL (new, conditional)
 → DOTFILES → PLUGIN MANAGER → ZSH PLUGINS → FLOW-CLI → GITHUB TOKEN → ALIASES
-```bash
+```
 
 ## API Design
 
@@ -106,7 +106,7 @@ _doctor_check_email()
 # Side effects: Populates _doctor_missing_brew[], _doctor_missing_pip[]
 # Output:   Formatted status lines to stdout
 # Verbose:  Tests IMAP connectivity (account, fetch, OAuth2, SMTP config)
-```bash
+```
 
 ### New Function: `_doctor_email_connectivity()`
 
@@ -119,7 +119,7 @@ _doctor_email_connectivity()
 #           4. SMTP config validation (parse config.toml, verify host/port/auth set)
 # Output:   Status lines with yellow warnings on failure
 # Latency:  ~3-5s total (all 4 checks)
-```bash
+```
 
 ### New Function: `_doctor_email_setup()`
 
@@ -133,7 +133,7 @@ _doctor_email_setup()
 #           5. Offer OAuth2 proxy setup (if Gmail/Outlook detected)
 #           6. Run connectivity test to verify
 # Output:   Step-by-step interactive prompts with colored feedback
-```bash
+```
 
 ### New Fix Category
 
@@ -143,14 +143,14 @@ if [[ ${#_doctor_missing_email_brew[@]} -gt 0 || "$_doctor_email_no_config" == t
     categories+=("email")
     category_info[email]="📧 Email Tools + Setup ($detail, ~${time})"
 fi
-```bash
+```
 
 ### New Flag (future): `--email`
 
 ```zsh
 # Mirrors --dot pattern for isolated email check
 doctor --email     # Check only EMAIL section
-```text
+```
 
 N/A for initial implementation — future enhancement.
 
@@ -185,7 +185,7 @@ N/A - No data model changes. Uses existing `_doctor_missing_brew[]`, `_doctor_mi
     Page size:   25
     Folder:      INBOX
     Config file: (none — using env defaults)
-```text
+```
 
 ### Fix Mode Menu (with email)
 
@@ -198,7 +198,7 @@ N/A - No data model changes. Uses existing `_doctor_missing_brew[]`, `_doctor_mi
 │                                                │
 │  0. Exit without fixing                        │
 ╰───────────────────────────────────────────────╯
-```text
+```
 
 ### Verbose Mode Output (--verbose)
 
@@ -223,7 +223,7 @@ N/A - No data model changes. Uses existing `_doctor_missing_brew[]`, `_doctor_mi
     Page size:   25
     Folder:      INBOX
     Config file: ~/.config/himalaya/config.toml
-```text
+```
 
 ### Verbose Connectivity Failure (warning, not error)
 
@@ -233,7 +233,7 @@ N/A - No data model changes. Uses existing `_doctor_missing_brew[]`, `_doctor_mi
     △ IMAP: connection timed out (check network/firewall)
     △ OAuth2: email-oauth2-proxy not running
     ○ SMTP config: not configured (send may fail)
-```text
+```
 
 ### Fix Mode Output (email setup)
 
@@ -264,7 +264,7 @@ N/A - No data model changes. Uses existing `_doctor_missing_brew[]`, `_doctor_mi
   ✓ Account config valid
   ✓ IMAP connected (fetched 1 message)
   ✓ Email setup complete!
-```diff
+```
 
 ### Provider Auto-Detection
 
@@ -348,7 +348,7 @@ else
         fi
     done
 fi
-```diff
+```
 
 ### Fix Mode Tracking
 

--- a/docs/specs/SPEC-em-features-2026-02-18.md
+++ b/docs/specs/SPEC-em-features-2026-02-18.md
@@ -52,7 +52,7 @@ graph TD
     MOVE --> FZF[fzf folder picker]
     DIGEST --> HML
     DIGEST --> AI[_em_ai_query]
-```text
+```
 
 All new features follow the existing adapter pattern — they delegate to `_em_hml_*` functions in `lib/em-himalaya.zsh` for CLI operations and use `_em_ai_query` for AI features.
 
@@ -76,7 +76,7 @@ All new features follow the existing adapter pattern — they delegate to `_em_h
 ~/.flow/email-snooze/
 ├── pending.json          # Active snooze entries
 └── completed.json        # Expired (for cleanup)
-```text
+```
 
 ```json
 {
@@ -90,7 +90,7 @@ All new features follow the existing adapter pattern — they delegate to `_em_h
     }
   ]
 }
-```diff
+```
 
 N/A for thread, star, move, digest — these are stateless operations.
 
@@ -114,7 +114,7 @@ em thread 42
   │  └─ #42  Jane Smith    2026-02-18  ← current
   └─ #41  Bob Lee          2026-02-17
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```text
+```
 
 ### Digest Output
 

--- a/docs/specs/SPEC-email-dispatcher.md
+++ b/docs/specs/SPEC-email-dispatcher.md
@@ -83,7 +83,7 @@ OUTCOME: Professor sees the 3 urgent items, handles the scheduling
          rest to after the first work block.
 
 TIME: ~90 seconds
-```diff
+```
 
 **Key design decisions:**
 - `em` with no arguments shows categorized summary, not raw inbox
@@ -144,7 +144,7 @@ OUTCOME: 5 student emails handled in ~3 minutes
          AI used syllabus + office hours from .flow/ context
 
 TIME: ~3 minutes
-```diff
+```
 
 **Key design decisions:**
 - fzf multi-select for batch operations
@@ -191,7 +191,7 @@ OUTCOME: Urgent email handled in <30 seconds without leaving terminal
          Calendar awareness prevents scheduling conflicts
 
 TIME: ~30 seconds
-```diff
+```
 
 **Key design decisions:**
 - Urgent items get structured breakdown, not just summary
@@ -247,7 +247,7 @@ OUTCOME: Clean end-of-day with no lingering email anxiety
          Progress visible in session summary
 
 TIME: ~2 minutes
-```diff
+```
 
 **Key design decisions:**
 - `finish` integration is opt-in, not blocking
@@ -556,7 +556,7 @@ em sync                                         # 1 batch AI call
 em review                                       # 1 fzf session
   [Tab] [Tab] [Tab] [Ctrl-A]                   # bulk approve
                                                 # 0 context switches
-```diff
+```
 
 ### Pattern 2: Visible Progress and Completion Signals
 
@@ -576,7 +576,7 @@ em student     -> "5 student emails (3 drafts ready)"
 [approve 3]    -> "3 sent! 2 remaining"
 [approve 2]    -> "Student inbox clear! (+5 win streak)"
 em             -> "Today: 14/14 handled | Inbox at zero"
-```text
+```
 
 ### Pattern 3: Time-Boxing Email Sessions
 
@@ -594,7 +594,7 @@ em review --time 5              # Start 5-minute email session
 │                                                           │
 │ [c]ontinue (2 more min)  [f]inish  [q]uick-approve-rest │
 └──────────────────────────────────────────────────────────┘
-```diff
+```
 
 - Default timer set in config: `em config timer.default 5`
 - Timer is informational, not enforced (ADHD needs agency, not constraints)
@@ -619,7 +619,7 @@ em config notify.ambient true        # tmux badge (default: on)
 em config notify.nudge true          # red urgent badge (default: on)
 em config notify.interrupt false     # terminal bell (default: OFF)
 em config notify.dnd true            # suppress all during work session deep focus
-```diff
+```
 
 - **Default is conservative:** ambient + nudge, no interrupt
 - DND (do not disturb) mode auto-activates when `FLOW_SESSION_PROJECT` is set and project priority is P0/P1
@@ -654,7 +654,7 @@ em config notify.dnd true            # suppress all during work session deep foc
 │                     ^                                     │
 │               cursor starts here                          │
 └──────────────────────────────────────────────────────────┘
-```diff
+```
 
 ### Pattern 6: Preventing Email as Overwhelm Source
 
@@ -676,7 +676,7 @@ em zero                            # Hide everything except urgent
 │                                                           │
 │ You're doing fine. Focus on your work.                    │
 └──────────────────────────────────────────────────────────┘
-```diff
+```
 
 ---
 
@@ -772,7 +772,7 @@ The closest competitor is Shortwave, but it requires a GUI, costs $14/month, onl
                      │    corrections.json (feedback)         │
                      │    stats.json      (usage analytics)   │
                      └──────────────────────────────────────┘
-```text
+```
 
 ### File Structure
 
@@ -800,7 +800,7 @@ flow-cli/
 └── docs/
     └── reference/
         └── em-dispatcher.md       # User-facing documentation
-```text
+```
 
 ### AI Prompt Architecture
 
@@ -838,7 +838,7 @@ Subject: Office Hours Wednesday
 Body: [first 500 chars]
 ---
 [...more emails...]
-```text
+```
 
 **Draft Generation Prompt (per-email, only for needs_response=true):**
 
@@ -863,7 +863,7 @@ Previous thread messages (if any):
 {{thread_context}}
 
 Write ONLY the reply body. No subject line. No greeting repetition if replying in thread.
-```bash
+```
 
 ### AI Backend Abstraction (Phase 4)
 
@@ -894,7 +894,7 @@ _em_ai_call() {
             ;;
     esac
 }
-```zsh
+```
 
 ### Dispatcher Pattern (matches flow-cli conventions)
 
@@ -935,7 +935,7 @@ em() {
         *)            _em_help ;;
     esac
 }
-```text
+```
 
 ### Cache Schema
 

--- a/docs/specs/SPEC-email-himalaya-nvim-ux-analysis.md
+++ b/docs/specs/SPEC-email-himalaya-nvim-ux-analysis.md
@@ -63,7 +63,7 @@ The flow-cli `cc` dispatcher works precisely because it does not try to embed Cl
 7. Edit draft in buffer
 8. :HimalayaSend or keymap                 -- DID THIS ACTUALLY SEND? Where's confirmation?
 9. Close splits, return to inbox buffer    -- State management: did the inbox refresh?
-```diff
+```
 
 **Problem count:** 4 unresolved UX questions in a single email reply cycle.
 
@@ -146,7 +146,7 @@ em reply               # AI generates draft, nvim opens with draft pre-filled
                        # User must explicitly type 'y'
 
 em                     # Back to inbox (sub-second)
-```diff
+```
 
 **Step count for one reply: 4 conscious decisions** (pick email, read, edit draft, confirm send).
 
@@ -230,7 +230,7 @@ This is a multi-day yak shave for a Lua beginner.
 6. AI draft appears in buffer somehow (?)     -- UNSOLVED without Lua
 7. Edit draft
 8. Save → send?                               -- Confirmation UX unclear
-```diff
+```
 
 ### 3. Context Switching Cost
 
@@ -377,7 +377,7 @@ em reply              # User selected email #42 from fzf
     - Spinner: "Sending..."
     - Success: "Sent reply to sender@example.com"
     - Temp files cleaned up
-```diff
+```
 
 ### Safety Mechanisms (Preventing Accidental Send)
 
@@ -409,7 +409,7 @@ For a nicer experience later (optional, not day-1):
 vim.opt_local.textwidth = 72
 vim.opt_local.spell = true
 vim.opt_local.spelllang = "en"
-```text
+```
 
 ---
 
@@ -429,7 +429,7 @@ em send                # Send a saved draft
 em accounts            # Show configured accounts
 em doctor              # Health check (himalaya, IMAP, SMTP)
 em help                # Help (80% section + full reference)
-```text
+```
 
 **Grammar:** `em [verb] [target]` -- identical to `g [verb] [target]`.
 

--- a/docs/specs/SPEC-help-compliance-2026-02-02.md
+++ b/docs/specs/SPEC-help-compliance-2026-02-02.md
@@ -79,7 +79,7 @@ lib/help-compliance.zsh
   _flow_help_compliance_check()      # Check single dispatcher
   _flow_help_compliance_check_all()  # Check all dispatchers
   _flow_help_compliance_rules()      # Return rule definitions
-```bash
+```
 
 ### Compliance Rules
 

--- a/docs/specs/SPEC-himalaya-ai-commands-2026-02-11.md
+++ b/docs/specs/SPEC-himalaya-ai-commands-2026-02-11.md
@@ -57,7 +57,7 @@ Add `:HimalayaAi <subcommand>` umbrella command to manage AI prompts and setting
     +-- edit       --> vsplit config.lua --> BufWritePost auto-reload
     +-- validate   --> select prompt --> detect email source --> run_ai --> result split
     +-- set        --> parse key/value --> validate --> update M.config --> persist to config.lua
-```text
+```
 
 **Config loading flow:**
 
@@ -69,7 +69,7 @@ tbl_deep_extend(defaults, config)  -->  M.config  (runtime)
     ^                                       |
     |                                       v
     +--- :HimalayaAi set (writes back) <--- M.config update
-```text
+```
 
 ---
 
@@ -85,7 +85,7 @@ N/A — This is a Neovim user command, not an HTTP API.
 :HimalayaAi edit
 :HimalayaAi validate [prompt_name]
 :HimalayaAi set <key> <value>
-```text
+```
 
 **Argument table:**
 
@@ -125,7 +125,7 @@ return {
     tldr = "...",
   },
 }
-```yaml
+```
 
 ---
 
@@ -159,7 +159,7 @@ Prompts (4):
   tldr           You are an executive assistant triag...
 
 [q] close
-```diff
+```
 
 - Opens in `botright vnew` (same pattern as result split)
 - `buftype=nofile`, `filetype=markdown`, closeable with `q`
@@ -178,7 +178,7 @@ HimalayaAi Prompts
   tldr           You are an executive assistant triag...
 
 [e] edit config   [v] validate   [q] close
-```diff
+```
 
 - `e` opens config.lua in split (same as `:HimalayaAi edit`)
 - `v` prompts which prompt to test, then runs validation

--- a/docs/specs/SPEC-himalaya-editor-plugin-2026-02-11.md
+++ b/docs/specs/SPEC-himalaya-editor-plugin-2026-02-11.md
@@ -68,7 +68,7 @@ Evaluate and prototype a Himalaya email CLI integration plugin for editor enviro
 | claude/  | | w3m/bat/ |           |  Email Server    |
 | gemini   | | glow     |           |  (1 account)     |
 +----------+ +----------+           +------------------+
-```text
+```
 
 **6-layer architecture:** dispatcher -> himalaya adapter (`em-himalaya.zsh`) -> AI layer (`em-ai.zsh`) -> cache (`em-cache.zsh`) -> render (`em-render.zsh`) -> helpers (`email-helpers.zsh`)
 
@@ -86,7 +86,7 @@ Evaluate and prototype a Himalaya email CLI integration plugin for editor enviro
 | Editor-native UI |                   |  Email Server    |
 | (TreeView/buffer)|                   |  (1 account)     |
 +------------------+                   +------------------+
-```diff
+```
 
 ### Integration Pattern (All Editors)
 
@@ -130,7 +130,7 @@ N/A - No persistent data model. All data flows through Himalaya CLI JSON output.
   "date": "2026-02-11T10:00:00Z",
   "flags": ["Seen"]
 }
-```diff
+```
 
 ---
 
@@ -159,7 +159,7 @@ Open editor -> Click inbox icon / run command
     -> Keybinds: r(reply), f(forward), d(delete), a(archive)
     -> AI keybinds: ms(summarize), mt(todos), mr(draft-reply)
     -> Compose: opens editor buffer/modal, send on save/confirm
-```text
+```
 
 ### Wireframe (VS Code - Primary Target)
 

--- a/docs/specs/SPEC-latex-macros-2026-01-28.md
+++ b/docs/specs/SPEC-latex-macros-2026-01-28.md
@@ -89,7 +89,7 @@ graph TB
 
     CACHE --> LIST & DOC
     ASSOC --> VAL & ANA & SCH
-```yaml
+```
 
 ---
 
@@ -133,7 +133,7 @@ teaching_style:
     scholar:
       export_format: "json"
       include_in_prompts: true
-```zsh
+```
 
 ---
 
@@ -155,7 +155,7 @@ typeset -gA _FLOW_MACRO_META=(
   [Var]="_macros.qmd:6:0"
   [indep]="_macros.qmd:10:0"
 )
-```yaml
+```
 
 ### Cache File (.flow/macros.yml)
 
@@ -176,7 +176,7 @@ macros:
     description: Variance
     category: operators
     args: 0
-```diff
+```
 
 ---
 
@@ -214,7 +214,7 @@ sequenceDiagram
     User->>CLI: teach macros list
     CLI->>Cache: Read cached macros
     CLI->>User: Display formatted table
-```text
+```
 
 ### Output Examples
 
@@ -233,7 +233,7 @@ SYMBOLS
   \iid           → \text{i.i.d.}        IID notation
 
 Source: _macros.qmd (synced 2h ago)
-```text
+```
 
 **teach doctor (macro section):**
 

--- a/docs/specs/SPEC-nvim-himalaya-integration-2026-02-11.md
+++ b/docs/specs/SPEC-nvim-himalaya-integration-2026-02-11.md
@@ -64,7 +64,7 @@ The goal is NOT to build a new plugin from scratch. It is to configure an existi
 | claude -p /      |
 | gemini CLI       |
 +------------------+
-```diff
+```
 
 ### Integration Pattern
 
@@ -132,7 +132,7 @@ Open Neovim -> :Himalaya (or keybind)
     -> AI: <leader>ms(summarize), <leader>mt(todos), <leader>mr(draft)
     -> AI response appears in floating window
     -> Close float with q or <Esc>
-```text
+```
 
 ### Floating Window Spec
 

--- a/docs/specs/SPEC-project-cache-auto-discovery.md
+++ b/docs/specs/SPEC-project-cache-auto-discovery.md
@@ -30,7 +30,7 @@ _proj_list_all() {
     # Full filesystem scan EVERY TIME
     # 8 categories × 15 projects = 120 stat calls per pick invocation
 }
-```diff
+```
 
 **Impact:**
 - 100+ stat calls per `pick` invocation
@@ -44,7 +44,7 @@ _proj_list_all() {
 time pick >/dev/null
 # Current: ~200ms (100 projects)
 # Target: <10ms (cache hit)
-```bash
+```
 
 #### Issue 2: Hardcoded Category List (Medium - Extensibility)
 
@@ -57,7 +57,7 @@ PROJ_CATEGORIES=(
     "dev-tools:dev:🔧"
     # ... must manually update for new categories
 )
-```diff
+```
 
 **Impact:**
 - Users cannot add custom project directories
@@ -85,7 +85,7 @@ Phase 1: Caching Layer (v5.3.0)
 Phase 2: Auto-Discovery (v5.4.0)
    ↓
 Phase 3: Integration (v5.5.0)
-```text
+```
 
 ---
 
@@ -101,13 +101,13 @@ flow-cli|dev|🔧|/Users/dt/projects/dev-tools/flow-cli|🟢 2h
 aiterm|dev|🔧|/Users/dt/projects/dev-tools/aiterm|
 scribe|app|📱|/Users/dt/projects/apps/scribe|🟡 old
 ...
-```bash
+```
 
 **Cache Location:**
 
 ```bash
 ${XDG_CACHE_HOME:-$HOME/.cache}/flow-cli/projects.cache
-```bash
+```
 
 **TTL:** 5 minutes (balances freshness vs performance)
 
@@ -189,7 +189,7 @@ _format_duration() {
         echo "${secs}s"
     fi
 }
-```zsh
+```
 
 **Modified File:** `commands/pick.zsh`
 
@@ -201,14 +201,14 @@ _proj_list_all_uncached() {
 
 # New cached version (imports from lib/project-cache.zsh)
 # _proj_list_all() is now defined in project-cache.zsh
-```zsh
+```
 
 **Modified File:** `flow.plugin.zsh`
 
 ```zsh
 # Add after other lib/ sources
 source "$FLOW_PLUGIN_ROOT/lib/project-cache.zsh"
-```text
+```
 
 ### User Commands
 
@@ -218,7 +218,7 @@ source "$FLOW_PLUGIN_ROOT/lib/project-cache.zsh"
 flow cache refresh   # Manual invalidation (regenerate now)
 flow cache clear     # Delete cache file
 flow cache status    # Show cache age and stats
-```bash
+```
 
 **Implementation in `commands/flow.zsh`:**
 
@@ -245,7 +245,7 @@ flow-cache() {
             ;;
     esac
 }
-```diff
+```
 
 ### Rollout Strategy
 
@@ -258,7 +258,7 @@ flow-cache() {
 
 ```zsh
 export FLOW_CACHE_ENABLED=0  # Skip cache, use direct scan
-```diff
+```
 
 **Expected Issues:**
 - Stale cache after git clone in another terminal
@@ -300,7 +300,7 @@ work/internal:work:🏢
 
 # Override default icon for dev-tools
 dev-tools:dev:⚙️
-```zsh
+```
 
 ### Implementation
 
@@ -437,14 +437,14 @@ _proj_init_categories() {
         fi
     done
 }
-```bash
+```
 
 **Modified File:** `commands/pick.zsh`
 
 ```zsh
 # Remove hardcoded PROJ_CATEGORIES array (lines 9-18)
 # Now initialized by _proj_init_categories() in auto-discover.zsh
-```zsh
+```
 
 **Modified File:** `flow.plugin.zsh`
 
@@ -454,7 +454,7 @@ source "$FLOW_PLUGIN_ROOT/lib/project-auto-discover.zsh"
 
 # Initialize categories at startup
 _proj_init_categories
-```text
+```
 
 ### User Commands
 
@@ -463,7 +463,7 @@ _proj_init_categories
 ```bash
 flow discover        # Show discovered categories
 flow discover refresh # Re-scan filesystem
-```bash
+```
 
 **Implementation:**
 
@@ -491,7 +491,7 @@ flow-discover() {
             ;;
     esac
 }
-```diff
+```
 
 ### Rollout Strategy
 
@@ -537,7 +537,7 @@ local proj_icon=$(_flow_project_icon "$detected_type")
 # Override category type/icon with detected values if more specific
 local final_type="${detected_type:-$cat_type}"
 local final_icon="${proj_icon:-$cat_icon}"
-```diff
+```
 
 **Benefits:**
 - Quarto project in dev-tools → shows 📝 (not 🔧)
@@ -563,7 +563,7 @@ _flow_project_icon() {
         worktree) echo "🌳" ;;
     esac
 }
-```diff
+```
 
 ---
 
@@ -658,7 +658,7 @@ test_cache_stats() {
     assert_contains "$output" "Cache age:"
     assert_contains "$output" "Projects cached:"
 }
-```bash
+```
 
 **New Test Suite:** `tests/test-auto-discover.zsh`
 
@@ -697,7 +697,7 @@ test_fallback_to_hardcoded() {
 
     rm -rf "$FLOW_PROJECTS_ROOT"
 }
-```bash
+```
 
 ### Integration Tests
 
@@ -732,7 +732,7 @@ flow cache refresh
 # 8. Verify new project appears
 pick dev | grep new-tool
 # Expected: new-tool appears in picker
-```bash
+```
 
 ### Performance Benchmarks
 
@@ -763,7 +763,7 @@ echo "With cache - subsequent runs (hot, 10 runs):"
 for i in {1..10}; do
     /usr/bin/time -p pick >/dev/null 2>&1
 done | grep real | awk '{sum+=$2; count++} END {print "Average:", sum/count, "seconds"}'
-```text
+```
 
 **Expected Results:**
 
@@ -771,7 +771,7 @@ done | grep real | awk '{sum+=$2; count++} END {print "Average:", sum/count, "se
 Without cache: ~0.20s average
 With cache (cold): ~0.20s (initial generation)
 With cache (hot): ~0.005s average (40x faster)
-```yaml
+```
 
 ---
 
@@ -875,7 +875,7 @@ _proj_watch_filesystem() {
         done &
     fi
 }
-```zsh
+```
 
 ### Parallel Category Scanning (v5.7.0)
 
@@ -897,7 +897,7 @@ _proj_cache_generate_parallel() {
     cat "${tmpfiles[@]}" > "$PROJ_CACHE_FILE"
     rm -f "${tmpfiles[@]}"
 }
-```bash
+```
 
 ### Remote Cache Sync (v6.0.0)
 

--- a/docs/specs/SPEC-teach-comprehensive-2026-02-02.md
+++ b/docs/specs/SPEC-teach-comprehensive-2026-02-02.md
@@ -114,7 +114,7 @@ flowchart TD
     end
 
     GAP --> NEW
-```text
+```
 
 ### Deliverable Dependencies
 
@@ -128,7 +128,7 @@ flowchart LR
     D --> F[6. mkdocs.yml + build verify]
     E --> F
     F --> G[7. Bidirectional cross-references]
-```text
+```
 
 ---
 
@@ -173,7 +173,7 @@ flowchart LR
 | teach archive | a | teach archive [SEMESTER] | Archive course |
 | teach hooks | hook | teach hooks [install|remove|status] | Git hooks |
 | teach profiles | prof | teach profiles [list|switch|create] | Profile management |
-```text
+```
 
 **Cross-references:** Link each command to its detailed documentation (guide, tutorial, or REFCARD).
 
@@ -227,7 +227,7 @@ flowchart LR
 - Generating a full week of content
 - Creating an exam from lesson plan
 - Customizing output with prompts and macros
-```text
+```
 
 **Mermaid Diagrams Required:**
 
@@ -237,13 +237,13 @@ flowchart LR
 teach exam → Scholar Plugin → Claude → Output
                 ↑
          teach-config.yml + prompts + macros
-```text
+```
 
 1. **Config Resolution Chain:**
 
 ```text
 Course (.flow/prompts/) > User (~/.flow/prompts/) > Plugin (defaults)
-```text
+```
 
 ---
 
@@ -292,7 +292,7 @@ Course (.flow/prompts/) > User (~/.flow/prompts/) > Plugin (defaults)
 - semester_info.weeks[].number must be unique integers
 - semester_info.weeks[].style must be one of: conceptual, computational, rigorous, applied
 - ...
-```text
+```
 
 **Example:** Full annotated STAT-101 demo course config.
 
@@ -328,7 +328,7 @@ Course (.flow/prompts/) > User (~/.flow/prompts/) > Plugin (defaults)
 - Common deployment issues
 - Permission errors
 - Build failures
-```diff
+```
 
 ---
 
@@ -363,7 +363,7 @@ Four diagrams distributed across deliverables:
 init → config → plan → [generate content] → validate → deploy
                          ↓
               lecture / exam / quiz / slides / ...
-```text
+```
 
 **Command Taxonomy:**
 
@@ -382,7 +382,7 @@ teach
 └── Infrastructure
     ├── doctor, dates, cache, clean
     └── hooks, profiles
-```diff
+```
 
 ---
 
@@ -397,14 +397,14 @@ Add to the `Teaching > Reference > Quick Reference Cards` section:
 - Content Analysis: reference/REFCARD-ANALYSIS.md
 - Date Management: reference/REFCARD-DATES.md
 - Health Check: reference/REFCARD-DOCTOR.md
-```diff
+```
 
 Add to the `Teaching > Core Workflows` section:
 
 ```yaml
 - Scholar Wrappers: guides/SCHOLAR-WRAPPERS-GUIDE.md
 - Deployment: guides/TEACH-DEPLOY-GUIDE.md
-```text
+```
 
 Add to the `Teaching > Reference` section:
 

--- a/docs/specs/SPEC-teach-deploy-safety-2026-02-08.md
+++ b/docs/specs/SPEC-teach-deploy-safety-2026-02-08.md
@@ -69,7 +69,7 @@ _teach_deploy_enhanced()
 
 _deploy_summary_box()
     +-- [NEW] Actions URL line (always)
-```diff
+```
 
 No new files. All changes in existing files.
 
@@ -124,7 +124,7 @@ _deploy_direct_merge() {
     trap - EXIT INT TERM
     return 0
 }
-```bash
+```
 
 **In PR mode section (line ~854):**
 
@@ -136,7 +136,7 @@ trap "git checkout '$draft_branch' 2>/dev/null" EXIT INT TERM
 
 # Clear trap before _deploy_cleanup_globals
 trap - EXIT INT TERM
-```bash
+```
 
 **Risk:** Low. Trap is additive. Existing manual checkout calls remain as belt-and-suspenders.
 
@@ -161,7 +161,7 @@ if ! git commit -m "$commit_msg"; then
     echo "  ${FLOW_COLORS[dim]}Your changes are still staged. Nothing was lost.${FLOW_COLORS[reset]}"
     return 1
 fi
-```bash
+```
 
 **CI mode:** Same message, exits non-zero (no interactive options).
 
@@ -181,7 +181,7 @@ repo_slug=$(git config --get remote.origin.url 2>/dev/null | \
 if [[ -n "$repo_slug" && "$repo_slug" != "$(git config --get remote.origin.url)" ]]; then
     printf "│  %-10s %-42s│\n" "Actions:" "https://github.com/${repo_slug}/actions"
 fi
-```bash
+```
 
 **Always shown.** If the remote URL isn't GitHub, the regex won't match and the line is skipped.
 
@@ -238,7 +238,7 @@ if ! _git_is_clean; then
             ;;
     esac
 fi
-```text
+```
 
 **Note:** This replaces the existing `require_clean` check for the prompt path. The `require_clean` config option is still respected: if set to `false`, this block is skipped entirely (already handled by preflight).
 
@@ -252,7 +252,7 @@ fi
   Uncommitted changes detected
   Suggested: content: week-05 lecture
   Commit and continue? [Y/n]:
-```text
+```
 
 Uses `FLOW_COLORS[warn]` for header, `FLOW_COLORS[info]` for suggested message, `FLOW_COLORS[prompt]` for input.
 
@@ -267,7 +267,7 @@ Uses `FLOW_COLORS[warn]` for header, `FLOW_COLORS[info]` for suggested message, 
     3. Force commit: git commit --no-verify -m "message"
 
   Changes are still staged.
-```text
+```
 
 ### Deploy Summary Box (Updated)
 

--- a/docs/specs/SPEC-teach-deploy-v2-2026-02-03.md
+++ b/docs/specs/SPEC-teach-deploy-v2-2026-02-03.md
@@ -63,7 +63,7 @@ teach deploy [args]
       └── Post-deploy:
           ├── _deploy_history_append()
           └── _deploy_update_status_file()
-```yaml
+```
 
 ---
 
@@ -103,7 +103,7 @@ deploys:
     tag: null
     user: 'dt'
     duration_seconds: 12
-```diff
+```
 
 ---
 
@@ -141,7 +141,7 @@ deploys:
 
   Done in 11s
   Site: https://example.github.io/stat-545/
-```text
+```
 
 ### Dry-Run Output
 
@@ -157,7 +157,7 @@ deploys:
   Would merge: draft -> production (direct mode)
   Would log: deploy #12 to .flow/deploy-history.yml
   Would update: .STATUS (teaching_week: 5)
-```text
+```
 
 ### Rollback Interactive
 

--- a/docs/specs/SPEC-teach-doctor-v2-2026-02-07.md
+++ b/docs/specs/SPEC-teach-doctor-v2-2026-02-07.md
@@ -81,7 +81,7 @@ teach doctor [flags]
        |
        |-- _teach_doctor_summary()  # Severity-grouped
        +-- Exit code (0=ok, 1=failures)
-```text
+```
 
 ### Status Line Integration
 
@@ -90,7 +90,7 @@ teach [any subcommand]
   -> Check last doctor result (file-based, no cache TTL)
   -> If stale or missing: run quick doctor silently
   -> Show dot in header: green/yellow/red
-```zsh
+```
 
 ---
 
@@ -114,7 +114,7 @@ _teach_doctor_check_quarto_extensions() {
     local ext_count=${#ext_dirs}
     # ... rest of function uses ext_count safely ...
 }
-```bash
+```
 
 ### Bug Fix 2: R Package False Negatives (renv Isolation)
 
@@ -137,7 +137,7 @@ _teach_doctor_check_r_packages() {
     # Compare against expected packages
     # ...
 }
-```zsh
+```
 
 ### Bug Fix 3: Section Nesting
 
@@ -174,7 +174,7 @@ _teach_doctor_spinner_start() {
 _teach_doctor_spinner_stop() {
     # Stop spinner, show result
 }
-```text
+```
 
 Implementation: Background subshell writes spinner characters to `/dev/tty`. Main process sends SIGUSR1 or writes to a named pipe to stop it. Elapsed time updates every second after 5s threshold.
 
@@ -190,7 +190,7 @@ Failures (2):
 
 Warnings: 3 | Passed: 12
 ────────────────────────────────────────────────────────────
-```text
+```
 
 ### Feature: renv-Aware R Section
 
@@ -200,7 +200,7 @@ Warnings: 3 | Passed: 12
 R Environment:
   ok R (4.4.2) | renv active | library synced
      -> Run --full for 27 package details
-```text
+```
 
 **Full mode output:**
 
@@ -211,7 +211,7 @@ R Environment:
   ok renv.lock last updated: 2026-02-01
   ok renv sync: 27/27 packages match lock file
   ok R: 25/27 installed | Missing: pkgA, pkgB
-```diff
+```
 
 **renv detection details:**
 - renv status: active/inactive (check `renv/activate.R` exists + sourced in `.Rprofile`)
@@ -228,7 +228,7 @@ Missing R packages: pkgA, pkgB
   -> Install via renv or system? [r/s]
   r) renv::install(c("pkgA", "pkgB"))  # Project-local
   s) install.packages(c("pkgA", "pkgB"))  # System-wide
-```zsh
+```
 
 ### Feature: Status Line Health Indicator
 
@@ -240,7 +240,7 @@ _teach_health_indicator() {
     # If file missing or > 1 hour old, run quick doctor silently
     # Return emoji: green_dot / yellow_dot / red_dot
 }
-```text
+```
 
 Status file: `.flow/doctor-status.json`
 
@@ -252,7 +252,7 @@ Status file: `.flow/doctor-status.json`
     "failures": 0,
     "status": "yellow"
 }
-```bash
+```
 
 ### Feature: --ci Mode + GitHub Action
 
@@ -263,7 +263,7 @@ Status file: `.flow/doctor-status.json`
 # - Exit code 1 on any failure
 # - Stdout: machine-parseable summary
 # - Compatible with GitHub Actions annotation format
-```bash
+```
 
 GitHub Action integration (future):
 
@@ -271,7 +271,7 @@ GitHub Action integration (future):
 # .github/workflows/teach-doctor.yml
 - name: Check teaching environment
   run: teach doctor --ci
-```diff
+```
 
 ### Feature: --brief (renamed from --quiet)
 
@@ -307,7 +307,7 @@ N/A - CLI command, no API changes.
     "totals": {"passed": 14, "warnings": 1, "failures": 0},
     "status": "yellow"
 }
-```yaml
+```
 
 ---
 
@@ -348,7 +348,7 @@ Git:
 Skipped (run --full): quarto extensions, hooks, cache, macros, style
 
 Summary: 14 passed, 0 warnings, 0 failures
-```text
+```
 
 ### Full Mode Output
 

--- a/docs/specs/SPEC-teach-map-2026-02-08.md
+++ b/docs/specs/SPEC-teach-map-2026-02-08.md
@@ -59,7 +59,7 @@ _teach_map()
          +-- Phase: VALIDATION & QUALITY
          +-- Phase: DEPLOYMENT
          +-- Phase: SEMESTER TRACKING
-```text
+```
 
 Single function in `teach-dispatcher.zsh`. No new files.
 
@@ -74,7 +74,7 @@ N/A -- No API changes. This is a pure ZSH print function.
 ```text
 teach map          # Show full ecosystem map
 teach map --help   # Same as teach map (it IS the help)
-```diff
+```
 
 **Aliases:** `map` only (no shortcut needed -- it's a discovery command, not a daily-use one).
 

--- a/docs/specs/SPEC-teach-plan-v2-2026-01-29.md
+++ b/docs/specs/SPEC-teach-plan-v2-2026-01-29.md
@@ -79,7 +79,7 @@ teach plan show <week> [--json]
 teach plan edit <week>
 teach plan delete <week> [--force]
 teach plan help
-```yaml
+```
 
 **Shortcuts:** `teach pl`, `teach plan c`, `teach plan ls`, `teach plan s`
 
@@ -106,7 +106,7 @@ weeks:
     topic: "Probability Foundations"
     style: "rigorous"
     # ...
-```text
+```
 
 ---
 
@@ -127,7 +127,7 @@ Load guard + source deps
      ├─ _teach_plan_edit()   # Extract → $EDITOR → merge back
      ├─ _teach_plan_delete() # Remove from weeks[] array
      └─ _teach_plan_help()   # Standard help output
-```bash
+```
 
 ### Dispatch Integration
 
@@ -141,7 +141,7 @@ plan|pl)
         *) _teach_plan "$@" ;;
     esac
     ;;
-```bash
+```
 
 ### Source Loading (teach-dispatcher.zsh header)
 

--- a/docs/specs/SPEC-teach-prompt-v2-2026-01-29.md
+++ b/docs/specs/SPEC-teach-prompt-v2-2026-01-29.md
@@ -58,7 +58,7 @@ Priority 2: User defaults
 
 Priority 3 (lowest): Plugin defaults
   lib/templates/teaching/claude-prompts/<name>.md
-```text
+```
 
 Resolution rule: First match wins.
 
@@ -74,7 +74,7 @@ teach lecture "ANOVA"
     -> scholar_cmd += --prompt "$rendered"
   -> Scholar merges with 4-layer style system
   -> Content generated
-```diff
+```
 
 ### Prompt File Format
 
@@ -99,7 +99,7 @@ Generate instructor-facing lecture notes for {{COURSE}} ...
 
 ## Structure Requirements
 ...
-```diff
+```
 
 ---
 
@@ -152,7 +152,7 @@ Available Teaching Prompts
 Legend: [C] Course  [U] User  [P] Plugin  * = overrides lower tier
 
 Usage: teach prompt show <name> to view
-```text
+```
 
 ### `teach prompt show <name>` (error)
 
@@ -163,7 +163,7 @@ Available prompts:
   lecture-notes, revealjs-slides, derivations-appendix
 
 Run 'teach prompt list' for details
-```text
+```
 
 ### `teach prompt validate`
 
@@ -176,7 +176,7 @@ Validating teaching prompts...
   ✗ custom-broken          Error: invalid YAML frontmatter
 
 3 valid, 1 warning, 1 error
-```diff
+```
 
 ---
 

--- a/docs/specs/SPEC-template-support-2026-01-28.md
+++ b/docs/specs/SPEC-template-support-2026-01-28.md
@@ -61,7 +61,7 @@ Add support for project-local templates at `.flow/templates/` with discovery, co
 └── checklists/                 # QA checklists
     ├── pre-publish.md
     └── new-content.md
-```text
+```
 
 ### Plugin Templates (Defaults)
 
@@ -74,14 +74,14 @@ lib/templates/teaching/         # Already exists
 ├── teach-config.yml.template
 ├── lecture-with-concepts.qmd.template
 └── ...
-```text
+```
 
 ### Resolution Order
 
 ```text
 1. .flow/templates/<type>/<name>     # Project (highest priority)
 2. lib/templates/teaching/<name>     # Plugin (fallback)
-```yaml
+```
 
 ---
 
@@ -101,7 +101,7 @@ template_variables:
   - DATE                           # Current date (auto-filled)
   - INSTRUCTOR                     # Instructor name (from teach-config.yml)
 ---
-```diff
+```
 
 ### Variable Substitution
 
@@ -137,7 +137,7 @@ teach templates                    # Alias for 'teach templates list'
 teach templates list               # List all templates
 teach templates list --type content   # Filter by type
 teach templates list --source project # Show only project templates
-```text
+```
 
 **Output:**
 
@@ -158,7 +158,7 @@ teach templates list --source project # Show only project templates
 │ Legend: [P] = Project, [D] = Default (plugin)                │
 │                                                              │
 └──────────────────────────────────────────────────────────────┘
-```diff
+```
 
 **Flags:**
 - `--type TYPE` - Filter by type: content, prompts, metadata, checklists
@@ -182,7 +182,7 @@ teach templates new lecture week-05              # → lectures/week-05/lecture.
 teach templates new lab week-03                  # → labs/week-03/lab.qmd
 teach templates new slides "ANOVA" --week 6      # → slides/week-06/slides-anova.qmd
 teach templates new assignment "Homework 1"      # → assignments/homework-1.qmd
-```yaml
+```
 
 **UX Flow:**
 
@@ -204,7 +204,7 @@ Preview:
   lectures/week-05/lecture-05-linear-regression.qmd
 
 ✓ Created: lectures/week-05/lecture-05-linear-regression.qmd
-```diff
+```
 
 **Flags:**
 - `--dry-run` - Preview without creating file
@@ -235,7 +235,7 @@ Preview:
 ```bash
 teach templates validate                 # Validate all project templates
 teach templates validate lecture.qmd     # Validate specific template
-```text
+```
 
 **Output:**
 
@@ -257,7 +257,7 @@ teach templates validate lecture.qmd     # Validate specific template
 │ Summary: 4 templates, 3 valid, 1 warning                     │
 │                                                              │
 └──────────────────────────────────────────────────────────────┘
-```diff
+```
 
 ---
 
@@ -274,7 +274,7 @@ teach templates validate lecture.qmd     # Validate specific template
 teach templates sync                     # Sync all from plugin
 teach templates sync --dry-run           # Preview what would change
 teach templates sync lecture.qmd         # Sync specific template
-```text
+```
 
 **UX Flow:**
 
@@ -292,7 +292,7 @@ Would skip:
   content/slides.qmd      v1.2 > v1.0 (project is newer)
 
 Run without --dry-run to apply changes.
-```diff
+```
 
 **Flags:**
 - `--dry-run` - Preview without changes
@@ -318,7 +318,7 @@ Run without --dry-run to apply changes.
 ```bash
 teach init "STAT 545" --with-templates    # Create course with templates
 teach init --with-templates               # Add templates to existing course
-```yaml
+```
 
 **UX Flow:**
 
@@ -341,7 +341,7 @@ Templates:
 Next steps:
   teach templates list              # View available templates
   teach templates new lecture week-01   # Create first lecture
-```python
+```
 
 ---
 
@@ -364,7 +364,7 @@ def get_prompt(prompt_type: str, course_dir: str) -> str:
     if local_prompt.exists():
         return local_prompt.read_text()
     return get_default_prompt(prompt_type)
-```diff
+```
 
 **Prompt Types:**
 - `lecture-notes` → `lecture-notes.md`
@@ -414,7 +414,7 @@ def get_prompt(prompt_type: str, course_dir: str) -> str:
 │   lib/templates/teaching/   Plugin defaults (fallback)       │
 │                                                              │
 └──────────────────────────────────────────────────────────────┘
-```bash
+```
 
 ---
 
@@ -449,7 +449,7 @@ test_templates_sync_creates_directory
 test_templates_sync_dry_run
 test_templates_sync_skips_newer_project
 test_templates_sync_creates_backup
-```bash
+```
 
 ### Integration Tests
 
@@ -458,7 +458,7 @@ test_templates_sync_creates_backup
 test_init_with_templates_creates_structure
 test_new_lecture_then_edit_workflow
 test_scholar_uses_local_prompt
-```bash
+```
 
 ---
 
@@ -475,7 +475,7 @@ teach init --with-templates
 # Or manually create structure
 mkdir -p .flow/templates/{content,prompts,metadata,checklists}
 teach templates sync
-```diff
+```
 
 ### stat-545 Course
 
@@ -545,7 +545,7 @@ By the end of this lecture, students will be able to:
 ## Summary
 
 ## Next Steps
-```diff
+```
 
 ### prompts/lecture-notes.md
 

--- a/docs/specs/TEACH-DOCTOR-V2-IMPLEMENTATION.md
+++ b/docs/specs/TEACH-DOCTOR-V2-IMPLEMENTATION.md
@@ -35,7 +35,7 @@
 
 ```bash
 teach doctor
-```text
+```
 
 **Output:**
 
@@ -97,13 +97,13 @@ Cache Health:
 ────────────────────────────────────────────────────────────
 Summary: 28 passed, 0 warnings, 0 failures
 ────────────────────────────────────────────────────────────
-```text
+```
 
 ### Interactive Fix Mode
 
 ```bash
 teach doctor --fix
-```text
+```
 
 **Interactive Prompts:**
 
@@ -128,13 +128,13 @@ R Packages:
 Cache Health:
   ⚠ Cache is stale (31 days old)
   → Clear stale cache? [y/N] n
-```text
+```
 
 ### Brief Mode
 
 ```bash
 teach doctor --brief
-```text
+```
 
 **Only shows warnings and failures:**
 
@@ -151,13 +151,13 @@ teach doctor --brief
 ────────────────────────────────────────────────────────────
 Summary: 25 passed, 3 warnings, 0 failures
 ────────────────────────────────────────────────────────────
-```text
+```
 
 ### JSON Output (CI/CD)
 
 ```bash
 teach doctor --json
-```text
+```
 
 **Output:**
 
@@ -184,7 +184,7 @@ teach doctor --json
     {"check":"cache_freshness","status":"warn","message":"31 days old"}
   ]
 }
-```bash
+```
 
 **CI/CD Integration:**
 
@@ -194,7 +194,7 @@ teach doctor --json
   run: |
     teach doctor --json > health.json
     jq -e '.summary.status == "healthy"' health.json
-```yaml
+```
 
 ---
 
@@ -305,7 +305,7 @@ teach doctor
   │   └── _teach_doctor_check_cache()
   ├── Result tracking (passed, warnings, failures)
   └── Output formatting (text or JSON)
-```zsh
+```
 
 ### State Variables
 
@@ -317,7 +317,7 @@ local -i passed=0      # Pass counter
 local -i warnings=0    # Warning counter
 local -i failures=0    # Failure counter
 local -a json_results  # JSON result array
-```text
+```
 
 ### Helper Functions
 
@@ -327,13 +327,13 @@ local -a json_results  # JSON result array
 _teach_doctor_pass "message"              # ✓ green
 _teach_doctor_warn "message" "fix hint"   # ⚠ yellow
 _teach_doctor_fail "message" "fix hint"   # ✗ red
-```text
+```
 
 **Interactive Fix:**
 
 ```zsh
 _teach_doctor_interactive_fix "name" "install_cmd" ["optional"]
-```text
+```
 
 **Specialized Checks:**
 
@@ -341,7 +341,7 @@ _teach_doctor_interactive_fix "name" "install_cmd" ["optional"]
 _teach_doctor_check_dep "name" "cmd" "fix_cmd" "required"
 _teach_doctor_check_r_packages
 _teach_doctor_check_quarto_extensions
-```text
+```
 
 ### JSON Result Format
 
@@ -349,7 +349,7 @@ Each check appends to `json_results` array:
 
 ```zsh
 json_results+=("{\"check\":\"$name\",\"status\":\"$status\",\"message\":\"$msg\"}")
-```diff
+```
 
 **Status values:** `pass`, `warn`, `fail`
 
@@ -433,14 +433,14 @@ Passed:        39
 Failed:        0
 
 All tests passed! ✓
-```bash
+```
 
 ### Demo Script
 
 ```bash
 # Interactive demo
 ./tests/demo-teach-doctor.sh
-```diff
+```
 
 ---
 
@@ -471,7 +471,7 @@ Uses flow-cli standard colors:
 ✗ Failure   - FLOW_COLORS[error]    # Soft red
 → Action    - FLOW_COLORS[info]     # Calm blue
   Muted     - FLOW_COLORS[muted]    # Gray
-```diff
+```
 
 ---
 
@@ -505,7 +505,7 @@ which yq
 
 # Reinstall
 brew reinstall yq
-```bash
+```
 
 **Issue:** R packages check fails
 
@@ -513,7 +513,7 @@ brew reinstall yq
 # Install R packages manually
 R
 > install.packages(c("ggplot2", "dplyr", "tidyr", "knitr", "rmarkdown"))
-```bash
+```
 
 **Issue:** Git hooks show as "not installed" but exist
 
@@ -523,21 +523,21 @@ ls -la .git/hooks/
 
 # Make executable
 chmod +x .git/hooks/pre-commit
-```bash
+```
 
 **Issue:** Cache freshness check incorrect
 
 ```bash
 # Verify _freeze timestamps
 find _freeze -type f -exec stat -f "%m %N" {} \; | sort -rn | head
-```bash
+```
 
 ### Debug Mode
 
 ```bash
 # Enable debug output
 FLOW_DEBUG=1 teach doctor
-```text
+```
 
 ---
 
@@ -547,7 +547,7 @@ FLOW_DEBUG=1 teach doctor
 
 ```zsh
 _teach_doctor [OPTIONS]
-```diff
+```
 
 **Options:**
 - `--brief` - Only show warnings and failures
@@ -564,7 +564,7 @@ _teach_doctor_check_git()
 _teach_doctor_check_scholar()
 _teach_doctor_check_hooks()
 _teach_doctor_check_cache()
-```text
+```
 
 ### Helper Functions
 

--- a/docs/specs/TEACH-DOCTOR-V2-SUMMARY.md
+++ b/docs/specs/TEACH-DOCTOR-V2-SUMMARY.md
@@ -140,7 +140,7 @@
   → Install yq? [Y/n] y
   → brew install yq
   ✓ yq installed
-```diff
+```
 
 **Supported fixes:**
 
@@ -166,7 +166,7 @@
     ...
   ]
 }
-```text
+```
 
 **GitHub Actions Example:**
 
@@ -175,7 +175,7 @@
   run: |
     teach doctor --json > health.json
     jq -e '.summary.status == "healthy"' health.json
-```diff
+```
 
 ### 4. Performance
 
@@ -236,7 +236,7 @@
 
 ```bash
 teach doctor
-```text
+```
 
 **Output:** Complete health report with all 6 categories
 
@@ -244,7 +244,7 @@ teach doctor
 
 ```bash
 teach doctor --quiet
-```text
+```
 
 **Output:** Only warnings and failures
 
@@ -252,7 +252,7 @@ teach doctor --quiet
 
 ```bash
 teach doctor --fix
-```bash
+```
 
 **Output:** Prompts to install missing dependencies
 
@@ -261,13 +261,13 @@ teach doctor --fix
 ```bash
 teach doctor --json | jq '.summary.status'
 # Output: "healthy" or "unhealthy"
-```text
+```
 
 ### Get Help
 
 ```bash
 teach doctor --help
-```text
+```
 
 **Output:** Complete usage guide with examples
 
@@ -286,7 +286,7 @@ Test Summary:
   Failed:        0
 
 All tests passed! ✓
-```bash
+```
 
 **Test execution time:** ~5 seconds
 
@@ -303,7 +303,7 @@ All tests passed! ✓
 doctor)
     _teach_doctor "$@"
     ;;
-```bash
+```
 
 **Usage:** `teach doctor [OPTIONS]`
 

--- a/docs/specs/TEST-PLAN-EM-REVIEW.md
+++ b/docs/specs/TEST-PLAN-EM-REVIEW.md
@@ -22,7 +22,7 @@
 
 ```zsh
 em respond --count 3
-```bash
+```
 
 **Expected behavior:**
 1. Header: `em respond — scanning 3 emails in INBOX`
@@ -45,7 +45,7 @@ em respond --count 3
 ```zsh
 em cache stats
 # Should show: drafts  N items  ...  TTL=1h
-```text
+```
 
 ---
 
@@ -55,7 +55,7 @@ em cache stats
 
 ```zsh
 em respond --review --count 3
-```diff
+```
 
 **Expected behavior:**
 1. Header: `em respond --review — reviewing cached drafts in INBOX`
@@ -91,7 +91,7 @@ em respond --review --count 3
 ```zsh
 em cache clear
 em respond --review --count 3
-```text
+```
 
 **Expected behavior:**
 1. Header: `em respond --review — reviewing cached drafts in INBOX`
@@ -109,7 +109,7 @@ em respond --review --count 3
 
 ```zsh
 em respond -R --count 3
-```bash
+```
 
 **Expected:** Same behavior as `em respond --review --count 3`.
 
@@ -130,7 +130,7 @@ em respond --review --count 1
 # → Y to review
 # → Edit draft in $EDITOR if needed
 # → y to send
-```diff
+```
 
 **Expected:**
 - Draft opens in $EDITOR with cached content
@@ -145,7 +145,7 @@ em respond --review --count 1
 
 ```zsh
 em respond --dry-run --count 3
-```diff
+```
 
 **Expected:**
 - Classifies emails with category icons
@@ -159,7 +159,7 @@ em respond --dry-run --count 3
 
 ```zsh
 em respond --help
-```diff
+```
 
 **Verify these lines appear:**
 - `em respond --review|-R  Review/send cached drafts (skip classification)`
@@ -176,7 +176,7 @@ em respond --review --folder Sent --count 5
 
 # Review with custom count
 em respond -R -n 10
-```bash
+```
 
 **Expected:** Flags combine correctly, no errors.
 

--- a/docs/specs/UX-SPEC-prompt-management-2026-01-21.md
+++ b/docs/specs/UX-SPEC-prompt-management-2026-01-21.md
@@ -25,7 +25,7 @@ This document specifies the **complete user experience** for managing teaching p
 
 ```bash
 teach prompt show <type>
-```bash
+```
 
 ### Behavior
 
@@ -50,7 +50,7 @@ Compatible with: flow-cli 5.14.0+, Scholar 2.x
 Generate instructor-facing lecture notes (20-40 pages) for statistics courses...
 
 (Press q to quit, / to search, space for next page)
-```bash
+```
 
 ### Implementation
 
@@ -73,7 +73,7 @@ _teach_prompt_show() {
     echo "📍 Location: $prompt_file"
     echo "🔧 Edit: teach prompt edit $type"
 }
-```text
+```
 
 ---
 
@@ -83,7 +83,7 @@ _teach_prompt_show() {
 
 ```bash
 teach prompt edit <type>
-```yaml
+```
 
 ### Behavior: Copy to Course, Then Edit
 
@@ -123,7 +123,7 @@ Next steps:
   1. Test: teach lecture "Test Topic"
   2. Commit: git add .claude/prompts/ && git commit
   3. Promote to global: teach prompt promote lecture (if you want to use in all courses)
-```text
+```
 
 ### Edge Cases
 
@@ -140,7 +140,7 @@ $ teach prompt edit lecture
 Opening in: $EDITOR
 
 (No copy needed, directly edit local version)
-```text
+```
 
 #### Case 2: No Global, Only Local
 
@@ -155,7 +155,7 @@ $ teach prompt edit lecture
    This prompt is unique to this course
 
 Opening in: $EDITOR
-```text
+```
 
 ---
 
@@ -165,7 +165,7 @@ Opening in: $EDITOR
 
 ```bash
 teach prompt enhance <type>
-```sql
+```
 
 ### Behavior: Interactive Wizard
 
@@ -284,7 +284,7 @@ Next steps:
   1. Test: teach lecture "Test Topic"
   2. Review: teach prompt show lecture (will use enhanced version)
   3. Promote: teach prompt promote lecture (if you want to use globally)
-```text
+```
 
 ---
 
@@ -294,7 +294,7 @@ Next steps:
 
 ```bash
 teach prompt add <name>
-```diff
+```
 
 ### Behavior: Ask Every Time (Detailed Explanation)
 
@@ -382,7 +382,7 @@ Next steps:
      (Optional: adds 'teach lab "Topic"' command)
   2. Use: teach prompt show lab-worksheet
   3. Test: Generate content with Scholar or direct use
-```text
+```
 
 ---
 
@@ -392,7 +392,7 @@ Next steps:
 
 ```bash
 teach prompt promote <type>
-```yaml
+```
 
 ### Behavior: Copy Local → Global
 
@@ -454,7 +454,7 @@ New global version:
 Next steps:
   1. Test in new course: cd ~/teaching/new-course && teach lecture "Topic"
   2. Rollback if needed: teach prompt restore lecture-notes-v1.0.0-backup
-```bash
+```
 
 ---
 
@@ -477,7 +477,7 @@ _detect_prompt_conflict() {
     fi
     return 1
 }
-```yaml
+```
 
 **Resolution Workflow:**
 
@@ -558,7 +558,7 @@ Generating lecture "ANOVA" with course-specific customizations...
 
 💡 Tip: To always use local in this course, run:
    teach prompt prefer local
-```yaml
+```
 
 ---
 
@@ -576,7 +576,7 @@ prompts:
   default_save_location: global  # global | local
   always_confirm: true           # Show default, allow override
   auto_promote: false            # Prompt before promoting
-```text
+```
 
 **Behavior with Preference:**
 
@@ -598,7 +598,7 @@ Choice [g/l] (default: g): [Enter]
 ✅ Using default: global
 
 Creating prompt...
-```diff
+```
 
 ---
 
@@ -729,7 +729,7 @@ teach prompt edit lecture
          ↓
    Show next steps
    (test, commit, promote)
-```text
+```
 
 ### Add Prompt Flow
 
@@ -752,7 +752,7 @@ teach prompt add exam
          ↓
    Show next steps
    (register, test)
-```text
+```
 
 ### Conflict Resolution Flow
 

--- a/docs/specs/UX-WORKFLOW-ANALYSIS-2026-01-09.md
+++ b/docs/specs/UX-WORKFLOW-ANALYSIS-2026-01-09.md
@@ -219,7 +219,7 @@ win "Fixed bug"           # Log win
 flow goal                 # Check progress manually
 # ...end of day...
 yay --week                # Review wins manually
-```diff
+```
 
 **Problems:**
 - No automatic "you hit your goal!" celebration
@@ -248,7 +248,7 @@ why                       # Shows current project + last commit
 trail                     # Shows breadcrumbs
 git log -3                # Recent commits
 cat .STATUS               # Check focus field
-```bash
+```
 
 **Recommendation:** Single command to restore context
 
@@ -260,7 +260,7 @@ flow resume               # or `flow context`
 # - Current focus from .STATUS
 # - Recent breadcrumbs
 # - Next task suggestion
-```diff
+```
 
 #### 4. Break Management Workflow
 
@@ -280,7 +280,7 @@ brk                       # Smart break workflow
 # 2. Show timer + break suggestion
 # 3. After break: restore context
 # 4. Suggest easy warmup task
-```yaml
+```
 
 ---
 
@@ -345,7 +345,7 @@ if [[ $wins_today -ge $daily_goal ]]; then
   echo "You did $wins_today wins today!"
   echo ""
 fi
-```bash
+```
 
 **Medium effort:**
 
@@ -353,14 +353,14 @@ fi
 # Streak grace period
 ## Instead of: streak = 0
 ## Use: streak_buffer = 1 (allow 1 missed day)
-```text
+```
 
 **Long term:**
 
 ```bash
 flow share                # Share today's wins to Slack/Discord
 flow team                 # Team dashboard (shared wins)
-```diff
+```
 
 ### Overwhelm (dash complexity vs quick info)
 
@@ -388,14 +388,14 @@ Today: 2/3 wins · 2h 15m · 🔥 5 days
 🎯 Next: Review PR #185
 
 💡 Tip: Try `morning` to plan your day
-```bash
+```
 
 **2. Full dash (opt-in):**
 
 ```bash
 dash -v    # or dash --full
 # Current 50+ line output
-```bash
+```
 
 ### Paralysis (js vs next vs stuck)
 
@@ -421,7 +421,7 @@ flow stuck               # Smart workflow
 # - Mid-task → "Try `brk` for a break"
 # - Multiple tasks → "Try `next --ai` for priority"
 # - Frustrated → "Try `stuck --ai` for help"
-```text
+```
 
 ---
 
@@ -439,7 +439,7 @@ flow goal                 # Check goal
 dash                      # Review projects
 next                      # Pick task
 work project              # Start
-```bash
+```
 
 **Recommendation:** Integrated morning workflow
 
@@ -450,7 +450,7 @@ morning                   # Single command
 # 3. Show top 3 projects (frecency)
 # 4. AI suggest: "Start with X because..."
 # 5. Offer to launch with `js`
-```diff
+```
 
 #### End of Day Routine (Missing entirely)
 
@@ -469,7 +469,7 @@ flow eod                  # End of day
 # 4. Prompt to commit/push
 # 5. Suggest tomorrow's focus
 # 6. Ask to set tomorrow's goal
-```bash
+```
 
 #### Weekly Review (Opt-in, easy to forget)
 
@@ -484,7 +484,7 @@ flow eod                  # End of day
 # Or automatic in `flow eod` on Fridays:
 flow eod
 # (shows week summary automatically)
-```diff
+```
 
 ---
 
@@ -507,7 +507,7 @@ flow review today         # Today's activity
 flow review yesterday     # Yesterday (for standup)
 flow review week          # This week
 flow review project       # Current project only
-```text
+```
 
 **Output format:**
 
@@ -531,7 +531,7 @@ flow review project       # Current project only
 🔥 Streak: 9 days
 
 💡 Great work! Tomorrow: Plan v5.1.0
-```diff
+```
 
 ### 2. Planning Sessions ("help me plan my day")
 
@@ -548,7 +548,7 @@ flow review project       # Current project only
 flow plan today           # Today's plan with AI help
 flow plan week            # Weekly planning
 flow plan sprint          # Sprint planning (project-specific)
-```text
+```
 
 **Interactive workflow:**
 
@@ -570,7 +570,7 @@ Active projects:
   End with nexus docs (low energy task)
 
 Set today's goal? [3]
-```bash
+```
 
 ### 3. Context Restoration ("I was working on X, what was I doing?")
 
@@ -589,7 +589,7 @@ flow resume               # Restore context
 # - Recent breadcrumbs
 # - Pending tasks from inbox
 # - Suggested next action
-```text
+```
 
 **Smart context detection:**
 
@@ -608,7 +608,7 @@ Recent activity:
 
 💡 Suggested next:
   Monitor Homebrew PR, then start v5.1.0 planning
-```diff
+```
 
 ### 4. Energy Management ("I'm tired, what should I do?")
 
@@ -627,14 +627,14 @@ Recent activity:
 flow energy low           # Show low-energy tasks
 flow energy high          # Show high-energy tasks
 flow energy               # Log current energy (track patterns)
-```text
+```
 
 **Task energy tagging (in .STATUS):**
 
 ```markdown
 ## Focus: Fix bug #123
 ## Energy: high          # New field
-```bash
+```
 
 **Medium implementation:**
 
@@ -643,7 +643,7 @@ flow energy               # Log current energy (track patterns)
 next --energy low         # Filter for low-energy tasks
 next --energy high        # Filter for high-energy tasks
 next                      # Auto-detect from time of day + history
-```diff
+```
 
 **Long-term implementation:**
 - Track energy patterns (time of day, day of week)
@@ -675,7 +675,7 @@ next                      # Auto-detect from time of day + history
 ```bash
 flow learn                # First-week tutorial (new)
 flow tips beginner        # Top 10 commands to learn
-```diff
+```
 
 ### Intermediate User (Month 1-3)
 
@@ -697,7 +697,7 @@ flow tips beginner        # Top 10 commands to learn
 ```bash
 flow tips intermediate    # Next 10 commands
 flow stats                # Show your usage patterns
-```diff
+```
 
 ### Power User (Month 3+)
 
@@ -719,7 +719,7 @@ flow stats                # Show your usage patterns
 ```bash
 flow tips power           # Hidden gems + flags
 flow customize            # Customization guide
-```bash
+```
 
 ---
 
@@ -732,7 +732,7 @@ flow customize            # Customization guide
 ```bash
 flow resume               # or flow context
 # Shows: project, focus, commits, breadcrumbs, next task
-```bash
+```
 
 **Impact:** Reduces 5-step manual process to 1 command
 **ADHD Benefit:** Instant context recovery after interruptions
@@ -743,7 +743,7 @@ flow resume               # or flow context
 flow eod                  # End of day review
 # Shows: wins, goal progress, celebration if met
 # Prompts: commit, tomorrow's plan
-```text
+```
 
 **Impact:** Creates daily closure ritual
 **ADHD Benefit:** Dopamine from reviewing accomplishments
@@ -753,7 +753,7 @@ flow eod                  # End of day review
 ```bash
 dash                      # Quick mode (10 lines)
 dash -v                   # Full mode (current)
-```bash
+```
 
 **Impact:** Reduces cognitive load for quick glances
 **ADHD Benefit:** Less overwhelm, faster decisions
@@ -765,7 +765,7 @@ dash -v                   # Full mode (current)
 ```bash
 flow plan today           # Interactive daily planning
 # Shows: yesterday, suggests priorities, AI help
-```bash
+```
 
 **Impact:** Structured morning routine
 **ADHD Benefit:** Reduces morning paralysis
@@ -775,7 +775,7 @@ flow plan today           # Interactive daily planning
 ```bash
 flow review today|yesterday|week
 # Unified activity review for standups
-```bash
+```
 
 **Impact:** One command for all review needs
 **ADHD Benefit:** Easy standup prep, accomplishment visibility
@@ -786,7 +786,7 @@ flow review today|yesterday|week
 flow stuck                # Context-aware unstuck help
 # Detects: paralysis, frustration, low energy
 # Routes to: js, brk, next --ai, stuck --ai
-```bash
+```
 
 **Impact:** ONE path when paralyzed
 **ADHD Benefit:** Reduces decision paralysis
@@ -798,7 +798,7 @@ flow stuck                # Context-aware unstuck help
 ```bash
 flow energy low|high|log
 # Tag tasks by energy, get energy-aware suggestions
-```text
+```
 
 **Impact:** Task recommendations match energy level
 **ADHD Benefit:** Work with your energy, not against it
@@ -808,7 +808,7 @@ flow energy low|high|log
 ```bash
 flow tips beginner|intermediate|power|adhd
 flow learn                # Interactive tutorials
-```diff
+```
 
 **Impact:** Progressive feature discovery
 **ADHD Benefit:** Less overwhelm, guided learning
@@ -833,7 +833,7 @@ flow learn                # Interactive tutorials
 ```bash
 flow map                  # Visual command relationships
 flow map session|dopamine|git
-```diff
+```
 
 **Impact:** Better mental model
 **ADHD Benefit:** Understand connections, not memorize
@@ -857,7 +857,7 @@ morning                   # (hidden gem, manual)
 work project              # (requires decision)
 win "text"                # (manual throughout day)
 # (no eod command)
-```bash
+```
 
 **Recommended:** Integrated flow
 
@@ -872,7 +872,7 @@ flow eod                  # New end of day command
 # → Shows wins + goal
 # → Celebrates if met
 # → Preps tomorrow
-```bash
+```
 
 ### Pattern 2: Pick → Code → Review → Merge
 
@@ -885,7 +885,7 @@ g status                  # Manual check
 g commit                  # Manual commit
 g push                    # Manual push
 # (create PR manually)
-```bash
+```
 
 **Recommended:** Streamlined
 
@@ -897,7 +897,7 @@ g feature finish          # All-in-one
 # → Auto push
 # → Create PR
 # → Log win
-```bash
+```
 
 ### Pattern 3: Break → Resume Context
 
@@ -908,7 +908,7 @@ brk 5                     # Timer only
 # (after break, manual context restore)
 why                       # Show context (manual)
 trail                     # Show breadcrumbs (manual)
-```bash
+```
 
 **Recommended:** Automatic
 
@@ -918,7 +918,7 @@ brk                       # Smart break
 # → Timer
 # → After break: restore context automatically
 # → Suggest warmup task
-```diff
+```
 
 ---
 
@@ -963,7 +963,7 @@ brk                       # Smart break
 
 🤖 AI ASSISTANCE
   cc → next --ai → stuck --ai
-```text
+```
 
 **Implementation:**
 

--- a/docs/specs/_archive/BRAINSTORM-dot-unlock-simplify-2026-01-13.md
+++ b/docs/specs/_archive/BRAINSTORM-dot-unlock-simplify-2026-01-13.md
@@ -25,7 +25,7 @@ dot unlock
             ├─► _dot_session_cache_expired()
             ├─► _dot_session_cache_touch()
             └─► _dot_session_time_remaining()
-```bash
+```
 
 ### Problems Identified
 
@@ -57,7 +57,7 @@ if [[ $unlock_status -ne 0 ]]; then
     cat "$temp_err" >&2
 fi
 rm -f "$temp_err"
-```diff
+```
 
 ### Pros
 
@@ -99,7 +99,7 @@ _dot_bw_session_valid() {
     # Just check if BW_SESSION is set and valid
     [[ -n "$BW_SESSION" ]] && bw unlock --check &>/dev/null
 }
-```diff
+```
 
 ### Remove
 
@@ -176,7 +176,7 @@ _dot_unlock() {
 _dot_bw_session_valid() {
     [[ -n "$BW_SESSION" ]] && bw unlock --check &>/dev/null
 }
-```diff
+```
 
 ### Pros
 
@@ -216,7 +216,7 @@ _dot_unlock() {
 _dot_bw_session_valid() {
     bw unlock --check &>/dev/null 2>&1
 }
-```diff
+```
 
 ### Remove Everything Else
 
@@ -234,7 +234,7 @@ if ! bw unlock --check &>/dev/null; then
     _flow_log_error "Vault locked. Run: bw unlock"
     return 1
 fi
-```diff
+```
 
 ### Pros
 
@@ -335,7 +335,7 @@ security find-generic-password \
 security delete-generic-password \
     -a "account-name" \
     -s "service-name"
-```diff
+```
 
 **Benefits:**
 - Native macOS security (Keychain Access)
@@ -371,7 +371,7 @@ dot secret get <name>         # Retrieve from Keychain (silent)
 dot secret list               # List all dot-managed secrets
 dot secret delete <name>      # Remove from Keychain
 dot secret import             # Import from Bitwarden to Keychain (one-time)
-```zsh
+```
 
 ### Implementation
 
@@ -458,7 +458,7 @@ _dot_secret_import() {
         _flow_log_success "Imported: $name"
     done
 }
-```zsh
+```
 
 ### Usage in Other Commands
 
@@ -472,7 +472,7 @@ _dot_get_secret() {
 _dot_get_secret() {
     _dot_secret_get "$1"  # Instant, local, no unlock needed
 }
-```diff
+```
 
 ### Pros
 

--- a/docs/specs/_archive/EXAMPLES-vhs-syntax-fixes.md
+++ b/docs/specs/_archive/EXAMPLES-vhs-syntax-fixes.md
@@ -84,7 +84,7 @@ Type "# → GitHub repo creation? (y/N)" Sleep 500ms Enter
 
 # Line 100
 Type "# ✅ All 5 Phases Complete!" Enter
-```bash
+```
 
 ### After (CORRECT)
 
@@ -148,7 +148,7 @@ Type "echo '→ GitHub repo creation? (y/N)'" Sleep 500ms Enter
 
 # Line 100
 Type "echo '✅ All 5 Phases Complete!'" Enter
-```diff
+```
 
 ### Key Changes
 
@@ -203,7 +203,7 @@ Type@100ms "# Get help anytime"
 
 # Line 103
 Type "# Dotfile management made easy!"
-```bash
+```
 
 ### After (CORRECT)
 
@@ -243,7 +243,7 @@ Type@100ms "echo 'Get help anytime'"
 
 # Line 103
 Type "echo 'Dotfile management made easy!'"
-```diff
+```
 
 ### Key Changes
 
@@ -299,7 +299,7 @@ Type "#   finish       - End session with optional note"
 
 # Line 133
 Type "# That's it! You've completed your first session."
-```bash
+```
 
 ### After (CORRECT)
 
@@ -341,7 +341,7 @@ Type "echo '  finish       - End session with optional note'"
 
 # Line 133
 Type "echo 'That'\''s it! You'\''ve completed your first session.'"
-```diff
+```
 
 ### Key Changes
 
@@ -360,7 +360,7 @@ Type "echo 'That'\''s it! You'\''ve completed your first session.'"
 Set FontSize 14
 Set Width 1200
 Set Height 800
-```text
+```
 
 ### After (CORRECT)
 
@@ -368,7 +368,7 @@ Set Height 800
 Set FontSize 18  # Minimum for teaching workflows
 Set Width 1400   # Increased for better readability
 Set Height 900   # Increased for better readability
-```diff
+```
 
 **Affected files:**
 - teaching-git-workflow.tape (14 → 18)
@@ -394,7 +394,7 @@ Type "# Phase 1: Introduction" Enter
 
 # ✅ CORRECT
 Type "echo 'Phase 1: Introduction'" Enter
-```bash
+```
 
 ### Pattern 2: Bullet Lists
 
@@ -406,7 +406,7 @@ Type "#   • Item 2" Enter
 # ✅ CORRECT
 Type "echo '  • Item 1'" Enter
 Type "echo '  • Item 2'" Enter
-```bash
+```
 
 ### Pattern 3: Numbered Lists
 
@@ -418,7 +418,7 @@ Type "#   2) Second option" Enter
 # ✅ CORRECT
 Type "echo '  1) First option'" Enter
 Type "echo '  2) Second option'" Enter
-```bash
+```
 
 ### Pattern 4: Empty Lines
 
@@ -428,7 +428,7 @@ Type "#" Enter
 
 # ✅ CORRECT
 Type "echo ''" Enter
-```bash
+```
 
 ### Pattern 5: Status Messages
 
@@ -442,7 +442,7 @@ Type "# ⚠ Warning message" Enter
 Type "echo '✓ Success!'" Enter
 Type "echo '✗ Error occurred'" Enter
 Type "echo '⚠ Warning message'" Enter
-```bash
+```
 
 ### Pattern 6: Multiline Blocks
 
@@ -458,7 +458,7 @@ Type "echo 'System Information:'" Enter
 Type "echo '  OS: macOS'" Enter
 Type "echo '  Shell: zsh'" Enter
 Type "echo '  Version: 5.22.0'" Enter
-```bash
+```
 
 ---
 
@@ -474,7 +474,7 @@ Type "echo 'That's great!'" Enter
 
 # ✅ CORRECT (escape apostrophe)
 Type "echo 'That'\''s great!'" Enter
-```bash
+```
 
 **Explanation:** `'\''` breaks out of single quotes, adds escaped apostrophe, resumes single quotes
 
@@ -483,7 +483,7 @@ Type "echo 'That'\''s great!'" Enter
 ```bash
 # ✅ ALSO CORRECT (if no other quotes in text)
 Type "echo \"That's great!\"" Enter
-```text
+```
 
 ---
 
@@ -499,14 +499,14 @@ For bulk fixing in editors:
 
 " Add closing quote and parenthesis (manual verification needed)
 :%s/Type "echo '\(.*\)" Enter/Type "echo '\1'" Enter/g
-```text
+```
 
 ### VS Code (Regex Find/Replace)
 
 ```text
 Find:    Type "# (.*)\" Enter
 Replace: Type "echo '$1'" Enter
-```bash
+```
 
 ### sed (Command Line)
 
@@ -516,7 +516,7 @@ cp teaching-git-workflow.tape teaching-git-workflow.tape.bak
 
 # Simple replacement (requires manual quote fixing)
 sed -i '' 's/Type "#/Type "echo '"'"'/g' teaching-git-workflow.tape
-```bash
+```
 
 **Note:** Automated replacement requires careful review due to quote escaping complexity.
 
@@ -531,7 +531,7 @@ sed -i '' 's/Type "#/Type "echo '"'"'/g' teaching-git-workflow.tape
 grep 'Type "#' teaching-git-workflow.tape
 
 # Should return no results if all fixed
-```bash
+```
 
 ### Automated Validation
 
@@ -541,7 +541,7 @@ grep 'Type "#' teaching-git-workflow.tape
 
 # Expected output:
 # ✓ teaching-git-workflow.tape
-```bash
+```
 
 ### Test Generation
 
@@ -552,7 +552,7 @@ vhs teaching-git-workflow.tape
 
 # Check for ZSH errors in terminal output
 # Verify GIF displays correctly
-```zsh
+```
 
 ---
 
@@ -605,7 +605,7 @@ Sleep 1s
 # Completion
 Type "echo '✓ Demo complete!'" Enter
 Sleep 2s
-```zsh
+```
 
 ### Dispatcher Demo Template (CORRECT)
 

--- a/docs/specs/_archive/SPEC-cc-unified-grammar-2026-01-02.md
+++ b/docs/specs/_archive/SPEC-cc-unified-grammar-2026-01-02.md
@@ -52,7 +52,7 @@ Add support for **both mode-first and target-first** command orders in the `cc` 
 cc .                  # Explicit HERE
 cc here               # Readable HERE
 cc opus .             # Opus mode HERE
-```text
+```
 
 ### Story 3: Reserved Keyword Handling
 
@@ -65,7 +65,7 @@ cc opus .             # Opus mode HERE
 ```bash
 cc opus               # Mode (Opus HERE)
 cc pick opus          # Project (jump to 'opus')
-```text
+```
 
 ---
 
@@ -79,7 +79,7 @@ cc pick opus          # Project (jump to 'opus')
 cc [mode] [target]
   mode   = (empty) | yolo | plan | opus | haiku
   target = (empty) | pick | <project> | wt <branch>
-```text
+```
 
 **Parsing:** Mode-first only, positional
 
@@ -89,7 +89,7 @@ cc [mode] [target]
 cc [mode|target] [target|mode]
   mode   = (empty) | yolo | y | plan | p | opus | o | haiku | h
   target = (empty) | . | here | pick | <project> | wt <branch>
-```text
+```
 
 **Parsing:** Detect mode vs target, accept either order
 
@@ -120,7 +120,7 @@ flowchart TD
 
     LaunchHere --> End[Done]
     Execute --> End
-```text
+```
 
 ### Grammar Specification
 
@@ -131,7 +131,7 @@ yolo, y       → --dangerously-skip-permissions
 plan, p       → --permission-mode plan
 opus, o       → --model opus --permission-mode acceptEdits
 haiku, h      → --model haiku --permission-mode acceptEdits
-```text
+```
 
 #### Reserved Keywords (Targets)
 
@@ -141,7 +141,7 @@ haiku, h      → --model haiku --permission-mode acceptEdits
 pick          → Project picker (fzf)
 wt, w         → Worktree (requires branch arg)
 <string>      → Project name (via pick direct jump)
-```text
+```
 
 #### Precedence Rules
 
@@ -156,7 +156,7 @@ wt, w         → Worktree (requires branch arg)
 
 ```bash
 cc [mode|target] [target|mode] [args...]
-```diff
+```
 
 #### Examples Table
 
@@ -214,7 +214,7 @@ Execute: pick --no-claude "flow" && claude --model opus --permission-mode accept
 
    ↓
 Result: Changed to flow-cli directory, launched Claude with Opus
-```text
+```
 
 ### Help Text Updates
 
@@ -223,7 +223,7 @@ Result: Changed to flow-cli directory, launched Claude with Opus
 ```text
 🚀 LAUNCH MODES:
   cc opus pick          Pick project → Opus model
-```text
+```
 
 #### After (v4.8.0)
 
@@ -233,7 +233,7 @@ Result: Changed to flow-cli directory, launched Claude with Opus
   cc pick opus          Target first (natural reading)
 
   Both work! Use whichever feels natural.
-```diff
+```
 
 ### Accessibility
 
@@ -355,7 +355,7 @@ cc pick wt            # Two targets
 
 cc opus haiku         # Two modes
 → Error: "Cannot combine modes 'opus' and 'haiku'"
-```text
+```
 
 **Unknown arguments:**
 
@@ -363,7 +363,7 @@ cc opus haiku         # Two modes
 cc invalidmode
 → Assume project name, attempt pick direct jump
 → If pick fails: "Project 'invalidmode' not found"
-```text
+```
 
 ### Backward Compatibility
 
@@ -376,7 +376,7 @@ cc opus               ✅ Opus HERE
 cc opus pick          ✅ Opus + picker
 cc flow               ✅ Jump to flow
 cc yolo wt feature    ✅ YOLO + worktree
-```text
+```
 
 **New v4.8.0 patterns:**
 
@@ -385,7 +385,7 @@ cc pick opus          ✅ NEW: Opus + picker
 cc flow opus          ✅ NEW: Jump to flow + Opus
 cc here               ✅ NEW: Explicit HERE
 cc .                  ✅ NEW: Explicit HERE (short)
-```yaml
+```
 
 ---
 
@@ -427,14 +427,14 @@ cc .                  ✅ NEW: Explicit HERE (short)
 
 ```bash
 cc                    # Smart: HERE if in project, PICK if not
-```text
+```
 
 ### v5.0: Project Namespacing
 
 ```bash
 cc @opus              # Always project
 cc %opus              # Always mode
-```text
+```
 
 ### v5.0: REPL Mode
 
@@ -443,7 +443,7 @@ cc repl
 > mode opus
 > target pick
 > go
-```text
+```
 
 ### v6.0: Custom Modes
 

--- a/docs/specs/_archive/SPEC-dot-secret-management-v2-2026-01-10.md
+++ b/docs/specs/_archive/SPEC-dot-secret-management-v2-2026-01-10.md
@@ -105,7 +105,7 @@ flowchart TB
 
     Wizard --> Browser
     Expiry --> Meta
-```bash
+```
 
 ### Component Responsibilities
 
@@ -154,7 +154,7 @@ dot secret add npm-token --notes "automation token for CI"
 2. Optional: prompt for expiration
 3. Store in Bitwarden with metadata
 4. Confirm storage
-```bash
+```
 
 #### `dot token github`
 
@@ -170,7 +170,7 @@ dot token github [--type classic|fine-grained] [--scopes <list>]
 5. Validate token against GitHub API
 6. Store with expiration date
 7. Show usage example
-```bash
+```
 
 #### `dot secrets`
 
@@ -189,7 +189,7 @@ dot token github [--type classic|fine-grained] [--scopes <list>]
   Vault: 🔓 Unlocked (12 min remaining)
 
   ⚠ 1 token expiring soon. Run: dot token npm --refresh
-```text
+```
 
 ---
 
@@ -209,7 +209,7 @@ Stored alongside secret in Bitwarden notes field:
   "project": "flow-cli",
   "notes": "user notes here"
 }
-```text
+```
 
 ### Session Cache
 
@@ -219,7 +219,7 @@ File-based cache at `~/.cache/dot/session`:
 BW_SESSION_TOKEN=<encrypted>
 UNLOCK_TIME=1704888000
 IDLE_TIMEOUT=900
-```diff
+```
 
 ---
 
@@ -280,7 +280,7 @@ IDLE_TIMEOUT=900
 │                                                             │
 │ 💡 Usage: GITHUB_TOKEN=$(dot secret github-token)           │
 └─────────────────────────────────────────────────────────────┘
-```text
+```
 
 ### Wireframe: Secrets Dashboard
 

--- a/docs/specs/_archive/SPEC-flow-scholar-integration-improvements-2026-01-14.md
+++ b/docs/specs/_archive/SPEC-flow-scholar-integration-improvements-2026-01-14.md
@@ -51,7 +51,7 @@ This spec analyzes the current integration between flow-cli's `teach` dispatcher
 │                                                                      │
 │  Shared Config: .flow/teach-config.yml                              │
 └─────────────────────────────────────────────────────────────────────┘
-```text
+```
 
 ### Current Command Mapping (9 commands)
 
@@ -87,7 +87,7 @@ This spec analyzes the current integration between flow-cli's `teach` dispatcher
 │ Source: Scholar plugin defaults                                 │
 │ Hardcoded sensible defaults                                     │
 └─────────────────────────────────────────────────────────────────┘
-```bash
+```
 
 ---
 
@@ -105,7 +105,7 @@ The `teach lecture` wrapper exists in flow-cli but Scholar's `/teaching:lecture`
 ```bash
 # Users must use Claude directly
 claude "Create a lecture outline for Week 3: Data Wrangling"
-```bash
+```
 
 ### 2. No Explicit Config Passing
 
@@ -121,7 +121,7 @@ teach exam "Midterm"
 # Translates to:
 claude --print "/teaching:exam" "Midterm"
 # Scholar independently searches for .flow/teach-config.yml
-```bash
+```
 
 **Problem:** If user runs from a subdirectory without config, Scholar uses defaults silently.
 
@@ -136,7 +136,7 @@ Flow-cli passes flags to Scholar without validation. Invalid flags fail inside C
 ```bash
 teach exam --invalid-flag "Midterm"
 # Results in Claude error, not helpful flow-cli error
-```diff
+```
 
 ### 4. No Bidirectional State Sync
 
@@ -200,7 +200,7 @@ _flow_find_teach_config() {
         dir="${dir:h}"
     done
 }
-```yaml
+```
 
 **Scholar changes:** Accept `--config` flag in teaching commands.
 
@@ -220,7 +220,7 @@ output:
   lectures: lectures/
   slides: slides/
   rubrics: rubrics/
-```zsh
+```
 
 **Flow-cli change:**
 
@@ -237,7 +237,7 @@ _teach_post_process() {
         _flow_log_success "Created: $target_dir/$(basename $generated_file)"
     fi
 }
-```zsh
+```
 
 ### 🎯 Enhancement 3: Flag Validation Layer
 
@@ -279,7 +279,7 @@ _teach_validate_flags() {
         fi
     done
 }
-```zsh
+```
 
 ### 🎯 Enhancement 4: Post-Generation Hooks
 
@@ -320,7 +320,7 @@ _teach_show_summary() {
     echo "  • Review: $EDITOR $file"
     echo "  • Deploy: teach deploy"
 }
-```bash
+```
 
 ### 🎯 Enhancement 5: Interactive Mode Support
 
@@ -339,7 +339,7 @@ teach exam --interactive "Midterm"
 # 3. Prompt: "Refine? (y/n/done)"
 # 4. If y: re-run with feedback
 # 5. Loop until done
-```zsh
+```
 
 ### 🎯 Enhancement 6: Progress Indicator
 
@@ -366,7 +366,7 @@ _teach_with_progress() {
 
     return $status
 }
-```bash
+```
 
 ### 🎯 Enhancement 7: teach status Integration
 
@@ -401,7 +401,7 @@ _teach_status_enhanced() {
         echo "   $(basename $f) - $(stat -f '%Sm' -t '%Y-%m-%d' $f)"
     done
 }
-```zsh
+```
 
 ### 🎯 Enhancement 8: Unified teach help
 

--- a/docs/specs/_archive/SPEC-prompt-dispatcher-integration.md
+++ b/docs/specs/_archive/SPEC-prompt-dispatcher-integration.md
@@ -83,7 +83,7 @@ prompt [action] [options]
     ├── p10k        → _prompt_p10k()
     ├── list (ls)   → _prompt_list()
     └── help        → _prompt_help()
-```text
+```
 
 #### File Structure
 
@@ -93,7 +93,7 @@ completions/_prompt                       # Tab completion
 docs/reference/MASTER-DISPATCHER-GUIDE.md   # Documentation
 docs/guides/PROMPT-DISPATCHER.md         # Guide
 tests/test-prompt-dispatcher.zsh         # Unit & E2E tests
-```diff
+```
 
 #### Environment
 
@@ -203,7 +203,7 @@ export FLOW_PROMPT_ENGINE="${FLOW_PROMPT_ENGINE:-powerlevel10k}"
 
 # Accessed by dispatcher
 $FLOW_PROMPT_ENGINE  # Current engine
-```text
+```
 
 ### Engine Configuration
 
@@ -219,7 +219,7 @@ Starship:
   - Binary: /opt/homebrew/bin/starship (or in PATH)
   - Init: eval "$(starship init zsh)"
   - Cache: ~/.cache/starship
-```bash
+```
 
 ---
 
@@ -237,7 +237,7 @@ prompt starship            # Switch to Starship
 prompt p10k                # Switch to P10k
 prompt list                # List available engines
 prompt help                # Show this help
-```text
+```
 
 ### Output Format
 
@@ -248,7 +248,7 @@ prompt help                # Show this help
    Alternative: starship
 
    To switch: prompt toggle
-```text
+```
 
 #### `prompt toggle`
 
@@ -256,7 +256,7 @@ prompt help                # Show this help
 ✅ Switched to starship
 
 [... terminal reloads ...]
-```text
+```
 
 #### `prompt list`
 
@@ -270,7 +270,7 @@ Available Prompt Engines:
   ○ starship
     Minimal, fast Rust-based prompt
     Config: ~/.config/starship.toml
-```text
+```
 
 #### `prompt help`
 
@@ -295,7 +295,7 @@ EXAMPLES:
    prompt starship          # Go to Starship
    prompt p10k              # Go to Powerlevel10k
    prompt list              # See available engines
-```text
+```
 
 ---
 
@@ -314,7 +314,7 @@ EXAMPLES:
 ✓ Validation helper function
 ✓ Get current engine function
 ✓ Get alternatives function
-```text
+```
 
 ### E2E Tests
 
@@ -325,7 +325,7 @@ EXAMPLES:
 ✓ Status shows correct engine after switch
 ✓ Multiple toggles in sequence
 ✓ Switching to same engine (idempotent)
-```text
+```
 
 ### Integration Tests
 
@@ -335,7 +335,7 @@ EXAMPLES:
 ✓ Tab completion works
 ✓ No conflicts with other dispatchers
 ✓ Works with custom flow-cli settings
-```text
+```
 
 ---
 
@@ -350,7 +350,7 @@ User: prompt status
 System: Shows current engine + alternatives
         "To switch: prompt toggle"
 Time: ~100ms
-```text
+```
 
 #### Scenario 2: Switch Engines
 
@@ -360,7 +360,7 @@ System: Shows "✅ Switched to starship"
         Shell reloads (exec zsh)
         New prompt loads
 Time: ~500ms
-```text
+```
 
 #### Scenario 3: Learn Available Options
 
@@ -368,7 +368,7 @@ Time: ~500ms
 User: prompt help
 System: Shows all actions with examples
 Time: ~50ms
-```text
+```
 
 #### Scenario 4: Legacy Alias Usage
 
@@ -378,7 +378,7 @@ System: (maps to prompt toggle)
         Shows "✅ Switched to ..."
         Works exactly as before
 Time: ~500ms
-```diff
+```
 
 ### Error Handling
 

--- a/docs/specs/_archive/SPEC-prompt-dispatcher-v2.md
+++ b/docs/specs/_archive/SPEC-prompt-dispatcher-v2.md
@@ -81,7 +81,7 @@ prompt [subcommand]
     ├── ohmyposh        → _prompt_switch()      [Force to ohmyposh]
     ├── list            → _prompt_list()        [Show all engines with details]
     └── help            → _prompt_help()        [Display help]
-```zsh
+```
 
 ### Engine Definitions
 
@@ -108,7 +108,7 @@ Binary: (loaded via antidote plugin manager)
 Description: Feature-rich, highly customizable prompt engine
 Install Check: grep -q "romkatv/powerlevel10k" ~/.config/zsh/.zsh_plugins.txt
 Init Method: source ~/.config/zsh/.p10k.zsh (after antidote loads)
-```text
+```
 
 #### Engine 2: Starship
 
@@ -121,7 +121,7 @@ Description: Minimal, fast Rust-based prompt engine
 Install Check: command -v starship >/dev/null 2>&1
 Init Method: eval "$(starship init zsh)"
 Status: ✅ Currently installed and configured
-```text
+```
 
 #### Engine 3: OhMyPosh (NEW)
 
@@ -134,7 +134,7 @@ Description: Modular prompt engine with extensive themes
 Install Check: command -v oh-my-posh >/dev/null 2>&1
 Init Method: eval "$(oh-my-posh init zsh)"
 Status: ⏳ To be implemented in v5.7.0
-```text
+```
 
 ### File Structure
 
@@ -157,7 +157,7 @@ flow-cli/
 ├── setup/
 │   └── prompt-setup.zsh                     # NEW: OhMyPosh setup script
 └── CLAUDE.md                                # UPDATE: Add prompt dispatcher
-```diff
+```
 
 ### Environment Variables
 
@@ -174,7 +174,7 @@ export FLOW_PROMPT_ENGINE="${FLOW_PROMPT_ENGINE:-powerlevel10k}"
 if [[ "$FLOW_PROMPT_ENGINE" == "starship" ]]; then
     eval "$(starship init zsh)"
 fi
-```text
+```
 
 ---
 
@@ -202,7 +202,7 @@ Prompt Engines:
     Config: ~/.config/ohmyposh/config.json
 
 To switch: prompt toggle
-```diff
+```
 
 **Implementation Notes:**
 - Use Unicode bullets: `●` for current, `○` for available
@@ -314,7 +314,7 @@ starship       ○         ~/.config/starship.toml
 oh-my-posh     ○         ~/.config/ohmyposh/config.json
 
 Legend: ● = current, ○ = available
-```diff
+```
 
 **What's Included:**
 - All 4 columns: name, status (● = current, ○ = available), config path
@@ -355,7 +355,7 @@ SETUP:
 
 For more info:
    https://data-wise.github.io/flow-cli/dispatchers/prompt/
-```diff
+```
 
 ---
 
@@ -413,7 +413,7 @@ Active Engine: powerlevel10k ✅
 
 ---
 To fix issues: Select 'F' → 'Prompt engines' or run: flow doctor prompt
-```bash
+```
 
 ### Auto-Fix Workflow (Delegated to Flow Doctor)
 
@@ -430,7 +430,7 @@ $ flow doctor
     2. Create OhMyPosh config
 
 Fix these issues? (y/n)
-```diff
+```
 
 **Smart Flow Doctor Handles:**
 - ✅ Detecting all missing/broken components
@@ -450,7 +450,7 @@ Fix these issues? (y/n)
 5. Create configs from templates
 6. Validate all fixes
 7. Report results with next steps
-```text
+```
 
 **User Experience:**
 
@@ -462,7 +462,7 @@ Installing Oh My Posh...
 
 ✅ Prompt Engines: Ready to use
 Run: prompt help
-```diff
+```
 
 #### Why Delegate to Flow Doctor
 
@@ -517,7 +517,7 @@ _fix_prompt_engines() {
     # Create missing configs
     # Verify all fixed
 }
-```bash
+```
 
 #### Installation Logic
 
@@ -539,7 +539,7 @@ _install_engine_interactive() {
     # Verify installation
     _verify_installation "$engine"
 }
-```zsh
+```
 
 #### Configuration Creation
 
@@ -555,7 +555,7 @@ _create_engine_config() {
             ;;
     esac
 }
-```diff
+```
 
 ### Integration with Existing Doctor
 
@@ -601,7 +601,7 @@ command -v oh-my-posh >/dev/null 2>&1
 
 # Check Antidote (required)
 command -v antidote >/dev/null 2>&1
-```diff
+```
 
 ### Configuration Validation
 
@@ -622,7 +622,7 @@ Manual fix:
    1. Edit file: nano ~/.config/starship.toml
    2. Validate syntax with: starship config
    3. Run: flow doctor  (to verify)
-```diff
+```
 
 ### Issue Severity
 
@@ -649,7 +649,7 @@ Manual fix:
   ▸ Current: powerlevel10k ✅
 
   Antidote: ✅ installed
-```text
+```
 
 #### Missing Optional Engine
 
@@ -664,7 +664,7 @@ Manual fix:
   Antidote: ✅ installed
 
 Status: Working (2/3 engines available)
-```text
+```
 
 #### Broken Configuration
 
@@ -683,7 +683,7 @@ Manual fix:
   3. Recheck: flow doctor
 
 ▸ Current: powerlevel10k ✅ (still working)
-```text
+```
 
 #### Missing Antidote
 
@@ -701,7 +701,7 @@ Fix:
 
 ▸ Current: powerlevel10k ⚠️ (P10k won't load)
 Status: Partially working (1/3 engines available)
-```text
+```
 
 ### User Workflow
 
@@ -719,7 +719,7 @@ Fix prompt engines? (y/n) y
 ✅ Oh My Posh installed
 ✅ Config created
 ✅ All checks passing!
-```text
+```
 
 #### Scenario 2: Troubleshooting
 
@@ -735,7 +735,7 @@ User: Selects 'Prompt engines'
 ✅ Fixed: Oh My Posh installation
 ✅ Fixed: OhMyPosh config
 ✅ All issues resolved!
-```text
+```
 
 #### Scenario 3: Maintenance Check
 
@@ -743,7 +743,7 @@ User: Selects 'Prompt engines'
 $ flow doctor
 
 Shows that everything is healthy, no action needed
-```zsh
+```
 
 ---
 
@@ -777,7 +777,7 @@ _prompt_get_current()   # Get current engine safely
 _prompt_get_alternatives() # Get list of non-current engines
 _prompt_init_engine()   # Initialize chosen engine
 _prompt_engine_exists() # Check if engine binary/config exists
-```zsh
+```
 
 ### Engine Registry (Data Structure)
 
@@ -797,7 +797,7 @@ _prompt_parse_engine() {
 
     # Returns requested field (name, display, binary, config, etc.)
 }
-```zsh
+```
 
 ### Validation Logic
 
@@ -820,7 +820,7 @@ _prompt_validate() {
             ;;
     esac
 }
-```sql
+```
 
 ### Toggle Logic with 3 Engines
 
@@ -836,7 +836,7 @@ _prompt_toggle() {
         break
     done
 }
-```text
+```
 
 ---
 
@@ -862,7 +862,7 @@ Prompt Engines:
   ○ oh-my-posh
     Modular prompt engine with extensive themes
     Config: ~/.config/ohmyposh/config.json
-```text
+```
 
 **Example 2: Toggle Interactively**
 
@@ -877,7 +877,7 @@ Which prompt engine would you like to use?
 ✅ Switched to Starship
 
 [shell reloads with new prompt]
-```text
+```
 
 **Example 3: Force Switch**
 
@@ -886,7 +886,7 @@ $ prompt starship
 ✅ Switched to Starship
 
 [new shell loads]
-```text
+```
 
 **Example 4: List All Engines**
 
@@ -902,7 +902,7 @@ starship       ○         ~/.config/starship.toml
 oh-my-posh     ○         ~/.config/ohmyposh/config.json
 
 Legend: ● = current, ○ = available
-```text
+```
 
 **Example 5: Validation Error**
 
@@ -915,7 +915,7 @@ Install with:
 
 Then configure with:
   prompt setup-ohmyposh
-```bash
+```
 
 ---
 
@@ -957,7 +957,7 @@ Then switch:
 
 Or use flow doctor:
   flow doctor  (shows 'F' to fix)
-```text
+```
 
 **Missing Engine Config:**
 
@@ -972,7 +972,7 @@ You can customize it:
   nano ~/.config/ohmyposh/config.json
 
 Ready to switch to Oh My Posh? (y/n)
-```bash
+```
 
 **Invalid/Broken Config:**
 
@@ -993,7 +993,7 @@ Fix manually:
 Or create from template:
   rm ~/.config/starship.toml
   prompt starship  (recreates with defaults)
-```text
+```
 
 ### OhMyPosh Setup Wizard
 

--- a/docs/specs/_archive/SPEC-teach-scholar-wrappers.md
+++ b/docs/specs/_archive/SPEC-teach-scholar-wrappers.md
@@ -108,7 +108,7 @@ teach exam "Hypothesis Testing" --dry-run --format quarto
 3. _teach_build_command()          # Build Scholar command string
 4. _teach_execute()                # Run Claude with Scholar command
 5. _teach_postprocess()            # Handle output, show summary
-```zsh
+```
 
 ### Preflight Checks
 
@@ -136,7 +136,7 @@ _teach_preflight() {
 
     return 0
 }
-```bash
+```
 
 ### Command Building
 
@@ -167,7 +167,7 @@ _teach_build_command() {
     # Build full command
     echo "claude --print \"$scholar_cmd ${args[*]}\""
 }
-```bash
+```
 
 ---
 
@@ -203,7 +203,7 @@ _teach_warn() {
     echo "⚠️  teach: $message" >&2
     [[ -n "$note" ]] && echo "   $note" >&2
 }
-```yaml
+```
 
 ---
 
@@ -228,7 +228,7 @@ scholar:
   defaults:
     exam_format: "quarto"      # Default --format for teach exam
     lecture_format: "quarto"   # Default --format for teach lecture
-```text
+```
 
 ---
 
@@ -251,7 +251,7 @@ scholar:
 
 5. Deploy to students
    └── teach deploy
-```zsh
+```
 
 ### Implementation
 
@@ -274,7 +274,7 @@ _teach_lecture_from_plan() {
     # Build Scholar command with context
     claude --print "/teaching:lecture \"$topic\" --objectives \"$objectives\""
 }
-```bash
+```
 
 ---
 
@@ -285,7 +285,7 @@ _teach_lecture_from_plan() {
 ```bash
 # Simple: Just check .flow/teach-config.yml
 teach exam "Topic"  # Scholar reads YAML directly
-```bash
+```
 
 ### Future Behavior (v2.1.0)
 
@@ -296,7 +296,7 @@ teach exam "Topic"
 # 2. Validate JSON schema
 # 3. Run Scholar command
 # 4. Auto-sync any new files
-```zsh
+```
 
 ### Sync Hook (future)
 
@@ -307,7 +307,7 @@ _teach_sync_config() {
         scholar-sync --quiet
     fi
 }
-```text
+```
 
 ---
 
@@ -326,7 +326,7 @@ lib/dispatchers/
 completions/
 └── _teach
     └── (Add Scholar subcommands)
-```zsh
+```
 
 ### Dispatcher Extension
 
@@ -354,7 +354,7 @@ teach() {
             ;;
     esac
 }
-```yaml
+```
 
 ---
 

--- a/docs/specs/_archive/SPEC-teaching-flags-enhancement-2026-01-17.md
+++ b/docs/specs/_archive/SPEC-teaching-flags-enhancement-2026-01-17.md
@@ -106,7 +106,7 @@ Each content flag has a negation form:
 --no-practice-problems
 --no-definitions
 --no-references
-```bash
+```
 
 ---
 
@@ -137,7 +137,7 @@ teach slides -w 8 --style rigorous --no-proof
 
 # Preset + both
 teach slides -w 8 --style computational --diagrams --no-practice-problems
-```text
+```
 
 ---
 
@@ -168,7 +168,7 @@ teach slides -w 8 --style computational --diagrams --no-practice-problems
         └── Prompt: "No plan found. Continue with topic 'X'? [Y/n]"
             └── If Y: Use topic from semester_info.weeks
             └── If N: Abort
-```yaml
+```
 
 ---
 
@@ -209,7 +209,7 @@ key_concepts:
 prerequisites:
   - "Simple linear regression (Week 6)"
   - "Matrix notation basics (Week 7)"
-```yaml
+```
 
 ### Minimal Schema (From Config)
 
@@ -222,7 +222,7 @@ semester_info:
     - number: 8
       start_date: "2026-03-02"
       topic: "Multiple Regression"  # Used as fallback
-```bash
+```
 
 ---
 
@@ -240,7 +240,7 @@ teach slides -w 8 --style rigorous --style conceptual
 
 teach slides  # No --topic or --week
 # Error: Must specify --topic or --week
-```text
+```
 
 ### Validation Messages
 
@@ -252,7 +252,7 @@ Error: Conflicting flags detected
 Fix: Remove one of the conflicting flags
 
   teach slides -w 8 --style rigorous --no-proof  ✓
-```zsh
+```
 
 ---
 
@@ -301,7 +301,7 @@ typeset -gA TEACH_SLIDES_FLAGS=(
     [-r]="--references"
     [--no-references]="boolean"
 )
-```zsh
+```
 
 ### Content Resolution Function
 
@@ -354,7 +354,7 @@ _teach_resolve_content() {
     # Return as comma-separated list
     print "${(kj:,:)content}"
 }
-```zsh
+```
 
 ### Lesson Plan Loading
 
@@ -382,7 +382,7 @@ _teach_load_lesson_plan() {
 
     return 1  # No plan found
 }
-```text
+```
 
 ---
 
@@ -403,7 +403,7 @@ What style should this content use?
   [4] applied       Explanation + examples + code + practice
 
 Your choice [1-4]: _
-```text
+```
 
 ### Missing Lesson Plan Prompt
 
@@ -415,7 +415,7 @@ Topic from config: "Multiple Regression"
 Continue with this topic? [Y/n]: _
 
 Hint: Create a lesson plan with: teach plan create 8
-```text
+```
 
 ### Flag Conflict Error
 
@@ -429,7 +429,7 @@ Hint: Create a lesson plan with: teach plan create 8
 Fix:
   teach slides -w 8 --style rigorous --no-proof
                                      ^^^^^^^^^ keep one
-```bash
+```
 
 ---
 
@@ -446,7 +446,7 @@ teach slides -w 8  # Uses week 8 plan defaults
 
 # Week with style override
 teach slides -w 8 --style rigorous
-```bash
+```
 
 ### Content Customization
 
@@ -462,7 +462,7 @@ teach slides -w 8 --explanation --examples --code
 
 # Kitchen sink
 teach slides -w 8 --style computational --diagrams --definitions --no-practice-problems
-```bash
+```
 
 ### Interactive Mode
 
@@ -472,7 +472,7 @@ teach slides -i -w 8
 
 # Interactive with preset (skips style prompt)
 teach slides -i -w 8 --style applied
-```bash
+```
 
 ---
 
@@ -495,7 +495,7 @@ test_teach_resolve_content_with_removals()
 test_teach_load_lesson_plan()
 test_teach_missing_lesson_plan()
 test_teach_week_topic_override()
-```bash
+```
 
 ### Integration Tests
 

--- a/docs/specs/_archive/SPEC-teaching-gifs-enhancement-2026-01-29.md
+++ b/docs/specs/_archive/SPEC-teaching-gifs-enhancement-2026-01-29.md
@@ -108,13 +108,13 @@ This specification addresses readability and quality issues in teaching workflow
 
 ```bash
 Type "# Phase 1: Smart Post-Generation" Enter  # ❌ WRONG
-```text
+```
 
 **Correct approach (from v3.0 tutorials):**
 
 ```bash
 Type "echo 'Phase 1: Smart Post-Generation'" Enter  # ✅ CORRECT
-```diff
+```
 
 **Affected tapes:**
 - `teaching-git-workflow.tape` - 60+ problematic lines
@@ -253,7 +253,7 @@ Type "echo 'Phase 1: Smart Post-Generation'" Enter  # ✅ CORRECT
             ├─ File size within target range
             ├─ No visual artifacts
             └─ Update inventory documentation
-```zsh
+```
 
 ### 4.2 VHS Tape Standards (NEW)
 
@@ -293,7 +293,7 @@ Sleep 1s
 # Cleanup
 Type "echo '✓ Demo complete!'" Enter
 Sleep 2s
-```zsh
+```
 
 **Standard template for dispatcher demos:**
 
@@ -322,7 +322,7 @@ Type "echo '<Dispatcher> Demo'" Enter
 Sleep 1s
 
 # Your demo commands here...
-```bash
+```
 
 ### 4.3 Validation Script Design
 
@@ -413,7 +413,7 @@ echo "Results: $PASSED/$TOTAL passed, $FAILED/$TOTAL failed"
 if [[ $FAILED -gt 0 ]]; then
     exit 1
 fi
-```bash
+```
 
 ### 4.4 Batch Generation Script Enhancement
 
@@ -458,7 +458,7 @@ done
 
 echo
 echo "✓ All GIFs generated and optimized!"
-```bash
+```
 
 ### 4.5 Pre-Commit Hook
 
@@ -480,7 +480,7 @@ if git diff --cached --name-only | grep -q '\.tape$'; then
 fi
 
 exit 0
-```text
+```
 
 ---
 
@@ -511,7 +511,7 @@ Phase 4: Verification & Rollout (Week 4)
 ├─ Update documentation site
 ├─ Archive old GIFs
 └─ Announce improvements
-```diff
+```
 
 ### 5.2 Detailed Task Breakdown
 
@@ -785,7 +785,7 @@ Type "# This is a comment" Enter
 
 # ✅ CORRECT - works in ZSH
 Type "echo 'This is a comment'" Enter
-```bash
+```
 
 **Problem 2: Quote Escaping**
 
@@ -795,7 +795,7 @@ Type "teach exam \"Topic\" --template foo" Enter
 
 # ✅ CORRECT - use single quotes
 Type "teach exam 'Topic' --template foo" Enter
-```zsh
+```
 
 **Problem 3: Missing Shell Initialization**
 

--- a/docs/specs/_archive/SPEC-teaching-integration-2026-01-17.md
+++ b/docs/specs/_archive/SPEC-teaching-integration-2026-01-17.md
@@ -109,7 +109,7 @@ Enhance the existing `teach` dispatcher to provide seamless Scholar plugin integ
 │ - Update .STATUS                                                │
 │ - Interactive commit workflow                                   │
 └─────────────────────────────────────────────────────────────────┘
-```yaml
+```
 
 ### Config Schema (teach-config.yml)
 
@@ -177,7 +177,7 @@ workflow:
   teaching_mode: true
   auto_commit: false
   auto_push: false
-```bash
+```
 
 ---
 
@@ -216,7 +216,7 @@ teach exam "Final" --context      # Include syllabus + past materials
 
 # Override week
 teach slides -w 10 "ANOVA"        # Force week 10
-```yaml
+```
 
 ---
 
@@ -243,7 +243,7 @@ units:
 
   - name: "Multiple Regression"
     weeks: [5, 6, 7, 8]
-```diff
+```
 
 ---
 
@@ -266,7 +266,7 @@ units:
 ⠋ Generating slides (~30s)...  12s
 ⠙ Generating slides (~30s)...  13s
 ⠹ Generating slides (~30s)...  14s
-```diff
+```
 
 **Implementation:**
 
@@ -288,7 +288,7 @@ Next steps:
   Preview:  qu preview slides/week08-regression.qmd
 
 Commit this content?  [1] Review  [2] Commit  [3] Skip: _
-```text
+```
 
 ### Error Message
 
@@ -302,7 +302,7 @@ Recovery:
    Edit schedule:             teach config
 
 Retry?  [Y/n] _
-```text
+```
 
 ### Interactive Mode Flow
 
@@ -315,7 +315,7 @@ Topic:
   [3] Enter custom topic
 
 Your choice [1-3]: _
-```text
+```
 
 ### Revision Menu
 

--- a/docs/specs/dot-dispatcher-refcard.md
+++ b/docs/specs/dot-dispatcher-refcard.md
@@ -78,7 +78,7 @@ df
 │   └── --setup-secrets
 │
 └── help          → Show full help
-```text
+```
 
 ---
 
@@ -106,7 +106,7 @@ RARE (5% of usage)
 │ df undo               (rollback)        │  █             1%
 │ df init               (first-time)      │  █             1%
 └─────────────────────────────────────────┘
-```text
+```
 
 ---
 
@@ -134,7 +134,7 @@ RARE (5% of usage)
                                    ├─→ df doctor (resolve)
                                    │
                                    └─→ df apply --force ──→ SYNCED
-```bash
+```
 
 ---
 
@@ -154,7 +154,7 @@ df edit brew     → ~/.local/share/chezmoi/Brewfile
 # 2. Basename match (.zshrc)
 # 3. Substring match (git → gitconfig)
 # 4. Multiple matches → fzf picker
-```text
+```
 
 ---
 
@@ -179,7 +179,7 @@ df edit brew     → ~/.local/share/chezmoi/Brewfile
          │   └─→ YES: df secret add → Retry
          │
          └─→ [Success]
-```text
+```
 
 ---
 
@@ -201,7 +201,7 @@ Action Colors:
 ⚠ Warning            → Yellow
 ✗ Error              → Red
 ✓ Success            → Green
-```text
+```
 
 ---
 
@@ -223,7 +223,7 @@ $ dash
 📦 Dotfiles: 🟢 Synced (2h ago)        ← NEW!
   3 secrets active • 0 pending changes
   💡 df sync to update
-```text
+```
 
 ### Work Command Integration
 
@@ -233,7 +233,7 @@ $ work my-project
 📦 Checking dotfiles...               ← NEW!
   ⚠ Behind remote by 2 commits
   💡 Run 'df sync' to update? [Y/n]
-```bash
+```
 
 ### Flow Doctor Integration
 
@@ -247,7 +247,7 @@ $ flow doctor
   ✓ Repository connected
   ✓ Secrets configured
   ✓ Synced with remote
-```text
+```
 
 ---
 
@@ -262,7 +262,7 @@ df se<TAB>         → Complete to 'secret'
 df sec <TAB>       → Show: list, add, test, unlock
 df ig<TAB>         → Complete to 'ignore'
 df ignore <TAB>    → Show: add, list, remove, edit, help
-```diff
+```
 
 ---
 
@@ -297,7 +297,7 @@ alias dfd='df diff'        # df diff
 alias dfst='df status'     # df status
 
 # Most users will just use: df edit, df sync, df push
-```text
+```
 
 ---
 
@@ -366,7 +366,7 @@ $ df help
 📚 See also: dash (shows dotfile status)
             work (checks for updates)
             flow doctor (includes dotfile check)
-```bash
+```
 
 ---
 
@@ -404,7 +404,7 @@ dot ignore list
 
 # Edit manually for complex patterns
 dot ignore edit
-```text
+```
 
 **Pattern Format:** Uses gitignore-style patterns (wildcards, directories, negation)
 
@@ -438,7 +438,7 @@ Repository Size Analysis
 💡 Suggestions:
   • Consider adding *.log to .chezmoiignore
   • Large binary detected: dot_background.png (should this be tracked?)
-```diff
+```
 
 **When to Use:**
 - Repository feels slow to sync
@@ -464,7 +464,7 @@ $ dot add ~/projects/my-app/.env
    Adding to chezmoi will duplicate version control.
 
    Continue? [y/N]
-```text
+```
 
 **Auto-Suggest Ignore Patterns:**
 
@@ -479,7 +479,7 @@ $ dot add node_modules/
    Run: dot ignore add "node_modules/"
 
    Continue with add? [y/N]
-```text
+```
 
 **Preview Before Apply:**
 
@@ -493,7 +493,7 @@ $ dot sync
   -  old_config.txt
 
 Apply these changes? [Y/n]
-```text
+```
 
 ---
 
@@ -536,7 +536,7 @@ Need to...
 │
 └─ First-time setup?
    └─→ df init
-```text
+```
 
 ---
 
@@ -560,7 +560,7 @@ Plus:
 🔐 Secret injection (Bitwarden)
 📝 Template rendering (machine-specific)
 🔄 Auto-backup before changes
-```text
+```
 
 ---
 

--- a/docs/specs/dotfile-ux-design.md
+++ b/docs/specs/dotfile-ux-design.md
@@ -37,7 +37,7 @@ df edit .zshrc  # Edit dotfile
 df sync         # Pull latest changes
 df push         # Push local changes
 df status       # Show sync status
-```diff
+```
 
 ### Option B: `dot` (Explicit)
 
@@ -100,7 +100,7 @@ df() {
         *)          echo "df: unknown action: $1" >&2; return 1 ;;
     esac
 }
-```bash
+```
 
 ---
 
@@ -118,7 +118,7 @@ df edit .zshrc
 # User makes changes
 # Auto-preview on save
 # Prompt: Apply changes? [Y/n]
-```diff
+```
 
 **ADHD-friendly features:**
 - One command, no mental overhead
@@ -133,7 +133,7 @@ df edit .zshrc     → ~/.config/zsh/.zshrc
 df edit zshrc      → ~/.config/zsh/.zshrc (fuzzy match)
 df edit git        → ~/.gitconfig (intelligent match)
 df edit ssh        → ~/.ssh/config
-```bash
+```
 
 ### 2. `dot sync` - Pull Latest (25% of daily use)
 
@@ -148,7 +148,7 @@ df sync
 #    M ~/.zshrc (3 lines changed)
 #    M ~/.gitconfig (1 line added)
 # Apply now? [Y/n]
-```diff
+```
 
 **Safety features:**
 - Shows diff before applying
@@ -176,7 +176,7 @@ df
 # Secrets: 3 injected
 #
 # 💡 Next: df sync (to pull latest)
-```text
+```
 
 **Information hierarchy:**
 1. Sync state (most critical)
@@ -200,7 +200,7 @@ $ df edit .zshrc
 🔑 Enter master password: ********
 ✓ Unlocked Bitwarden
 ✓ Opening ~/.zshrc in $EDITOR...
-```diff
+```
 
 **Auto-recovery features:**
 - Detects expired session before opening editor
@@ -214,7 +214,7 @@ $ df edit .zshrc
 df unlock
 # OR
 df secret unlock
-```yaml
+```
 
 ### Problem 2: Chezmoi Merge Conflicts
 
@@ -237,7 +237,7 @@ Choice [1-4]: 3
 (After user resolves)
 ✓ Conflict resolved
 Apply merged version? [Y/n]
-```diff
+```
 
 **Safety mechanisms:**
 - Always shows both versions before merge
@@ -261,7 +261,7 @@ Troubleshoot:
 
 Proceed without secrets? [y/N] n
 ✗ Aborted. Fix secrets first.
-```diff
+```
 
 **Graceful degradation:**
 - Clear error message with exact item name
@@ -286,7 +286,7 @@ $ df
   df sync           Pull latest
   df push           Push changes
   df help           Full help
-```text
+```
 
 **Level 2: Full help (`dot help`)**
 
@@ -338,14 +338,14 @@ $ df help
   sec = secret, ls = list, up = push
 
 💡 TIP: Run 'df' without arguments for quick status
-```bash
+```
 
 **Level 3: Command-specific help**
 
 ```bash
 $ df edit --help
 # Detailed help for edit subcommand
-```bash
+```
 
 ### Inline Hints
 
@@ -356,7 +356,7 @@ $ df diff
 # Shows changes...
 💡 Next: df apply (to apply changes)
        df edit <file> (to modify)
-```text
+```
 
 ### Integration with `dash`
 
@@ -381,7 +381,7 @@ $ dash
   💡 df sync to update
 
 ...
-```text
+```
 
 ### Integration with `work`
 
@@ -396,14 +396,14 @@ $ work flow-cli
   Skipped. You can sync later with 'df sync'.
 
 ✓ Session started
-```bash
+```
 
 **Configuration (opt-out):**
 
 ```bash
 # In .zshrc or flow-cli config
 export FLOW_DF_CHECK_ON_WORK=0  # Disable auto-check
-```diff
+```
 
 ---
 
@@ -438,7 +438,7 @@ export FLOW_DF_CHECK_ON_WORK=0  # Disable auto-check
 # Icons (consistent with flow-cli)
 📦 Dotfiles   ✓ Success   ⚠ Warning   ✗ Error
 🔐 Secrets    📝 File     🔄 Sync     💡 Tip
-```bash
+```
 
 ### Layout Pattern
 
@@ -452,7 +452,7 @@ export FLOW_DF_CHECK_ON_WORK=0  # Disable auto-check
 
 [FOOTER]      💡 Next step suggestions
               🔗 Related commands
-```text
+```
 
 ### Example: `dot status` output
 
@@ -487,7 +487,7 @@ export FLOW_DF_CHECK_ON_WORK=0  # Disable auto-check
 
 🔗 See also: df list (all files)
             df doctor (troubleshoot)
-```text
+```
 
 ---
 
@@ -501,7 +501,7 @@ df edit .zshrc      # → ~/.config/zsh/.zshrc
 df edit git         # → ~/.gitconfig
 df edit gitconfig   # → ~/.gitconfig
 df edit ssh         # → ~/.ssh/config
-```diff
+```
 
 **Fuzzy matching logic:**
 1. Exact match in tracked files
@@ -522,7 +522,7 @@ df edit ssh         # → ~/.ssh/config
 df undo             # Undo last apply
 df undo --list      # Show undo history (last 10)
 df undo 3           # Undo to 3 commits ago
-```text
+```
 
 **Implementation:** Leverage chezmoi's backup system
 
@@ -532,7 +532,7 @@ df undo 3           # Undo to 3 commits ago
 df sync --dry-run   # Preview without applying
 df push -n          # Preview without pushing
 df apply --dry      # Show what would change
-```diff
+```
 
 ---
 
@@ -599,7 +599,7 @@ flow-cli/
 │       └── DOT-DISPATCHER-REFERENCE.md # Full documentation
 └── tests/
     └── dot-dispatcher.test.zsh         # Test suite
-```diff
+```
 
 ### Development Phases
 
@@ -646,7 +646,7 @@ flow-cli/
 df version status              # Show R/Python versions across machines
 df version sync                # Sync mise configurations
 df version set R@4.5.2         # Set R version for project
-```text
+```
 
 ### Package Sync
 
@@ -654,7 +654,7 @@ df version set R@4.5.2         # Set R version for project
 df pkg status                  # Compare Homebrew packages
 df pkg sync                    # Install missing packages
 df pkg export                  # Update Brewfile
-```text
+```
 
 ### Template Picker
 
@@ -662,14 +662,14 @@ df pkg export                  # Update Brewfile
 df template                    # Interactive template editor
 df template add-machine        # Add machine-specific config
 df template test               # Preview template rendering
-```text
+```
 
 ### Automated Sync
 
 ```bash
 df watch                       # Auto-sync on file changes
 df schedule hourly             # Scheduled sync (via launchd)
-```text
+```
 
 ---
 
@@ -680,7 +680,7 @@ df schedule hourly             # Scheduled sync (via launchd)
 ```bash
 flow dotfile edit
 flow dotfile sync
-```diff
+```
 
 **Rejected because:**
 - `flow` command is meta-level (flow test, flow build, flow doctor)
@@ -692,7 +692,7 @@ flow dotfile sync
 ```bash
 cm edit .zshrc
 cm sync
-```diff
+```
 
 **Rejected because:**
 - Not integrated with flow-cli ecosystem
@@ -759,7 +759,7 @@ df push
 
 # Check status anytime
 df
-```bash
+```
 
 ### Troubleshooting
 
@@ -778,7 +778,7 @@ df undo
 
 # Show sync status
 df status -v
-```bash
+```
 
 ### One-Time Setup
 

--- a/docs/specs/workflow-system-architecture-analysis.md
+++ b/docs/specs/workflow-system-architecture-analysis.md
@@ -54,7 +54,7 @@ flow-cli manages state across **three persistence layers**:
 │ - Cross-project context                                 │
 │ - Advanced querying                                     │
 └─────────────────────────────────────────────────────────┘
-```diff
+```
 
 **Key Pattern:** Each layer is **self-sufficient** for its scope:
 - Layer 1 provides in-session context (environment variables)
@@ -87,7 +87,7 @@ _flow_session_start() {
     echo "$(_flow_timestamp) START $project" >> "$worklog"
   fi
 }
-```diff
+```
 
 **No distributed locks or transactions** - State propagates through:
 1. Function calls (synchronous)
@@ -108,7 +108,7 @@ _flow_session_start() {
 project=flow-cli
 start=1736451234
 date=2026-01-09
-```diff
+```
 
 **Operations:**
 - Read: `grep "^key=" file | cut -d= -f2`
@@ -121,7 +121,7 @@ date=2026-01-09
 # worklog format (timestamped events)
 2026-01-09 14:30:00 START flow-cli
 2026-01-09 15:45:00 END 75m (Completed CC unified grammar)
-```diff
+```
 
 **Operations:**
 - Append: `echo "$timestamp $event" >> logfile`
@@ -138,7 +138,7 @@ date=2026-01-09
 # wins.md format (structured markdown)
 - 💻 Implemented CC unified grammar (@flow-cli) #code [2026-01-09 14:30]
 - 🚀 Deployed v4.9.2 to production #ship [2026-01-09 15:45]
-```diff
+```
 
 **Operations:**
 - Append: `echo "- $icon $text #$category [$timestamp]" >> wins.md`
@@ -188,7 +188,7 @@ date=2026-01-09
 │ - Unset environment vars        │
 │ - Sync to atlas (optional)      │
 └─────────────────────────────────┘
-```diff
+```
 
 **State Recovery:** If shell crashes, `.current-session` persists:
 - Next shell reads orphaned session file
@@ -210,7 +210,7 @@ flow-cli supports **implicit chaining** through command sequences:
 work flow-cli       # Start session, export $FLOW_CURRENT_PROJECT
 win "Fixed bug"     # Log accomplishment (reads $FLOW_CURRENT_PROJECT)
 finish "All done"   # End session, optionally commit git changes
-```diff
+```
 
 **Context propagation:**
 - `work` → Exports `$FLOW_CURRENT_PROJECT`
@@ -224,7 +224,7 @@ finish "All done"   # End session, optionally commit git changes
 pick                # cd to project (changes $PWD)
 cc                  # Launch Claude in $PWD
 g push              # Push changes (reads $PWD/.git)
-```diff
+```
 
 **Context propagation:**
 - `pick` → Changes `$PWD` via `cd`
@@ -238,7 +238,7 @@ g push              # Push changes (reads $PWD/.git)
 r test              # Run R package tests
 qu preview          # Preview Quarto document
 g feature start foo # Start feature branch
-```diff
+```
 
 **Context propagation:**
 - Dispatchers read `$PWD` for project context
@@ -253,7 +253,7 @@ g feature start foo # Start feature branch
 ```bash
 # NOT SUPPORTED: Pipe output between commands
 pick --format=json | cc --from-json  # ❌ No JSON pipe interface
-```diff
+```
 
 **Why missing:** Commands are designed for **human interaction**, not machine consumption.
 
@@ -267,7 +267,7 @@ pick --format=json | cc --from-json  # ❌ No JSON pipe interface
 ```bash
 # NOT SUPPORTED: Run next command only if previous succeeds
 work flow-cli && r test && g push  # ✅ Shell-level (bash &&)
-```diff
+```
 
 **Actually works:** Shell's `&&` provides conditional chaining.
 
@@ -280,7 +280,7 @@ work flow-cli && r test && g push  # ✅ Shell-level (bash &&)
 ```bash
 # NOT SUPPORTED: Named workflow templates
 flow workflow run "feature-complete"  # ❌ No workflow engine
-```zsh
+```
 
 **Workaround:** User creates shell functions:
 
@@ -293,7 +293,7 @@ feature_complete() {
   gh pr create --fill
   finish "Feature complete"
 }
-```diff
+```
 
 **Integration point:** flow-cli could provide:
 - `flow workflow define <name> <commands>`
@@ -339,7 +339,7 @@ Add **structured output mode**:
 pick --format=json
 # Output:
 # {"project":"flow-cli","path":"/Users/dt/projects/dev-tools/flow-cli","type":"node"}
-```bash
+```
 
 Add **command hooks**:
 
@@ -347,7 +347,7 @@ Add **command hooks**:
 # Example: Run script after successful command
 work --after="notify-send 'Session started'"
 finish --after="~/scripts/backup-session.sh"
-```zsh
+```
 
 ---
 
@@ -364,7 +364,7 @@ flow-cli propagates **three context types**:
 _flow_detect_project_type "$PWD"  # → "r-package" | "node" | "quarto"
 _flow_find_project_root           # → "/Users/dt/projects/dev-tools/flow-cli"
 _flow_project_name "$path"        # → "flow-cli"
-```diff
+```
 
 **Propagation:**
 - Every command that needs project context calls these functions
@@ -377,7 +377,7 @@ _flow_project_name "$path"        # → "flow-cli"
 $FLOW_CURRENT_PROJECT              # Exported by work command
 $FLOW_SESSION_START                # Exported by work command
 ~/.config/flow-cli/.current-session # Persisted session state
-```diff
+```
 
 **Propagation:**
 - Environment variables (exported, inherited by subshells)
@@ -390,7 +390,7 @@ $FLOW_SESSION_START                # Exported by work command
 ~/Library/Application Support/flow-cli/wins.md        # Accomplishments
 ~/Library/Application Support/flow-cli/inbox.md       # Captured items
 ~/Library/Application Support/flow-cli/goal.json      # Daily goal
-```diff
+```
 
 **Propagation:**
 - Read/written by commands as needed
@@ -413,7 +413,7 @@ win() {
   # 2. Tag win with project context
   echo "- $icon $text${project:+ (@$project)} #$category [$timestamp]" >> "$wins"
 }
-```diff
+```
 
 **Resolution order:**
 1. Explicit argument (if provided)
@@ -433,7 +433,7 @@ win() {
 - Active sessions across projects
 - Project relationships
 - Cross-project breadcrumbs
-```diff
+```
 
 **Without atlas:**
 - Each project's context is isolated
@@ -449,7 +449,7 @@ Support **project relationships** in `.STATUS`:
 - aiterm (CLI tool)
 - atlas (state engine)
 - homebrew-tap (distribution)
-```diff
+```
 
 Commands can then:
 - Suggest related projects to work on
@@ -502,7 +502,7 @@ flow-cli provides **zero formal extension points**. All customization is:
     hooks/
       pre-work.zsh          # Runs before 'work' command
       post-finish.zsh       # Runs after 'finish' command
-```bash
+```
 
 #### Plugin Manifest
 
@@ -519,7 +519,7 @@ flow_plugin_register_command "backup" "$PLUGIN_DIR/commands/backup.zsh"
 # Register hooks
 flow_plugin_register_hook "pre-work" "$PLUGIN_DIR/hooks/pre-work.zsh"
 flow_plugin_register_hook "post-finish" "$PLUGIN_DIR/hooks/post-finish.zsh"
-```zsh
+```
 
 #### Hook Points
 
@@ -548,7 +548,7 @@ work() {
 
   _flow_run_hook "post-work" "$project"  # ← Hook point
 }
-```bash
+```
 
 **Hook API:**
 
@@ -560,7 +560,7 @@ work() {
 if [[ "$1" == "production" ]]; then
   echo "⚠️  Working on production - be careful!"
 fi
-```bash
+```
 
 ### 4.3 Workflow Plugin Example
 
@@ -596,13 +596,13 @@ flow-feature-complete() {
   # 6. End session
   finish "Feature $branch shipped"
 }
-```text
+```
 
 **Usage:**
 
 ```bash
 flow feature-complete  # Runs entire workflow
-```text
+```
 
 ---
 
@@ -635,7 +635,7 @@ commands/                    # 7 files (core commands)
   flow.zsh                   # Meta-command
   doctor.zsh                 # Health check
   pick.zsh                   # Project picker
-```diff
+```
 
 **Pattern: Dispatchers for domains**
 
@@ -670,7 +670,7 @@ Option 2: Subcommand of `flow`
 
 Decision: Option 2 (subcommand)
 Reason: Workflow management is meta-functionality, fits under `flow` namespace
-```zsh
+```
 
 ### 5.2 Namespace Collision Avoidance
 
@@ -717,7 +717,7 @@ real    0m0.125s   # 125ms (fzf startup)
 
 $ time g
 real    0m0.004s   # 4ms
-```diff
+```
 
 **Performance bottlenecks:**
 
@@ -757,7 +757,7 @@ _flow_list_projects_cached() {
   echo "$projects" > "$cache_file"
   echo "$projects"
 }
-```zsh
+```
 
 ---
 
@@ -797,7 +797,7 @@ _flow_session_start() {
     echo "START $project $timestamp" >> "$worklog"
   fi
 }
-```diff
+```
 
 **Benefits:**
 - Zero runtime overhead when atlas not installed
@@ -820,7 +820,7 @@ g() {
     *) git "$@" ;;
   esac
 }
-```diff
+```
 
 **Benefits:**
 - Progressive enhancement (add shortcuts without breaking existing usage)
@@ -844,7 +844,7 @@ catch() {
     read "text?💡 Quick capture: "
   fi
 }
-```yaml
+```
 
 ---
 
@@ -886,7 +886,7 @@ Based on flow-cli analysis, a workflow system should:
 # flow-cli delegates to workflow engine
 work flow-cli  # → workflow start session flow-cli
 finish         # → workflow end session
-```diff
+```
 
 **Pros:**
 - Separation of concerns
@@ -904,7 +904,7 @@ finish         # → workflow end session
 # flow-cli has workflow subcommands
 flow workflow define deploy "r test && g push && gh pr create"
 flow workflow run deploy
-```diff
+```
 
 **Pros:**
 - Integrated experience
@@ -926,7 +926,7 @@ flow workflow run deploy  # Sequential: r test && g push
 
 # Complex (external)
 atlas workflow run ci-pipeline  # Parallel, conditional, cross-project
-```bash
+```
 
 ### 7.3 Proposed Workflow API
 
@@ -950,7 +950,7 @@ flow workflow delete <name>
 
 # Show workflow steps
 flow workflow show <name>
-```text
+```
 
 **Storage:**
 
@@ -959,7 +959,7 @@ flow workflow show <name>
   deploy.yaml
   ci.yaml
   release.yaml
-```yaml
+```
 
 **Format:**
 

--- a/docs/tutorials/01-first-session.md
+++ b/docs/tutorials/01-first-session.md
@@ -29,7 +29,7 @@ ls ~/.config/zsh/functions/adhd-helpers.zsh
 
 # Check you have projects
 ls ~/projects/
-```diff
+```
 
 ---
 
@@ -53,7 +53,7 @@ Flow CLI helps you stay focused by tracking work sessions. Here's the workflow:
 │  Pick Project  │ --> │   Work on It   │ --> │  End Session   │
 │  (just-start)  │     │   (commands)   │     │   (finish)     │
 └────────────────┘     └────────────────┘     └────────────────┘
-```text
+```
 
 ---
 
@@ -65,7 +65,7 @@ Let's see what projects you can work on:
 
 ```bash
 dash
-```text
+```
 
 **What happened:** You see a dashboard showing all your projects organized by status (Active, Ready, Paused, Blocked).
 
@@ -82,7 +82,7 @@ Example output:
 
 📋 READY TO START (1):
   📊 research-project [P2] 20% - Literature review
-```text
+```
 
 ### Step 1.2: Let Flow Pick For You
 
@@ -90,7 +90,7 @@ Instead of deciding, let Flow choose based on priority:
 
 ```bash
 just-start
-```text
+```
 
 **What happened:** Flow automatically selects your highest-priority active project and shows you the details:
 
@@ -113,7 +113,7 @@ just-start
    dash          = See all projects
 
 📁 /Users/dt/projects/dev-tools/flow-cli
-```text
+```
 
 > **Note:** Flow picks based on: P0 active → P1 active → any active → most recent
 
@@ -123,7 +123,7 @@ Now start a session on the project:
 
 ```bash
 work .
-```diff
+```
 
 **What happened:** Flow starts a work session — it `cd`s into the project, shows context, and begins session tracking.
 
@@ -148,7 +148,7 @@ At this point, you should have:
 ```bash
 pwd
 # Expected: You're in the project directory
-```text
+```
 
 ---
 
@@ -160,7 +160,7 @@ Now set a focus timer to stay on track:
 
 ```bash
 f25
-```text
+```
 
 **What happened:** A 25-minute Pomodoro timer starts. Your terminal shows a countdown.
 
@@ -171,7 +171,7 @@ Example output:
 ⏱️  25:00 remaining...
 
 [Terminal shows countdown in prompt]
-```text
+```
 
 > **Tip:** Use `f50` for a 50-minute deep work session instead
 
@@ -181,7 +181,7 @@ If you forget what you're working on:
 
 ```bash
 why
-```text
+```
 
 **What happened:** Shows your current project context:
 
@@ -196,7 +196,7 @@ Task:     Documentation improvements
 Progress: 95%
 
 Active since: 14 minutes ago
-```diff
+```
 
 ### Step 2.3: Work on Your Task
 
@@ -223,7 +223,7 @@ npm run build # Build project
 gst          # Check status (git status)
 ga .         # Stage changes (git add .)
 gcmsg "msg"  # Commit (git commit -m "msg")
-```text
+```
 
 ### Step 2.4: Log Your Wins
 
@@ -231,7 +231,7 @@ When you accomplish something:
 
 ```bash
 win "Completed first Flow tutorial"
-```diff
+```
 
 **What happened:** Your accomplishment is logged to track progress.
 
@@ -249,7 +249,7 @@ At this point, you should have:
 ```bash
 wins
 # Expected: See your logged wins for today
-```text
+```
 
 ---
 
@@ -261,7 +261,7 @@ Before ending, update the project status:
 
 ```bash
 status .
-```text
+```
 
 **What happened:** Flow asks for updates interactively:
 
@@ -287,7 +287,7 @@ Progress? [95]
 > 100
 
 ✅ Updated! Press Enter to continue...
-```text
+```
 
 > **Tip:** Press Enter to keep current values, only type when you want to change something
 
@@ -300,7 +300,7 @@ gst          # Check what changed
 gaa          # Stage all changes
 gcmsg "docs: add first session tutorial"
 gp           # Push to remote
-```text
+```
 
 ### Step 3.3: View Today's Wins
 
@@ -308,7 +308,7 @@ See what you accomplished:
 
 ```bash
 wins
-```text
+```
 
 **What happened:** Lists all wins you logged today:
 
@@ -319,7 +319,7 @@ wins
 2. ✅ Updated project documentation
 
 💪 Great work today!
-```diff
+```
 
 ### Understanding Session Tracking
 
@@ -363,7 +363,7 @@ why                    # Where am I? What am I doing?
 status .               # Update progress
 gaa && gcmsg "msg"     # Commit changes
 wins                   # See accomplishments
-```bash
+```
 
 **Time:** <3 minutes to start/end, focused time in between
 
@@ -398,7 +398,7 @@ pick
 # Option 3: Use dashboard
 dash research        # Filter by category
 work research-project
-```sql
+```
 
 </details>
 
@@ -416,7 +416,7 @@ status stat-440 active P1 "Grade final exams" 80
 
 # Verify
 dash
-```sql
+```
 
 </details>
 
@@ -439,7 +439,7 @@ status new-project ready P2 "Initial setup" 0
 
 # Verify it appears in dashboard
 dash
-```bash
+```
 
 </details>
 
@@ -459,7 +459,7 @@ source ~/.zshrc
 
 # Or check if functions exist
 ls ~/.config/zsh/functions/adhd-helpers.zsh
-```bash
+```
 
 ### "No projects found"
 
@@ -474,7 +474,7 @@ status your-project --create
 
 # Check project structure
 ls ~/projects/
-```bash
+```
 
 ### "Editor didn't open"
 
@@ -491,7 +491,7 @@ work . -e positron # Positron
 # Or open manually
 code .     # VS Code
 rstudio .  # RStudio
-```text
+```
 
 ---
 
@@ -521,7 +521,7 @@ why            # Check context
 win "msg"      # Log accomplishment
 wins           # See today's wins
 status .       # Update progress
-```diff
+```
 
 ---
 

--- a/docs/tutorials/02-multiple-projects.md
+++ b/docs/tutorials/02-multiple-projects.md
@@ -21,7 +21,7 @@ Before starting, you should:
 dash | grep -E "ACTIVE|READY"
 
 # Should see at least 2-3 projects
-```yaml
+```
 
 ---
 
@@ -51,7 +51,7 @@ Flow CLI helps you juggle these without losing track:
 │  All Projects│ --> │Filter Category│ --> │ Work on One │
 │   (dash)     │     │  (dash X)     │     │   (work X)   │
 └──────────────┘     └──────────────┘     └──────────────┘
-```text
+```
 
 ---
 
@@ -63,7 +63,7 @@ Start by seeing everything:
 
 ```bash
 dash
-```text
+```
 
 **What happened:** You see projects grouped by status:
 
@@ -83,7 +83,7 @@ dash
   📊 product-of-three [P1] 60% - Review simulations
   📦 rmediation [P2] 0% - Add new feature
   📚 causal-inference [P2] 0% - Prep next semester
-```bash
+```
 
 > **Note:** Too many active projects? This is common - we'll fix it!
 
@@ -94,7 +94,7 @@ Focus on one type of work:
 ```bash
 # Teaching projects only
 dash teaching
-```text
+```
 
 **What happened:** Shows only teaching-related projects:
 
@@ -106,7 +106,7 @@ dash teaching
 🔥 ACTIVE (2):
   📚 stat-440 [P0] 60% - Grade midterms
   📚 causal-inference [P2] 0% - Prep next semester
-```text
+```
 
 **Other category filters:**
 
@@ -114,7 +114,7 @@ dash teaching
 dash research      # Research projects only
 dash packages      # R packages only
 dash dev           # Development tools
-```bash
+```
 
 ### Step 1.3: Prioritize What Matters
 
@@ -125,7 +125,7 @@ Identify which projects should be active:
 dash | grep P0     # Critical projects
 dash | grep P1     # Important projects
 dash | grep P2     # Normal projects
-```diff
+```
 
 ### Checkpoint
 
@@ -141,7 +141,7 @@ At this point, you should have:
 # Count active projects
 dash | grep "ACTIVE NOW" -A 20 | grep -c "%"
 # Expected: Number of your active projects (should be 2-4 ideally)
-```bash
+```
 
 ---
 
@@ -163,7 +163,7 @@ work collider
 # Evening: Package development
 dash packages
 work mediationverse
-```text
+```
 
 ### Step 2.2: Priority-Based Switching
 
@@ -171,7 +171,7 @@ Let Flow pick based on priority:
 
 ```bash
 just-start
-```text
+```
 
 **What happened:** Flow selects the highest-priority project automatically:
 
@@ -186,7 +186,7 @@ just-start
 │ Reason:  P0 priority + active               │
 │ Next:    Grade midterms                     │
 └─────────────────────────────────────────────┘
-```text
+```
 
 **How it picks:**
 
@@ -201,7 +201,7 @@ Use the project picker for fuzzy search:
 
 ```bash
 pick
-```text
+```
 
 **What happened:** Interactive fuzzy finder shows all projects. Type to filter:
 
@@ -214,7 +214,7 @@ pick
   📦 medfit
   📦 rmediation
   📚 mediation-planning
-```bash
+```
 
 Use arrow keys to select, press Enter to navigate.
 
@@ -230,7 +230,7 @@ work mediationverse
 work med           # → mediationverse
 work stat          # → stat-440
 work coll          # → collider
-```diff
+```
 
 ### Checkpoint
 
@@ -246,7 +246,7 @@ At this point, you should have:
 ```bash
 pwd
 # Expected: You're in a different project than you started
-```bash
+```
 
 ---
 
@@ -259,7 +259,7 @@ Too many active projects? Pause the less urgent ones:
 ```bash
 # Pause a project
 status medfit
-```text
+```
 
 Interactive prompt:
 
@@ -277,13 +277,13 @@ Progress? [30]
 > 30
 
 ✅ Updated!
-```text
+```
 
 Or quick mode:
 
 ```bash
 status medfit paused P2 "Resume later" 30
-```text
+```
 
 ### Step 3.2: Reactivate Projects
 
@@ -291,7 +291,7 @@ When ready to resume:
 
 ```bash
 status medfit active P1 "Add package vignettes" 30
-```text
+```
 
 ### Step 3.3: Mark Projects as Blocked
 
@@ -299,14 +299,14 @@ If waiting on something:
 
 ```bash
 status collider blocked P1 "Waiting for reviewer comments" 90
-```text
+```
 
 **What happened:** Project moves to BLOCKED section in dashboard:
 
 ```text
 🚫 BLOCKED (1):
   📊 collider [P1] 90% - Waiting for reviewer comments
-```bash
+```
 
 ### Step 3.4: Set Realistic Priorities
 
@@ -321,7 +321,7 @@ status product-of-three active P1 "Review sims" 60
 
 # Normal (when you can)
 status medfit paused P2 "Resume later" 30
-```diff
+```
 
 **Priority guidelines:**
 
@@ -346,7 +346,7 @@ At this point, you should have:
 ```bash
 dash
 # Expected: Fewer ACTIVE projects, some PAUSED/BLOCKED
-```bash
+```
 
 ---
 
@@ -366,7 +366,7 @@ work .
 
 # 4. Set focus timer
 f25
-```bash
+```
 
 **Time:** <30 seconds
 **Result:** Working on most important teaching task
@@ -385,7 +385,7 @@ f50
 
 # 4. Work, then update
 status . active P1 "Completed analysis" 95
-```bash
+```
 
 **Time:** <20 seconds
 **Result:** Focused research session
@@ -407,7 +407,7 @@ rdoc
 # 4. Commit progress
 gaa && gcmsg "feat: add new mediator"
 status . active P0 "Testing complete" 90
-```bash
+```
 
 **Time:** Varies by development
 **Result:** Incremental package progress
@@ -430,7 +430,7 @@ status mediationverse active P0 "Almost done" 95
 
 # 4. Pause what you can't do this week
 status medfit paused P2 "Next week" 30
-```bash
+```
 
 **Time:** 5-10 minutes weekly
 **Result:** Realistic priorities set
@@ -453,7 +453,7 @@ f25
 # 4. Return to original
 work mediationverse
 status . active P0 "Resume work" 75
-```bash
+```
 
 ---
 
@@ -491,7 +491,7 @@ status flow-cli active P1 "Documentation" 95
 # 4. Verify
 dash
 # Should see 2-4 active, rest paused
-```bash
+```
 
 </details>
 
@@ -523,7 +523,7 @@ work mediationverse
 f25
 # ... work ...
 status . active P0 "All tests pass" 90
-```bash
+```
 
 </details>
 
@@ -555,7 +555,7 @@ status . ready P2 "Done - archive if needed" 100
 # 5. Resume original work
 work current-project
 status . active P1 "Resume work" 60
-```bash
+```
 
 </details>
 
@@ -575,7 +575,7 @@ dash | grep ACTIVE
 # Pick 2-3 most important
 # Pause the rest
 status project-name paused P2 "Do later" X
-```bash
+```
 
 ### "Can't decide what to work on"
 
@@ -590,7 +590,7 @@ just-start
 # Or filter and pick
 dash teaching      # Focus on one category
 work stat-440      # Pick the urgent one
-```bash
+```
 
 ### "Switching too frequently"
 
@@ -607,7 +607,7 @@ dash teaching && work . && f50
 dash research && work . && f50
 
 # Use timers to enforce focus
-```text
+```
 
 ---
 
@@ -633,7 +633,7 @@ work <name>        # Switch to project
 status . paused    # Pause current
 status . active    # Activate project
 status . blocked   # Mark blocked
-```diff
+```
 
 **Key insights:**
 

--- a/docs/tutorials/03-status-visualizations.md
+++ b/docs/tutorials/03-status-visualizations.md
@@ -21,7 +21,7 @@ Before starting, you should:
 dash | grep "%"
 
 # Should see percentage values for projects
-```diff
+```
 
 ---
 
@@ -45,7 +45,7 @@ Flow CLI uses visual indicators to make progress tangible:
 │  Update %     │ --> │  See Progress │ --> │ Stay Motivated│
 │  (status)     │     │   (dash)      │     │   (wins)      │
 └───────────────┘     └───────────────┘     └───────────────┘
-```diff
+```
 
 Visual feedback helps ADHD-friendly workflows by:
 
@@ -63,7 +63,7 @@ View a project's progress:
 
 ```bash
 dash
-```text
+```
 
 **What you'll see:**
 
@@ -72,7 +72,7 @@ dash
   📦 mediationverse [P0] 85% - Final simulations
   📚 stat-440 [P1] 60% - Grade midterms
   🔧 flow-cli [P2] 95% - Documentation
-```bash
+```
 
 **Progress breakdown:**
 
@@ -91,7 +91,7 @@ Some commands show full progress bars:
 ```bash
 # View detailed status (if implemented)
 status mediationverse --show
-```text
+```
 
 **What you might see:**
 
@@ -109,7 +109,7 @@ Recent progress:
   Dec 20: 60% → 70% (+10%)
   Dec 22: 70% → 80% (+10%)
   Dec 24: 80% → 85% (+5%)
-```text
+```
 
 ### Step 1.3: Category Summaries
 
@@ -117,7 +117,7 @@ See aggregate progress:
 
 ```bash
 dash teaching
-```text
+```
 
 **What you'll see:**
 
@@ -130,7 +130,7 @@ dash teaching
 🔥 ACTIVE (2):
   📚 stat-440 [P0] 60% - Grade midterms
   📚 causal-inference [P2] 30% - Prep syllabus
-```diff
+```
 
 ### Checkpoint
 
@@ -145,7 +145,7 @@ At this point, you should understand:
 ```bash
 dash | grep "%"
 # Expected: See projects with different progress levels
-```bash
+```
 
 ---
 
@@ -159,14 +159,14 @@ When starting fresh:
 cd ~/projects/new-project
 status new-project --create
 status new-project ready P2 "Initial setup" 0
-```text
+```
 
 **What happened:** Project created at 0%:
 
 ```text
 📋 READY TO START (1):
   📊 new-project [P2] 0% - Initial setup
-```sql
+```
 
 ### Step 2.2: Small Incremental Updates
 
@@ -181,7 +181,7 @@ status new-project active P2 "First feature" 25
 
 # Week later: Halfway
 status new-project active P2 "Core complete" 50
-```diff
+```
 
 **Why small increments?**
 
@@ -197,7 +197,7 @@ Many projects follow this pattern:
 0-80%:   Fast progress (easy work)
 80-95%:  Slow progress (hard/tedious work)
 95-100%: Very slow (polish, edge cases)
-```bash
+```
 
 **Example progression:**
 
@@ -216,7 +216,7 @@ status project active P1 "Documentation" 95
 
 # Week 6: Complete
 status project ready P2 "Done!" 100
-```diff
+```
 
 > **Tip:** Don't be discouraged when 80-100% takes as long as 0-80%!
 
@@ -248,7 +248,7 @@ At this point, you should:
 status . active P1 "Reached 75% milestone" 75
 dash
 # Expected: See updated progress
-```bash
+```
 
 ---
 
@@ -270,7 +270,7 @@ win "75% complete - final push!"
 # Hit 100%!
 status . ready P2 "Complete!" 100
 win "COMPLETED mediationverse package!!!"
-```bash
+```
 
 ### Step 3.2: Track Velocity
 
@@ -285,13 +285,13 @@ status project active P1 "Week complete" 30
 
 # Velocity: 20% per week
 # Estimate: 3.5 weeks to complete (70% remaining / 20% per week)
-```text
+```
 
 **Track in your task description:**
 
 ```bash
 status project active P1 "Week 2 - on track (+20%)" 30
-```bash
+```
 
 ### Step 3.3: Use Visual Momentum
 
@@ -311,7 +311,7 @@ dash
 # flow-cli: 90% ⬆️ +10%
 
 win "Productive week! All projects advanced!"
-```bash
+```
 
 ### Step 3.4: Handle Setbacks
 
@@ -322,7 +322,7 @@ Sometimes progress goes backward:
 status project active P0 "Fix critical bug - set back" 70
 
 # Previous was 85%, now 70% (-15%)
-```diff
+```
 
 **This is OK!** Accurate progress > inflated numbers.
 
@@ -340,7 +340,7 @@ At this point, you should:
 ```bash
 wins
 # Expected: See celebration wins for milestones
-```bash
+```
 
 ---
 
@@ -363,7 +363,7 @@ status mediationverse active P0 "Package development" 75
 
 # Update based on weighted average
 status mediationverse active P0 "Focus on docs/vignettes" 70
-```bash
+```
 
 ### Technique 2: Must-Have vs Nice-to-Have
 
@@ -377,7 +377,7 @@ status project active P1 "All features" 60
 status project active P1 "Core features only" 85
 
 # Suddenly much closer to done!
-```bash
+```
 
 ### Technique 3: Time-Based vs Work-Based
 
@@ -388,14 +388,14 @@ Two ways to track:
 ```bash
 # Week 1 of 10 = 10%
 status project active P1 "Week 1" 10
-```bash
+```
 
 **Work-based (recommended):**
 
 ```bash
 # 3 of 10 features done = 30%
 status project active P1 "3/10 features" 30
-```bash
+```
 
 > **Tip:** Work-based is more accurate because work rarely distributes evenly over time.
 
@@ -413,7 +413,7 @@ win "Shipped project v1.0 - done is better than perfect!"
 
 # Future improvements are a new project
 status project-v2 ready P2 "Enhancements for v2" 0
-```bash
+```
 
 ---
 
@@ -455,7 +455,7 @@ status newpackage active P1 "Package skeleton created" 5
 status newpackage active P1 "Main functions working" 35
 
 # Continue incrementally...
-```bash
+```
 
 </details>
 
@@ -481,7 +481,7 @@ status project active P0 "Fixed root cause" 70
 status project active P0 "Re-implemented correctly" 80
 status project active P0 "Validated thoroughly" 90
 status project ready P2 "Done right this time!" 100
-```bash
+```
 
 </details>
 
@@ -515,7 +515,7 @@ win "PROJECT COMPLETE! Shipped and proud!"
 
 # View all celebrations
 wins
-```bash
+```
 
 </details>
 
@@ -539,7 +539,7 @@ status . active P1 "Fixed bug #2" 87
 status . active P1 "Added validation" 88
 
 # Smaller wins feel better!
-```bash
+```
 
 ### "Not sure what percentage to use"
 
@@ -558,7 +558,7 @@ status . active P1 "Added validation" 88
 # 100% = Complete and shipped
 
 # Estimate based on work done vs work remaining
-```bash
+```
 
 ### "Progress feels arbitrary"
 
@@ -573,7 +573,7 @@ status . active P1 "7 of 15 tests passing" 47
 status . active P1 "2 of 4 vignettes written" 80
 
 # % = (completed / total) * 100
-```bash
+```
 
 ---
 
@@ -604,7 +604,7 @@ status . active P0 "Reset to fix properly" 60
 
 # Ship at 95-100%, don't wait for perfection
 status . ready P2 "Good enough!" 100
-```diff
+```
 
 **Progress tips:**
 

--- a/docs/tutorials/04-web-dashboard.md
+++ b/docs/tutorials/04-web-dashboard.md
@@ -25,7 +25,7 @@ node --version
 
 # Check Flow CLI is installed
 which flow
-```diff
+```
 
 ---
 
@@ -50,7 +50,7 @@ The web dashboard provides rich browser-based visualizations:
 │  Launch        │ --> │  Interactive   │ --> │  Take Actions  │
 │  (flow dash)   │     │  Explore       │     │  (terminal)    │
 └────────────────┘     └────────────────┘     └────────────────┘
-```diff
+```
 
 Benefits over terminal dashboard:
 
@@ -70,7 +70,7 @@ Launch the dashboard:
 
 ```bash
 flow dashboard --web
-```text
+```
 
 **What happened:** A web server starts and opens your browser:
 
@@ -82,7 +82,7 @@ Dashboard: http://localhost:3000/dashboard
 
 ✨ Dashboard ready!
 Press Ctrl+C to stop server
-```text
+```
 
 **Your browser opens automatically** showing the dashboard.
 
@@ -112,7 +112,7 @@ The dashboard has 4 main sections:
 │   Active: 4 | Paused: 6 | Blocked: 1        │
 │   Average Progress: 62%                     │
 └─────────────────────────────────────────────┘
-```diff
+```
 
 ### Step 1.3: Navigation Basics
 
@@ -163,7 +163,7 @@ Use filters to focus:
 ☐ Blocked
 
 Apply Filters
-```text
+```
 
 **By category:**
 
@@ -176,7 +176,7 @@ Apply Filters
   Dev Tools
 
 Select: Teaching
-```text
+```
 
 **By priority:**
 
@@ -187,7 +187,7 @@ Select: Teaching
 ☐ P2 (Normal)
 
 Apply Filters
-```text
+```
 
 ### Step 2.2: Search Projects
 
@@ -195,7 +195,7 @@ Use the search box:
 
 ```bash
 [🔍 Search projects...]
-```diff
+```
 
 **Search examples:**
 
@@ -240,7 +240,7 @@ Click a project name to see details:
 │                                             │
 │ [Open in Terminal] [Update Status]          │
 └─────────────────────────────────────────────┘
-```diff
+```
 
 ### Checkpoint
 
@@ -269,7 +269,7 @@ When you have an active session, the dashboard shows live updates:
 # Start a session (in separate terminal)
 work mediationverse
 f25
-```text
+```
 
 **Dashboard displays:**
 
@@ -285,7 +285,7 @@ f25
 ╰───────────────────────────────────────────╯
 
 [Duration updates every second]
-```text
+```
 
 ### Step 3.2: Today's Metrics Charts
 
@@ -300,7 +300,7 @@ Sessions │████████░░ 4 sessions
 Time     │██████████ 3.5 hours
 Projects │███░░░░░░░ 3 active
 Progress │███████░░░ +15% total
-```text
+```
 
 **Progress Distribution:**
 
@@ -312,7 +312,7 @@ Progress Ranges
 51-75%  │████░░░░░░░ 4 projects
 76-99%  │██████░░░░░ 6 projects
 100%    │██░░░░░░░░░ 2 projects
-```text
+```
 
 ### Step 3.3: Statistics Summary
 
@@ -332,7 +332,7 @@ Key metrics at a glance:
 │ Completed This Week:  3 projects          │
 │ Total Time This Week: 18.5 hours          │
 ╰───────────────────────────────────────────╯
-```bash
+```
 
 ### Step 3.4: Auto-Refresh
 
@@ -346,7 +346,7 @@ flow dashboard --web --interval 2000
 
 # Slower updates (every 10 seconds)
 flow dashboard --web --interval 10000
-```sql
+```
 
 ### Checkpoint
 
@@ -386,7 +386,7 @@ Save dashboard views:
 flow status --json > projects.json
 
 # Share with team or import elsewhere
-```bash
+```
 
 ### Feature 2: Multiple Dashboard Windows
 
@@ -397,21 +397,21 @@ Open multiple views:
 ```bash
 flow dashboard --web --port 3000
 # Main dashboard
-```bash
+```
 
 **Terminal 2:**
 
 ```bash
 flow dashboard --web --port 3001 --category teaching
 # Teaching-only dashboard
-```bash
+```
 
 **Terminal 3:**
 
 ```bash
 flow dashboard --web --port 3002 --category research
 # Research-only dashboard
-```text
+```
 
 Now you have 3 browser tabs, each showing different views!
 
@@ -423,19 +423,19 @@ Use the dashboard URL in other apps:
 
 ```text
 http://localhost:3000/dashboard
-```bash
+```
 
 **Obsidian/Notion:**
 
 ```markdown
 [My Projects Dashboard](http://localhost:3000/dashboard)
-```text
+```
 
 **Alfred/Raycast workflow:**
 
 ```bash
 open http://localhost:3000/dashboard
-```text
+```
 
 ### Feature 4: Keyboard Shortcuts
 
@@ -461,7 +461,7 @@ Toggle theme (if implemented):
 ```bash
 [🌙] Dark Mode
 [☀️] Light Mode
-```sql
+```
 
 Or use browser's dark mode settings.
 
@@ -493,7 +493,7 @@ Combine filters (status, category, priority) and bookmark the result.
    - Status: Active
 3. Sort: Priority (P0 first)
 4. Bookmark: "Morning Teaching Focus"
-```text
+```
 
 **Research progress view:**
 
@@ -504,7 +504,7 @@ Combine filters (status, category, priority) and bookmark the result.
    - Progress: 50%+
 3. Sort: Progress (high to low)
 4. Bookmark: "Near-Complete Research"
-```bash
+```
 
 </details>
 
@@ -524,7 +524,7 @@ flow dashboard --web
 # Terminal 2: Start work session
 work mediationverse
 f50
-```bash
+```
 
 **Monitor:**
 
@@ -540,7 +540,7 @@ f50
 status . active P0 "Session complete (+10%)" 95
 
 # Dashboard: See progress update within 5 seconds
-```text
+```
 
 </details>
 
@@ -576,7 +576,7 @@ flow dashboard --web
    - Check: Statistics summary
    - Note: Total progress this week
    - Export: Screenshot for records
-```bash
+```
 
 </details>
 
@@ -597,7 +597,7 @@ flow dashboard --web --port 3001
 # Or manually open browser
 flow dashboard --web
 # Then open: http://localhost:3000/dashboard
-```bash
+```
 
 ### "Data not updating"
 
@@ -609,7 +609,7 @@ flow dashboard --web
 # Press 'r' to refresh manually
 # Or restart dashboard
 # Ctrl+C, then: flow dashboard --web
-```bash
+```
 
 ### "Charts look empty"
 
@@ -623,7 +623,7 @@ status project1 active P0 "Task 1" 50
 status project2 active P1 "Task 2" 75
 
 # Work on them, then refresh dashboard
-```text
+```
 
 ---
 
@@ -648,7 +648,7 @@ flow dashboard --web                  # Launch dashboard
 flow dashboard --web --port 3001      # Custom port
 flow dashboard --web --interval 2000  # Fast refresh
 flow status --json > data.json        # Export data
-```diff
+```
 
 **Dashboard sections:**
 

--- a/docs/tutorials/05-ai-commands.md
+++ b/docs/tutorials/05-ai-commands.md
@@ -23,7 +23,7 @@ First, verify Claude CLI is installed:
 
 ```bash
 command -v claude && echo "✅ Claude CLI found" || echo "❌ Install: npm i -g @anthropic-ai/claude-code"
-```text
+```
 
 ---
 
@@ -35,7 +35,7 @@ Ask AI anything about your project:
 
 ```bash
 flow ai "what testing framework should I use for this project?"
-```diff
+```
 
 The AI receives context about:
 
@@ -50,7 +50,7 @@ Get explanations of code or concepts:
 
 ```bash
 flow ai --explain "what does this regex do: ^##\s*Focus:"
-```text
+```
 
 ### Fix Mode
 
@@ -58,7 +58,7 @@ Get help fixing problems:
 
 ```bash
 flow ai --fix "my tests are failing with 'command not found'"
-```text
+```
 
 ### Suggest Mode
 
@@ -66,7 +66,7 @@ Get improvement suggestions:
 
 ```bash
 flow ai --suggest "make this function more efficient"
-```text
+```
 
 ### Create Mode
 
@@ -74,7 +74,7 @@ Generate code from descriptions:
 
 ```bash
 flow ai --create "a function that validates email addresses"
-```bash
+```
 
 ---
 
@@ -96,7 +96,7 @@ flow do "count lines of code in zsh files"
 
 # Check disk usage
 flow do "show largest files in current directory"
-```text
+```
 
 ### Dry Run Mode
 
@@ -104,7 +104,7 @@ See what command would run without executing:
 
 ```bash
 flow do --dry-run "delete all .bak files"
-```text
+```
 
 Output:
 
@@ -113,7 +113,7 @@ Output:
 📝 Command: find . -name "*.bak" -delete
 
 ⚠️  DRY RUN - command not executed
-```text
+```
 
 ### Safety Features
 
@@ -121,7 +121,7 @@ Dangerous commands require confirmation:
 
 ```bash
 flow do "remove all files"
-```text
+```
 
 Output:
 
@@ -131,7 +131,7 @@ Output:
 
 This command could cause data loss.
 Execute anyway? [y/N]:
-```bash
+```
 
 ---
 
@@ -148,7 +148,7 @@ stuck --ai
 
 # Describe your specific problem
 stuck --ai "can't figure out why the tests pass locally but fail in CI"
-```bash
+```
 
 The AI will:
 
@@ -164,7 +164,7 @@ next
 
 # Get AI-powered suggestion
 next --ai
-```diff
+```
 
 The AI considers:
 
@@ -182,7 +182,7 @@ Force context inclusion even for simple queries:
 
 ```bash
 flow ai --context "should I use async here?"
-```text
+```
 
 ### Verbose Mode
 
@@ -190,7 +190,7 @@ See what context is being sent to AI:
 
 ```bash
 flow ai --verbose "how do I add a new command?"
-```text
+```
 
 Output:
 
@@ -203,7 +203,7 @@ Changed files: 3
 ...
 
 🤖 Asking AI...
-```bash
+```
 
 ### Combine Modes
 
@@ -213,7 +213,7 @@ flow ai --explain --context "the _flow_detect_type function"
 
 # Fix with verbose output
 flow ai --fix --verbose "completion not working"
-```yaml
+```
 
 ---
 

--- a/docs/tutorials/06-dopamine-features.md
+++ b/docs/tutorials/06-dopamine-features.md
@@ -44,7 +44,7 @@ For ADHD minds, small visible rewards are essential for sustained focus:
 │  Do Something  →  Log Win  →  See Progress  →  Repeat  │
 │      🎯              🎉            📊           🔄      │
 └─────────────────────────────────────────────────────────┘
-```diff
+```
 
 Each win gives you a dopamine boost, making it easier to keep going.
 
@@ -65,7 +65,7 @@ First, do some work. It could be small:
 
 ```bash
 win "Fixed the typo in README"
-```text
+```
 
 **What happened:** You logged your first win! The output shows:
 
@@ -74,7 +74,7 @@ win "Fixed the typo in README"
 Fixed the typo in README
 
 Keep it up! 🚀
-```bash
+```
 
 Notice how it detected the category `#docs` from the word "README".
 
@@ -91,7 +91,7 @@ win "Fixed login bug"
 
 win "Added unit tests for auth module"
 # → 🧪 test (detected "tests")
-```bash
+```
 
 ---
 
@@ -120,7 +120,7 @@ Sometimes auto-detection doesn't match your intent:
 win --code "Wrote utility function"
 win -f "Resolved edge case"    # -f = fix
 win --ship "Merged feature branch"
-```text
+```
 
 !!! tip "When to Override"
 Use manual categories when: - Keywords are ambiguous ("added docs" → is it code or docs?) - You want a specific categorization for tracking - Auto-detection missed the context
@@ -133,7 +133,7 @@ Use manual categories when: - Keywords are ambiguous ("added docs" → is it cod
 
 ```bash
 yay
-```text
+```
 
 Output:
 
@@ -147,13 +147,13 @@ Output:
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Total: 3 wins | Streak: 🔥 5 days
-```text
+```
 
 ### Weekly Summary
 
 ```bash
 yay --week
-```text
+```
 
 Output:
 
@@ -172,7 +172,7 @@ Output:
 Mon Tue Wed Thu Fri Sat Sun
  ▁   ▃   ██  ▅   ▂
      Activity Graph
-```bash
+```
 
 !!! success "Celebrate Your Progress"
 The weekly summary shows your work patterns. Seeing your wins visualized helps reinforce the habit.
@@ -205,7 +205,7 @@ yay
 
 # In extended status
 status --extended
-```text
+```
 
 ### Building a Streak
 
@@ -215,7 +215,7 @@ Day 2: work project → 🌱 2 days
 Day 3: work project → 🔥 3 days - On a roll!
 Day 4: (no work)    → 😢 Streak reset
 Day 5: work project → 🌱 1 day (starting over)
-```bash
+```
 
 !!! tip "Maintain Your Streak"
 Even a 5-minute session counts! On busy days, do a quick `work` → `win "Quick check-in"` → `finish` to keep your streak alive.
@@ -229,19 +229,19 @@ Even a 5-minute session counts! On busy days, do a quick `work` → `win "Quick 
 ```bash
 # Set a goal of 3 wins per day
 flow goal set 3
-```text
+```
 
 Output:
 
 ```text
 🎯 Daily goal set: 3 wins
-```text
+```
 
 ### Check Your Progress
 
 ```bash
 flow goal
-```text
+```
 
 Output:
 
@@ -251,7 +251,7 @@ Output:
 ██████░░░░ 2/3 wins
 
 Log 1 more win to reach your goal!
-```text
+```
 
 ### Goal Shown in Dashboard
 
@@ -259,7 +259,7 @@ The dashboard now shows your goal progress:
 
 ```bash
 dash
-```text
+```
 
 ```text
 ┌─ 🎉 Recent Wins ─────────────────────────────────────────────┐
@@ -268,7 +268,7 @@ dash
 │ 💻 Implemented auth service              14:20               │
 │ 🔧 Fixed login redirect bug              11:45               │
 └──────────────────────────────────────────────────────────────┘
-```bash
+```
 
 ### Adjusting Your Goal
 
@@ -283,7 +283,7 @@ flow goal set 3
 
 # If you're crushing it
 flow goal set 5
-```text
+```
 
 ---
 
@@ -301,7 +301,7 @@ Open your project's `.STATUS` file:
 ## Status: active
 
 ## daily_goal: 5
-```text
+```
 
 ### How Priority Works
 
@@ -317,7 +317,7 @@ Open your project's `.STATUS` file:
 
 ```bash
 dash
-```text
+```
 
 ```text
 ╭──────────────────────────────────────────────────────────────╮
@@ -335,13 +335,13 @@ dash
 │ 🔧 Fixed login redirect bug              11:45               │
 │ 📝 Updated API documentation             09:30               │
 └──────────────────────────────────────────────────────────────┘
-```text
+```
 
 ### Interactive Dashboard
 
 ```bash
 dash -i
-```bash
+```
 
 **Keyboard shortcuts:**
 
@@ -383,7 +383,7 @@ finish "Good progress today"
 
 # Check your streak
 yay
-```bash
+```
 
 ---
 
@@ -396,7 +396,7 @@ Don't wait until the end of the day:
 ```bash
 # Right after finishing something
 win "Just fixed that annoying bug"
-```bash
+```
 
 The immediate feedback reinforces the behavior.
 
@@ -410,7 +410,7 @@ flow goal set 2
 
 # Week 2 (if consistently hitting)
 flow goal set 3
-```diff
+```
 
 ### 3. Use Categories
 
@@ -427,7 +427,7 @@ Make `dash` part of your morning:
 ```bash
 morning    # Morning routine with suggestions
 dash       # Quick dashboard check
-```bash
+```
 
 ---
 
@@ -441,7 +441,7 @@ ls -la ~/.local/share/flow/wins.md
 
 # View raw file
 cat ~/.local/share/flow/wins.md
-```bash
+```
 
 ### Streak Reset Unexpectedly
 
@@ -450,7 +450,7 @@ Streaks require at least one work session per day:
 ```bash
 # Check worklog for gaps
 tail -20 ~/.local/share/flow/worklog
-```bash
+```
 
 ### Goal Not Updating
 

--- a/docs/tutorials/07-sync-command.md
+++ b/docs/tutorials/07-sync-command.md
@@ -44,7 +44,7 @@ Flow CLI tracks data in multiple places:
                     │ flow sync   │
                     │ all         │
                     └─────────────┘
-```text
+```
 
 The `sync` command orchestrates keeping all this data consistent.
 
@@ -58,7 +58,7 @@ Run sync without arguments to see the current state:
 
 ```bash
 flow sync
-```text
+```
 
 Output:
 
@@ -72,13 +72,13 @@ Suggested sync targets:
 • status: 2 projects not updated today
 
 Run: flow sync all
-```text
+```
 
 ### Sync Everything
 
 ```bash
 flow sync all
-```text
+```
 
 Output:
 
@@ -93,7 +93,7 @@ Output:
 [5/5] git... done (pushed 3 commits)
 
 ✓ Sync complete (2s)
-```text
+```
 
 ---
 
@@ -107,13 +107,13 @@ Persists your current session data to the worklog:
 
 ```bash
 flow sync session
-```text
+```
 
 Output:
 
 ```text
 45m on flow-cli
-```text
+```
 
 ### Status Sync
 
@@ -121,13 +121,13 @@ Updates `.STATUS` timestamps and streaks for active projects:
 
 ```bash
 flow sync status
-```text
+```
 
 Output:
 
 ```text
 2 projects updated
-```text
+```
 
 ### Wins Sync
 
@@ -135,13 +135,13 @@ Aggregates project wins to the global wins file:
 
 ```bash
 flow sync wins
-```text
+```
 
 Output:
 
 ```text
 3 new wins aggregated
-```text
+```
 
 ### Goals Sync
 
@@ -149,13 +149,13 @@ Recalculates daily goal progress:
 
 ```bash
 flow sync goals
-```text
+```
 
 Output:
 
 ```text
 2/3 (67%)
-```text
+```
 
 ### Git Sync
 
@@ -163,13 +163,13 @@ Smart git sync with stash handling:
 
 ```bash
 flow sync git
-```text
+```
 
 Output:
 
 ```text
 pushed 3 commits
-```text
+```
 
 **What git sync does:**
 
@@ -187,7 +187,7 @@ Before syncing, preview what will happen:
 
 ```bash
 flow sync all --dry-run
-```text
+```
 
 Output:
 
@@ -208,7 +208,7 @@ Output:
              Would: fetch, rebase, push
 
 Run without --dry-run to execute
-```text
+```
 
 !!! tip "Use Dry Run First"
 Always run `--dry-run` before syncing if you're unsure what will happen.
@@ -223,7 +223,7 @@ When you just want to sync local data quickly:
 
 ```bash
 flow sync all --skip-git
-```text
+```
 
 This skips the git sync target, which can be slow if you have network issues.
 
@@ -233,7 +233,7 @@ See detailed output:
 
 ```bash
 flow sync all --verbose
-```text
+```
 
 ### Quiet Mode
 
@@ -241,7 +241,7 @@ Minimal output for scripts:
 
 ```bash
 flow sync all --quiet
-```text
+```
 
 ---
 
@@ -253,7 +253,7 @@ Set up automatic background sync using macOS launchd.
 
 ```bash
 flow sync schedule
-```text
+```
 
 Output:
 
@@ -263,7 +263,7 @@ Output:
 Status: Not configured
 
 Run 'flow sync schedule enable [minutes]' to start
-```bash
+```
 
 ### Enable Scheduled Sync
 
@@ -276,7 +276,7 @@ flow sync schedule enable 15
 
 # Every hour
 flow sync schedule enable 60
-```text
+```
 
 Output:
 
@@ -289,7 +289,7 @@ Targets: session, status, wins, goals (git skipped)
 
 View logs: flow sync schedule logs
 Disable: flow sync schedule disable
-```text
+```
 
 !!! note "Git Skipped"
 Scheduled sync skips git because it may require user interaction (merge conflicts, auth).
@@ -298,7 +298,7 @@ Scheduled sync skips git because it may require user interaction (merge conflict
 
 ```bash
 flow sync schedule logs
-```text
+```
 
 Output:
 
@@ -310,13 +310,13 @@ Last 20 entries:
 2025-12-27 14:30:00 Sync completed
 2025-12-27 14:00:00 Sync completed
 2025-12-27 13:30:00 Sync completed
-```text
+```
 
 ### Disable Scheduled Sync
 
 ```bash
 flow sync schedule disable
-```text
+```
 
 Output:
 
@@ -325,7 +325,7 @@ Output:
 
 ✓ Schedule disabled
 Plist removed
-```text
+```
 
 ---
 
@@ -335,7 +335,7 @@ View your sync history:
 
 ```bash
 flow sync --status
-```text
+```
 
 Output:
 
@@ -345,7 +345,7 @@ Output:
 Last full sync: 2025-12-27T14:30:00Z
 
 Run 'flow sync all' to sync everything
-```bash
+```
 
 ---
 
@@ -362,7 +362,7 @@ flow sync all
 
 # End of day: Full sync including git
 flow sync all
-```text
+```
 
 ### Before Switching Computers
 
@@ -370,7 +370,7 @@ Make sure everything is synced:
 
 ```bash
 flow sync all
-```bash
+```
 
 ### After Extended Break
 
@@ -385,7 +385,7 @@ flow sync all
 
 # Check your dashboard
 dash
-```text
+```
 
 ### CI/Automation
 
@@ -393,7 +393,7 @@ For scripts, use quiet mode:
 
 ```bash
 flow sync all --quiet --skip-git
-```text
+```
 
 ---
 
@@ -404,7 +404,7 @@ The sync runs in dependency order:
 ```text
 session → status → wins → goals → git
    1        2        3       4      5
-```bash
+```
 
 1. **Session** - Capture current session first
 2. **Status** - Update project statuses
@@ -429,7 +429,7 @@ git rebase --abort
 
 # Then retry
 flow sync git
-```text
+```
 
 ### Sync Takes Too Long
 
@@ -437,7 +437,7 @@ Skip git for quick local sync:
 
 ```bash
 flow sync all --skip-git
-```bash
+```
 
 ### Scheduled Sync Not Running
 
@@ -445,7 +445,7 @@ Check if the launch agent is loaded:
 
 ```bash
 launchctl list | grep flow
-```text
+```
 
 If not listed, re-enable:
 

--- a/docs/tutorials/08-git-feature-workflow.md
+++ b/docs/tutorials/08-git-feature-workflow.md
@@ -29,7 +29,7 @@ g help
 
 # Check you have main and dev branches
 git branch -a | grep -E "main|dev"
-```diff
+```
 
 ---
 
@@ -51,7 +51,7 @@ feature/* ──► dev ──► main
     │          │        │
     └── PR ────┘        │
                └── PR ──┘
-```diff
+```
 
 **Key Rules:**
 
@@ -68,14 +68,14 @@ feature/* ──► dev ──► main
 ```bash
 # Start a new feature from dev
 g feature start auth-improvements
-```text
+```
 
 **What happened:**
 
 ```text
 ✅ Created feature/auth-improvements from dev
 📍 Now on: feature/auth-improvements
-```diff
+```
 
 This:
 
@@ -88,14 +88,14 @@ This:
 ```bash
 # Check current branch
 g
-```text
+```
 
 **Output:**
 
 ```text
 On branch feature/auth-improvements
 nothing to commit, working tree clean
-```bash
+```
 
 ---
 
@@ -108,7 +108,7 @@ nothing to commit, working tree clean
 # Then commit
 g add .
 g commit "Add OAuth2 support"
-```bash
+```
 
 ### Step 2.2: Keep in Sync with Dev
 
@@ -117,14 +117,14 @@ While you work, `dev` may have new changes. Stay synced:
 ```bash
 # Rebase your feature onto latest dev
 g feature sync
-```text
+```
 
 **What happened:**
 
 ```text
 ✅ Rebased feature/auth-improvements onto dev
 📊 Your branch is 3 commits ahead of dev
-```bash
+```
 
 **Tip:** Run `g feature sync` daily to avoid big merge conflicts!
 
@@ -133,7 +133,7 @@ g feature sync
 ```bash
 # Push to remote
 g push
-```bash
+```
 
 The workflow guard will let this through because you're on a feature branch.
 
@@ -148,7 +148,7 @@ When your feature is ready:
 ```bash
 # Create PR: feature → dev
 g promote
-```text
+```
 
 **What happened:**
 
@@ -157,7 +157,7 @@ Creating PR: feature/auth-improvements → dev
 
 ✅ PR #42 created
    https://github.com/user/repo/pull/42
-```bash
+```
 
 ### Step 3.2: PR to Main (Release)
 
@@ -169,7 +169,7 @@ git checkout dev
 
 # Create PR: dev → main
 g release
-```text
+```
 
 **What happened:**
 
@@ -178,7 +178,7 @@ Creating PR: dev → main
 
 ✅ PR #43 created
    https://github.com/user/repo/pull/43
-```bash
+```
 
 ---
 
@@ -191,14 +191,14 @@ Push and create PR in one command:
 ```bash
 # Push + create PR to dev
 g feature finish
-```text
+```
 
 **What happened:**
 
 ```text
 📤 Pushing feature/auth-improvements...
 ✅ Created PR #42: feature/auth-improvements → dev
-```bash
+```
 
 ### Step 4.2: Clean Up Merged Branches
 
@@ -213,7 +213,7 @@ g feature prune
 
 # Also clean remote tracking branches
 g feature prune --all
-```text
+```
 
 **Output:**
 
@@ -227,7 +227,7 @@ Will delete:
 Delete 2 branches? [y/N] y
 
 ✅ Deleted 2 merged branches
-```bash
+```
 
 ---
 
@@ -241,7 +241,7 @@ The workflow guard protects `main` and `dev` from direct pushes:
 # Try to push to main (blocked)
 git checkout main
 g push
-```text
+```
 
 **Output:**
 
@@ -257,7 +257,7 @@ Commands:
   g release    Create PR: dev → main
 
 Override: GIT_WORKFLOW_SKIP=1 git push
-```bash
+```
 
 ### Override When Needed
 
@@ -266,7 +266,7 @@ For emergencies only:
 ```bash
 # Skip the guard (use sparingly!)
 GIT_WORKFLOW_SKIP=1 git push
-```diff
+```
 
 ---
 
@@ -293,7 +293,7 @@ g feature start new-feature    # Create branch
 # ... make changes ...
 g add . && g commit "message"  # Commit
 g feature finish               # Push + PR
-```bash
+```
 
 ### Scenario 2: Hotfix Needed
 
@@ -302,14 +302,14 @@ g feature start hotfix/urgent-fix  # Use hotfix/ prefix
 # ... fix the issue ...
 g promote                          # PR to dev
 g release                          # PR to main (after dev merge)
-```text
+```
 
 ### Scenario 3: Weekly Cleanup
 
 ```bash
 g feature list                 # See all feature branches
 g feature prune --all          # Clean merged + remote
-```bash
+```
 
 ---
 
@@ -321,7 +321,7 @@ g feature prune --all          # Clean merged + remote
 # Delete old branch first
 git branch -d feature/old-name
 g feature start new-name
-```bash
+```
 
 ### "Rebase conflicts"
 
@@ -330,7 +330,7 @@ g feature start new-name
 # 1. Fix conflicts in files
 # 2. git add <fixed-files>
 # 3. git rebase --continue
-```bash
+```
 
 ### "PR creation failed"
 

--- a/docs/tutorials/09-worktrees.md
+++ b/docs/tutorials/09-worktrees.md
@@ -29,7 +29,7 @@ wt help
 
 # Check cc wt integration
 cc wt help
-```diff
+```
 
 ---
 
@@ -55,7 +55,7 @@ git checkout feature-b       # Switch branches
 # ... work ...
 git checkout feature-a       # Switch back
 git stash pop                # Restore work
-```text
+```
 
 **The Worktree Solution:**
 
@@ -65,7 +65,7 @@ git stash pop                # Restore work
 ~/.git-worktrees/
   └── project/
       └── feature-b/    # Second worktree (feature-b)
-```text
+```
 
 Each worktree is a separate directory with its own working copy.
 
@@ -77,13 +77,13 @@ Each worktree is a separate directory with its own working copy.
 
 ```bash
 wt list
-```text
+```
 
 **Output:**
 
 ```text
 /Users/you/projects/myproject  abc1234 [main]
-```bash
+```
 
 ### Step 1.2: Create a Worktree
 
@@ -93,7 +93,7 @@ wt create feature/auth
 
 # Or for a new branch (auto-creates)
 wt create feature/new-thing
-```text
+```
 
 **What happened:**
 
@@ -101,7 +101,7 @@ wt create feature/new-thing
 ✓ Created worktree: ~/.git-worktrees/myproject/feature-auth
 
 Navigate: cd ~/.git-worktrees/myproject/feature-auth
-```bash
+```
 
 ### Step 1.3: View Worktree Overview
 
@@ -110,7 +110,7 @@ Navigate: cd ~/.git-worktrees/myproject/feature-auth
 ```bash
 # View all worktrees with status icons and session indicators
 wt
-```text
+```
 
 **Output:**
 
@@ -124,7 +124,7 @@ feature/dashboard   🧹 merged  🟡 2h   ~/.git-worktrees/myproject/feature-da
 main                🏠 main    ⚪      /Users/you/projects/myproject
 
 💡 Filter: wt <project> | Interactive picker: pick wt (Tab=multi-select, Ctrl-X=delete, Ctrl-R=refresh)
-```diff
+```
 
 **Status Icons:**
 - ✅ **active** - Unmerged feature branch
@@ -142,20 +142,20 @@ main                🏠 main    ⚪      /Users/you/projects/myproject
 ```bash
 # Show only flow-cli worktrees
 wt flow
-```bash
+```
 
 ### Step 1.5: Navigate to Worktrees Folder
 
 ```bash
 # Go to worktrees base directory (use 'cd')
 wt cd
-```text
+```
 
 **Output:**
 
 ```text
 ℹ Changed to: /Users/you/.git-worktrees
-```bash
+```
 
 ---
 
@@ -166,7 +166,7 @@ wt cd
 ```bash
 # Launch Claude in worktree (creates if needed!)
 cc wt feature/auth
-```text
+```
 
 **What happened:**
 
@@ -174,7 +174,7 @@ cc wt feature/auth
 ℹ Creating worktree for feature/auth...
 ✓ Created worktree: ~/.git-worktrees/myproject/feature-auth
 ✓ Launching Claude in ~/.git-worktrees/myproject/feature-auth
-```bash
+```
 
 Claude Code opens in the worktree directory, completely isolated from your main work.
 
@@ -183,7 +183,7 @@ Claude Code opens in the worktree directory, completely isolated from your main 
 ```bash
 # fzf picker for worktrees
 cc wt pick
-```bash
+```
 
 A picker appears showing all worktrees. Select one to launch Claude there.
 
@@ -203,7 +203,7 @@ cc wt opus feature/important
 
 # Haiku model in worktree
 cc wt haiku feature/quick
-```text
+```
 
 ---
 
@@ -215,7 +215,7 @@ cc wt haiku feature/quick
 ccw feature/auth     # = cc wt feature/auth
 ccwy feature/auth    # = cc wt yolo feature/auth
 ccwp                 # = cc wt pick
-```bash
+```
 
 ### Quick Reference
 
@@ -236,7 +236,7 @@ ccwp                 # = cc wt pick
 ```bash
 # Interactive worktree picker with actions
 pick wt
-```diff
+```
 
 The picker shows all worktrees with status icons and session indicators. You can:
 
@@ -257,7 +257,7 @@ The picker shows all worktrees with status icons and session indicators. You can
 
 ```sql
 Delete worktree: ~/.git-worktrees/myproject/feature-old? [y/n/a/q]
-```diff
+```
 
 - **y** - Yes, delete this one
 - **n** - No, skip this one
@@ -268,7 +268,7 @@ Delete worktree: ~/.git-worktrees/myproject/feature-old? [y/n/a/q]
 
 ```text
 Also delete branch 'feature-old'? [y/N]
-```bash
+```
 
 ### Step 4.3: Refresh Cache
 
@@ -288,33 +288,33 @@ Useful after making git changes outside the picker.
 ```bash
 # Remove specific worktree
 wt remove ~/.git-worktrees/myproject/feature-auth
-```text
+```
 
 **Output:**
 
 ```text
 ✓ Removed worktree: ~/.git-worktrees/myproject/feature-auth
-```bash
+```
 
 ### Step 5.2: Clean Stale Worktrees
 
 ```bash
 # Prune worktrees with missing directories
 wt clean
-```text
+```
 
 **Output:**
 
 ```text
 ✓ Pruned stale worktrees
-```bash
+```
 
 ### Step 5.3: Move Current Branch to Worktree
 
 ```bash
 # On feature/something branch
 wt move
-```bash
+```
 
 Creates a worktree for your current branch. Useful for moving in-progress work to a dedicated directory.
 
@@ -335,7 +335,7 @@ ccw hotfix/urgent
 # ... commit and push ...
 
 # Back to Terminal 1, no context lost!
-```bash
+```
 
 ### Pattern 2: Code Review
 
@@ -345,7 +345,7 @@ ccw feature/pr-123
 
 # Claude can help review without affecting your work
 cc wt plan feature/pr-123  # Plan mode for thorough review
-```bash
+```
 
 ### Pattern 3: Experimentation
 
@@ -356,7 +356,7 @@ ccwy experiment/new-approach
 # If it doesn't work out:
 wt remove ~/.git-worktrees/project/experiment-new-approach
 git branch -D experiment/new-approach
-```bash
+```
 
 ---
 
@@ -370,7 +370,7 @@ git branch -D experiment/new-approach
 
 # Customize in .zshrc
 export FLOW_WORKTREE_DIR="$HOME/worktrees"
-```text
+```
 
 ### Directory Structure
 
@@ -385,7 +385,7 @@ Worktrees are organized by project:
 │   └── feature-new-method/
 └── my-app/
     └── feature-dashboard/
-```diff
+```
 
 ---
 
@@ -425,7 +425,7 @@ Worktrees are organized by project:
 # Can't have same branch in two worktrees
 # Solution: Use a different branch name
 wt create feature/auth-v2
-```bash
+```
 
 ### "Worktree not found"
 
@@ -435,7 +435,7 @@ wt clean
 
 # Then try again
 wt list
-```bash
+```
 
 ### "Not in a git repository"
 

--- a/docs/tutorials/10-cc-dispatcher.md
+++ b/docs/tutorials/10-cc-dispatcher.md
@@ -29,7 +29,7 @@ cc help
 
 # Check Claude CLI
 claude --version
-```diff
+```
 
 ---
 
@@ -57,7 +57,7 @@ cc
 
 # Explicit HERE (same as above, more explicit)
 cc .
-```diff
+```
 
 **What happens:**
 - Claude starts with `--permission-mode acceptEdits`
@@ -73,7 +73,7 @@ For trusted tasks where you want maximum speed:
 ```bash
 # Launch with no confirmations
 cc yolo
-```diff
+```
 
 **What happens:**
 - Claude starts with `--dangerously-skip-permissions`
@@ -89,7 +89,7 @@ For exploration without code changes:
 ```bash
 # Launch in planning mode
 cc plan
-```diff
+```
 
 **What happens:**
 - Claude starts with `--permission-mode plan`
@@ -105,7 +105,7 @@ cc plan
 ```bash
 # Open project picker, then launch Claude
 cc pick
-```bash
+```
 
 **What happens:**
 1. fzf picker shows your projects
@@ -125,7 +125,7 @@ cc med
 
 # Jump to stat-440 → launch Claude
 cc stat
-```diff
+```
 
 **What happens:**
 - Uses `pick`'s fuzzy matching
@@ -148,7 +148,7 @@ cc yolo pick
 
 # Plan mode + direct jump
 cc plan med
-```bash
+```
 
 **Pattern:** `cc [mode] [project|pick]`
 
@@ -168,7 +168,7 @@ cc pick plan     # target-first ✨
 # These are equivalent:
 cc opus pick     # mode-first
 cc pick opus     # target-first ✨
-```diff
+```
 
 **Why this matters:**
 - Type in whatever order feels natural
@@ -190,7 +190,7 @@ cc opus flow
 
 # Opus + project picker
 cc opus pick
-```diff
+```
 
 **When to use Opus:**
 - Complex architectural decisions
@@ -208,7 +208,7 @@ cc haiku flow
 
 # Haiku + project picker
 cc haiku pick
-```diff
+```
 
 **When to use Haiku:**
 - Quick questions
@@ -224,7 +224,7 @@ cc haiku pick
 ```bash
 # Show Claude session picker
 cc resume
-```diff
+```
 
 **What happens:**
 - Lists your recent Claude conversations
@@ -236,7 +236,7 @@ cc resume
 ```bash
 # Resume the most recent conversation
 cc continue
-```diff
+```
 
 **What happens:**
 - Jumps directly to your last Claude session
@@ -252,7 +252,7 @@ cc continue
 ```bash
 # Get an answer without full session
 cc ask "how do I handle missing data in R?"
-```diff
+```
 
 **What happens:**
 - Claude answers in print mode
@@ -264,7 +264,7 @@ cc ask "how do I handle missing data in R?"
 ```bash
 # Review uncommitted changes
 cc diff
-```diff
+```
 
 **What happens:**
 - Pipes `git diff` to Claude
@@ -279,7 +279,7 @@ cc file R/myfunction.R
 
 # With custom prompt
 cc file R/myfunction.R "explain the algorithm"
-```diff
+```
 
 **What happens:**
 - Claude analyzes the file
@@ -291,7 +291,7 @@ cc file R/myfunction.R "explain the algorithm"
 ```bash
 # In an R package directory
 cc rpkg "add input validation"
-```diff
+```
 
 **What happens:**
 - Reads DESCRIPTION file
@@ -307,7 +307,7 @@ cc rpkg "add input validation"
 ```bash
 # Create/use worktree → launch Claude
 cc wt feature/auth
-```bash
+```
 
 **What happens:**
 1. Creates worktree if it doesn't exist
@@ -325,14 +325,14 @@ cc wt plan feature/complex
 
 # Worktree + Opus
 cc wt opus feature/refactor
-```bash
+```
 
 ### Step 6.3: Pick from Existing Worktrees
 
 ```bash
 # fzf picker for worktrees
 cc wt pick
-```diff
+```
 
 ---
 
@@ -379,7 +379,7 @@ cc continue
 
 # Option 2: Start fresh on a project
 cc flow
-```bash
+```
 
 ### Feature Development
 
@@ -389,7 +389,7 @@ cc plan pick
 
 # Switch to YOLO for implementation
 cc yolo
-```bash
+```
 
 ### Code Review
 
@@ -399,14 +399,14 @@ cc diff
 
 # Or analyze specific file
 cc file src/complex-function.js "review for bugs"
-```bash
+```
 
 ### Quick Questions
 
 ```bash
 # Get quick answers without full session
 cc ask "what's the best way to mock API calls in jest?"
-```bash
+```
 
 ### Parallel Work with Worktrees
 
@@ -416,7 +416,7 @@ cc wt feature/auth
 
 # Another terminal: quick fix in different worktree
 ccwy hotfix/urgent
-```text
+```
 
 ---
 
@@ -432,7 +432,7 @@ What's your task?
 │  └─ cc plan (or ccp)
 └─ Normal development
    └─ cc (default acceptEdits)
-```text
+```
 
 ### Which Model?
 
@@ -444,7 +444,7 @@ Task complexity?
 │  └─ cc haiku (or cch)
 └─ Normal tasks
    └─ cc (default Sonnet)
-```text
+```
 
 ### Resume vs New Session?
 
@@ -454,7 +454,7 @@ Do you need previous context?
 │  └─ cc resume or cc continue
 └─ No, fresh start
    └─ cc [mode] [project]
-```zsh
+```
 
 ---
 
@@ -468,14 +468,14 @@ source ~/.zshrc
 
 # Or check pick command
 pick help
-```bash
+```
 
 ### "claude: command not found"
 
 ```bash
 # Install Claude CLI
 # See: https://claude.ai/code
-```bash
+```
 
 ### "Not in a git repository" (for cc diff)
 

--- a/docs/tutorials/11-tm-dispatcher.md
+++ b/docs/tutorials/11-tm-dispatcher.md
@@ -29,7 +29,7 @@ tm help
 
 # Check which terminal you're using
 tm which
-```diff
+```
 
 ---
 
@@ -62,7 +62,7 @@ tm t "Bug fix #123"
 
 # Using the alias
 tmt "Code review"
-```diff
+```
 
 **What happens:**
 - Your tab/window title updates immediately
@@ -73,7 +73,7 @@ tmt "Code review"
 
 ```bash
 tm title "Tutorial in progress"
-```bash
+```
 
 Look at your terminal tab - it should show "Tutorial in progress"!
 
@@ -90,7 +90,7 @@ tm profile "Default"
 
 # Using shortcut
 tm p "Writing"
-```diff
+```
 
 **What happens:**
 - Colors, fonts, and settings change instantly
@@ -104,7 +104,7 @@ Find out which terminal you're running:
 ```bash
 tm which
 # → iterm2, ghostty, kitty, alacritty, wezterm, vscode, or terminal
-```diff
+```
 
 This is useful for:
 - Debugging terminal-specific issues
@@ -126,13 +126,13 @@ brew install data-wise/tap/aiterm
 
 # Or via pip
 pip install aiterm-dev
-```text
+```
 
 Verify installation:
 
 ```bash
 ait --version
-```text
+```
 
 ### Step 2.2: Detecting Project Context
 
@@ -140,7 +140,7 @@ Let aiterm analyze your current directory:
 
 ```bash
 tm detect
-```text
+```
 
 **Sample output:**
 
@@ -148,7 +148,7 @@ tm detect
 Terminal: iTerm2
 Project: flow-cli (zsh)
 Suggested: Coding profile, "flow-cli" title
-```text
+```
 
 ### Step 2.3: Applying Context Automatically
 
@@ -156,7 +156,7 @@ Apply the detected context to your terminal:
 
 ```bash
 tm switch
-```diff
+```
 
 **What happens:**
 - Sets appropriate title based on project
@@ -174,7 +174,7 @@ tm switch     # Apply context
 
 # Or use the alias
 tms
-```text
+```
 
 ---
 
@@ -186,7 +186,7 @@ If you're using Ghostty terminal:
 
 ```bash
 tm ghost theme
-```bash
+```
 
 Shows all 14+ built-in Ghostty themes.
 
@@ -197,19 +197,19 @@ Shows all 14+ built-in Ghostty themes.
 tm ghost theme tokyo-night
 tm ghost theme catppuccin-mocha
 tm ghost theme dracula
-```text
+```
 
 ### Step 3.3: Check Current Font
 
 ```bash
 tm ghost font
-```text
+```
 
 ### Step 3.4: Set Font
 
 ```bash
 tm ghost font "JetBrains Mono"
-```bash
+```
 
 ---
 
@@ -236,7 +236,7 @@ tmp "Default"
 
 # Quick context apply
 tms
-```bash
+```
 
 ---
 
@@ -253,7 +253,7 @@ tm switch
 
 # Or manually set title
 tm title "flow-cli: adding tm dispatcher"
-```bash
+```
 
 ### Workflow 2: Multiple Tabs
 
@@ -268,7 +268,7 @@ tm title "flow-cli: tests"
 
 # Tab 3: Docs
 tm title "flow-cli: docs"
-```bash
+```
 
 Now you can easily identify each tab!
 
@@ -285,7 +285,7 @@ tm profile "Writing Light"
 
 # Review mode
 tm profile "Review"
-```bash
+```
 
 ---
 
@@ -297,7 +297,7 @@ Shell-native commands still work. For full features:
 
 ```bash
 brew install data-wise/tap/aiterm
-```diff
+```
 
 ### Profile switching not working
 

--- a/docs/tutorials/12-dot-dispatcher.md
+++ b/docs/tutorials/12-dot-dispatcher.md
@@ -41,7 +41,7 @@ chezmoi init
 
 # Optional: Bitwarden CLI for secret management
 brew install bitwarden-cli
-```diff
+```
 
 ---
 
@@ -60,7 +60,7 @@ The `dots` dispatcher (and its siblings `sec` and `tok`) is a wrapper around che
 
 ```bash
 dots
-```text
+```
 
 **Output when chezmoi is not initialized:**
 
@@ -73,7 +73,7 @@ dots
 │  Initialize chezmoi:                              │
 │    chezmoi init                                   │
 ╰───────────────────────────────────────────────────╯
-```text
+```
 
 **Output when chezmoi is ready:**
 
@@ -90,7 +90,7 @@ dots
 │    dots sync           Pull latest changes         │
 │    dots help           Show all commands           │
 ╰───────────────────────────────────────────────────╯
-```bash
+```
 
 ---
 
@@ -103,7 +103,7 @@ Before you can use `dots edit`, the file must be tracked by chezmoi:
 ```bash
 # Add your shell config to chezmoi
 chezmoi add ~/.zshrc
-```text
+```
 
 This copies `~/.zshrc` to chezmoi's source directory (`~/.local/share/chezmoi/`).
 
@@ -111,7 +111,7 @@ This copies `~/.zshrc` to chezmoi's source directory (`~/.local/share/chezmoi/`)
 
 ```bash
 dots edit .zshrc
-```text
+```
 
 **What happens:**
 
@@ -140,7 +140,7 @@ dots edit .zshrc
   n - Keep in staging
 
 Apply? [Y/n/d]
-```diff
+```
 
 **Options:**
 - **y** (or Enter) - Apply changes to your actual `~/.zshrc`
@@ -157,7 +157,7 @@ dots diff
 
 # Apply all pending changes
 dots apply
-```text
+```
 
 ---
 
@@ -169,7 +169,7 @@ The `--dry-run` flag (or `-n`) shows what would change without actually modifyin
 
 ```bash
 dots apply --dry-run
-```text
+```
 
 **Output when nothing to apply:**
 
@@ -177,7 +177,7 @@ dots apply --dry-run
 ℹ DRY-RUN MODE - No changes will be applied
 
 ✓ No pending changes
-```text
+```
 
 **Output when changes are pending:**
 
@@ -188,7 +188,7 @@ dots apply --dry-run
 [chezmoi verbose diff output]
 
 ✓ Dry-run complete - no changes applied
-```diff
+```
 
 ### When to Use Dry-Run
 
@@ -212,7 +212,7 @@ chezmoi add ~/.gitconfig
 
 # Commit and push
 dots push
-```bash
+```
 
 ### On Other Machines
 
@@ -222,7 +222,7 @@ chezmoi init https://github.com/username/dotfiles.git
 
 # Apply to this machine
 dots apply
-```text
+```
 
 ### Daily Sync Pattern
 
@@ -230,7 +230,7 @@ dots apply
 
 ```bash
 dots sync
-```text
+```
 
 **Output:**
 
@@ -242,13 +242,13 @@ abc1234 Add new alias
 def5678 Update git config
 
 Apply updates? [Y/n/d]
-```text
+```
 
 **Push your changes:**
 
 ```bash
 dots push
-```text
+```
 
 **Output:**
 
@@ -259,7 +259,7 @@ dots push
 Commit message: [enter your message]
 
 ✓ Pushed to remote
-```diff
+```
 
 ---
 
@@ -276,7 +276,7 @@ The recommended way to manage secrets is using macOS Keychain. It provides:
 
 ```bash
 sec add github-token
-```text
+```
 
 **Output:**
 
@@ -284,7 +284,7 @@ sec add github-token
 Enter secret value: [hidden input]
 
 ✓ Secret 'github-token' stored in Keychain
-```bash
+```
 
 ### Retrieve a Secret
 
@@ -294,13 +294,13 @@ TOKEN=$(sec github-token)
 
 # Use in a command
 gh auth login --with-token <<< $(sec github-token)
-```text
+```
 
 ### List Keychain Secrets
 
 ```bash
 sec list
-```text
+```
 
 **Output:**
 
@@ -309,19 +309,19 @@ sec list
   • github-token
   • npm-token
   • anthropic-api-key
-```text
+```
 
 ### Delete a Secret
 
 ```bash
 sec delete old-token
-```text
+```
 
 **Output:**
 
 ```text
 ✓ Secret 'old-token' deleted
-```bash
+```
 
 ### Import from Bitwarden (One-Time Migration)
 
@@ -333,7 +333,7 @@ sec unlock
 
 # Import all secrets from 'flow-cli-secrets' folder
 sec import
-```text
+```
 
 **Output:**
 
@@ -346,7 +346,7 @@ Continue? [y/N] y
 ✓ Imported: anthropic-api-key
 
 ✓ Imported 3 secret(s) to Keychain
-```bash
+```
 
 After import, secrets are in Keychain and no longer need Bitwarden unlock.
 
@@ -363,13 +363,13 @@ brew install bitwarden-cli
 
 # Login (first time)
 bw login
-```text
+```
 
 ### Unlock Vault
 
 ```bash
 sec unlock
-```text
+```
 
 **Output:**
 
@@ -381,13 +381,13 @@ sec unlock
 
   Session active in this shell only
 ℹ Use 'sec <name>' to retrieve secrets
-```text
+```
 
 ### List Secrets
 
 ```bash
 sec list
-```text
+```
 
 **Output:**
 
@@ -400,7 +400,7 @@ sec list
 📝 ssh-passphrase (SSH)
 
 ℹ Usage: sec <name>
-```bash
+```
 
 ### Retrieve a Secret
 
@@ -410,7 +410,7 @@ TOKEN=$(sec github-token)
 
 # Use in a command
 curl -H "Authorization: Bearer $TOKEN" https://api.github.com/user
-```sql
+```
 
 ### Using Secrets in Templates
 
@@ -422,7 +422,7 @@ Create a template file in chezmoi:
 # API Keys (from Bitwarden)
 export GITHUB_TOKEN="{{ bitwarden "item" "github-token" }}"
 export ANTHROPIC_API_KEY="{{ bitwarden "item" "anthropic-api-key" }}"
-```bash
+```
 
 **Apply with secrets:**
 
@@ -435,7 +435,7 @@ dots apply --dry-run
 
 # Apply for real
 dots apply
-```text
+```
 
 ---
 
@@ -447,7 +447,7 @@ The token wizard guides you through creating properly-scoped tokens:
 
 ```bash
 tok github
-```text
+```
 
 **Example session:**
 
@@ -475,13 +475,13 @@ Paste your new token: ghp_xxxxxxxxxxxx
 ✓ Stored as 'github-token' in Bitwarden
 
 💡 Tip: tok github-token --refresh to rotate later
-```text
+```
 
 ### Check Token Expiration
 
 ```bash
 sec dashboard
-```text
+```
 
 **Output:**
 
@@ -503,13 +503,13 @@ sec dashboard
 │     Scope: project:mypackage                                  │
 │                                                               │
 ╰───────────────────────────────────────────────────────────────╯
-```text
+```
 
 ### Rotate an Expiring Token
 
 ```bash
 tok pypi-token --refresh
-```text
+```
 
 **Example session:**
 
@@ -531,7 +531,7 @@ Paste your new token: pypi-xxxxxxxx
 
 ⚠️  Remember to revoke the old token at:
    https://pypi.org/manage/account/token/
-```text
+```
 
 ### Sync to GitHub Actions
 
@@ -539,7 +539,7 @@ Push secrets to your repository for CI/CD:
 
 ```bash
 sec sync github
-```text
+```
 
 **Example session:**
 
@@ -557,13 +557,13 @@ Sync 2 secrets? [Y/n] y
 ✓ Synced NPM_TOKEN
 
 ✓ 2 secrets synced to repository
-```text
+```
 
 ### Generate .envrc for Local Development
 
 ```bash
 dots env
-```text
+```
 
 **Output:**
 
@@ -578,7 +578,7 @@ dots env
   ─────────────────────────────────
 
 💡 Run 'direnv allow' to activate
-```text
+```
 
 ---
 
@@ -591,28 +591,28 @@ dots env
 ```text
 ✗ File not found in managed dotfiles: .zshrc
 ℹ Use 'chezmoi add <file>' to start tracking a new file
-```text
+```
 
 **Vault locked:**
 
 ```text
 ✗ Bitwarden vault is locked
 ℹ Run: sec unlock
-```text
+```
 
 **Secret not found:**
 
 ```text
 ✗ Secret not found: wrong-name
 Tip: Use 'sec list' to see available items
-```text
+```
 
 **Session expired:**
 
 ```text
 ✗ Session expired
 Run: sec unlock
-```text
+```
 
 ---
 
@@ -626,14 +626,14 @@ dots edit <file>      # Edit dotfile (preview + apply)
 dots diff             # Show pending changes
 dots apply            # Apply pending changes
 dots apply --dry-run  # Preview what would change
-```text
+```
 
 ### Sync Commands
 
 ```bash
 dots sync             # Pull from remote
 dots push             # Push to remote
-```text
+```
 
 ### Keychain Secrets (v5.5.0 - Recommended)
 
@@ -643,7 +643,7 @@ sec <name>           # Get secret (Touch ID)
 sec list             # List Keychain secrets
 sec delete <name>    # Remove secret
 sec import           # Import from Bitwarden
-```text
+```
 
 ### Bitwarden Secrets (Cloud)
 
@@ -651,7 +651,7 @@ sec import           # Import from Bitwarden
 sec unlock           # Unlock Bitwarden vault
 sec bw <name> # Get Bitwarden secret
 sec dashboard          # Dashboard with expiration
-```text
+```
 
 ### Token Commands (v5.2.0)
 
@@ -662,7 +662,7 @@ tok pypi                # PyPI token wizard
 tok rotate NAME    # Rotate existing token
 sec sync github       # Sync to GitHub Actions
 dots env                  # Generate .envrc for direnv
-```text
+```
 
 ### Troubleshooting
 

--- a/docs/tutorials/13-prompt-dispatcher.md
+++ b/docs/tutorials/13-prompt-dispatcher.md
@@ -39,7 +39,7 @@ brew install starship
 
 # Option 3: Oh My Posh
 brew install oh-my-posh
-```diff
+```
 
 ---
 
@@ -57,7 +57,7 @@ The `prompt` dispatcher lets you:
 
 ```bash
 prompt status
-```text
+```
 
 **Example output:**
 
@@ -77,7 +77,7 @@ prompt status
     Config: ~/.config/ohmyposh/config.json
 
 To switch: prompt toggle
-```text
+```
 
 The `●` indicates your current engine; `○` shows available alternatives.
 
@@ -91,7 +91,7 @@ The easiest way to switch is using the toggle command:
 
 ```bash
 prompt toggle
-```text
+```
 
 **You'll see:**
 
@@ -101,7 +101,7 @@ Which prompt engine would you like to use?
 1) starship
 2) ohmyposh
 #?
-```bash
+```
 
 Enter the number of your choice and press Enter. The shell will reload automatically.
 
@@ -118,14 +118,14 @@ prompt p10k
 
 # Switch to Oh My Posh
 prompt ohmyposh
-```text
+```
 
 **Output:**
 
 ```text
 ✓ Switched to Starship
 Reloading shell...
-```text
+```
 
 ---
 
@@ -137,7 +137,7 @@ Not sure what will happen? Preview first:
 
 ```bash
 prompt --dry-run starship
-```text
+```
 
 **Output:**
 
@@ -153,13 +153,13 @@ Config file: ~/.config/starship.toml
 
 To apply these changes, run:
   prompt starship
-```text
+```
 
 ### Preview Toggle Options
 
 ```bash
 prompt --dry-run toggle
-```text
+```
 
 **Output:**
 
@@ -174,7 +174,7 @@ Available alternatives to switch to:
 
 To switch engines, run:
   prompt toggle
-```text
+```
 
 ---
 
@@ -186,7 +186,7 @@ If you haven't configured Oh My Posh yet, use the setup wizard:
 
 ```bash
 prompt setup-ohmyposh
-```text
+```
 
 **Output:**
 
@@ -200,13 +200,13 @@ Next steps:
   1. Customize your config: nano ~/.config/ohmyposh/config.json
   2. Validate: oh-my-posh config
   3. Switch to OhMyPosh: prompt ohmyposh
-```text
+```
 
 ### Step 2: Switch to Oh My Posh
 
 ```bash
 prompt ohmyposh
-```text
+```
 
 ### Step 3: Customize (Optional)
 
@@ -214,7 +214,7 @@ Edit the config file to customize your prompt:
 
 ```bash
 nano ~/.config/ohmyposh/config.json
-```text
+```
 
 Or browse the [Oh My Posh themes](https://ohmyposh.dev/docs/themes) for inspiration.
 
@@ -228,7 +228,7 @@ Get a tabular overview of all engines:
 
 ```bash
 prompt list
-```text
+```
 
 **Output:**
 
@@ -242,7 +242,7 @@ Starship           ○          ~/.config/starship.toml
 Oh My Posh         ○          ~/.config/ohmyposh/config.json
 
 Legend: ● = current, ○ = available
-```text
+```
 
 ---
 
@@ -255,13 +255,13 @@ Legend: ● = current, ○ = available
 ```text
 ✗ Starship not found in PATH
 Install with: brew install starship
-```bash
+```
 
 **Solution:**
 
 ```bash
 brew install starship
-```text
+```
 
 ### Config Missing
 
@@ -269,13 +269,13 @@ brew install starship
 
 ```text
 ⚠ OhMyPosh config missing at ~/.config/ohmyposh/config.json
-```text
+```
 
 **Solution:**
 
 ```bash
 prompt setup-ohmyposh
-```text
+```
 
 ### Prompt Doesn't Change After Switch
 
@@ -285,7 +285,7 @@ prompt setup-ohmyposh
 
 ```bash
 exec zsh -i
-```bash
+```
 
 Or simply open a new terminal tab.
 

--- a/docs/tutorials/14-teach-dispatcher.md
+++ b/docs/tutorials/14-teach-dispatcher.md
@@ -30,7 +30,7 @@ teach help
 
 # Check if you're in a course directory
 pwd
-```diff
+```
 
 ---
 
@@ -72,7 +72,7 @@ draft branch              production branch
                                          │
                                          ▼
                                    [Students see it!]
-```bash
+```
 
 **Demo:**
 
@@ -93,7 +93,7 @@ Navigate to your course repository and initialize:
 ```bash
 cd ~/projects/teaching/my-course
 teach init "STAT 545"
-```text
+```
 
 **What happens:**
 1. Creates `draft` and `production` branches
@@ -108,7 +108,7 @@ For scripting or when you know the defaults are fine:
 
 ```bash
 teach init -y "STAT 545"
-```text
+```
 
 The `-y` flag accepts all defaults without prompting.
 
@@ -116,7 +116,7 @@ The `-y` flag accepts all defaults without prompting.
 
 ```bash
 teach status
-```text
+```
 
 **Example output:**
 
@@ -130,7 +130,7 @@ Status: Ready to edit
 Quick Commands:
   teach deploy    Push changes to production
   teach week      Show current week info
-```text
+```
 
 ---
 
@@ -157,7 +157,7 @@ When you run `teach status` or any Scholar command, flow-cli validates:
 
 ```bash
 teach status
-```text
+```
 
 **When config is valid:**
 
@@ -167,14 +167,14 @@ teach status
 🎓 Level: graduate
 🔗 Scholar: configured
 ✅ Config: valid
-```text
+```
 
 **When config has issues:**
 
 ```text
 📚 STAT 545
 ⚠️  Config: has issues
-```text
+```
 
 ### Step 3.3: See Validation Details
 
@@ -182,7 +182,7 @@ For verbose output with specific errors:
 
 ```bash
 teach status --verbose
-```text
+```
 
 **Example with errors:**
 
@@ -191,7 +191,7 @@ teach status --verbose
   • Invalid semester 'fall' - must be Spring, Summer, Fall, or Winter
   • Invalid year '25' - must be between 2020 and 2100
   • Grading percentages sum to 80% - should be ~100%
-```text
+```
 
 ### Step 3.4: Hash-Based Change Detection
 
@@ -202,7 +202,7 @@ teach status          # First run: validates config
 teach status          # Second run: skips validation (unchanged)
 # Edit teach-config.yml
 teach status          # Re-validates (change detected)
-```text
+```
 
 This keeps commands fast even with complex validation rules.
 
@@ -226,7 +226,7 @@ Your `teach-config.yml` has two owners:
 
 ```bash
 work stat-545
-```diff
+```
 
 **What happens:**
 - Checks you're on the `draft` branch
@@ -244,7 +244,7 @@ When you're ready for students to see your changes:
 
 ```bash
 teach deploy
-```text
+```
 
 **What happens:**
 1. Commits any uncommitted changes
@@ -257,7 +257,7 @@ teach deploy
 
 ```bash
 teach week
-```text
+```
 
 **Example output:**
 
@@ -266,7 +266,7 @@ teach week
    Topic: Data Wrangling with dplyr
    Lecture: lectures/week-03/
    Due this week: Assignment 2
-```text
+```
 
 ---
 
@@ -280,7 +280,7 @@ The teach dispatcher wraps Scholar commands for AI-assisted content generation.
 
 ```bash
 teach exam "Midterm 1" --questions 25
-```diff
+```
 
 **What happens:**
 - Invokes Scholar's `/teaching:exam` command
@@ -291,19 +291,19 @@ teach exam "Midterm 1" --questions 25
 
 ```bash
 teach quiz "Week 3" --questions 10
-```text
+```
 
 ### Step 5.3: Generate Lecture Outline
 
 ```bash
 teach lecture "Data Wrangling"
-```text
+```
 
 ### Step 5.4: Create Assignment
 
 ```bash
 teach assignment "Homework 3" --due-date "2026-01-31"
-```text
+```
 
 ### Available Scholar Commands
 
@@ -327,7 +327,7 @@ Flow-cli can centralize all semester dates in `teach-config.yml` and automatical
 
 ```bash
 teach dates init
-```text
+```
 
 **Interactive wizard:**
 
@@ -339,7 +339,7 @@ Generating 15 weeks starting from 2025-01-13...
   Start: 2025-01-13
   End:   2025-05-02
   Weeks: 15
-```yaml
+```
 
 ### Step 7.2: Configure Dates
 
@@ -368,7 +368,7 @@ semester_info:
     - name: "Midterm"
       date: "2025-03-05"
       time: "2:00 PM - 3:50 PM"
-```text
+```
 
 ### Step 7.3: Sync Dates to Files
 
@@ -376,7 +376,7 @@ Preview changes first:
 
 ```bash
 teach dates sync --dry-run
-```text
+```
 
 **Output:**
 
@@ -386,13 +386,13 @@ teach dates sync --dry-run
    due: 2025-01-20 → 2025-01-22
 
 ℹ  Dry-run mode: No changes made
-```text
+```
 
 Apply changes:
 
 ```bash
 teach dates sync
-```text
+```
 
 **Interactive prompts:**
 
@@ -402,7 +402,7 @@ File: assignments/hw1.qmd
 │   due: 2025-01-20 → 2025-01-22
 Apply changes? [y/n/d/q] y
 ✓ Updated: assignments/hw1.qmd
-```bash
+```
 
 ### Step 7.4: Selective Sync
 
@@ -417,13 +417,13 @@ teach dates sync --lectures
 
 # Single file
 teach dates sync --file assignments/hw3.qmd
-```text
+```
 
 ### Step 7.5: Check Date Status
 
 ```bash
 teach dates status
-```text
+```
 
 **Output:**
 
@@ -434,7 +434,7 @@ teach dates status
 Config Dates Loaded: 23
 Teaching Files Found: 18
 Date Sync Status: ✅ All files in sync
-```diff
+```
 
 ### Why Use Date Automation?
 
@@ -463,7 +463,7 @@ At the end of the semester:
 
 ```bash
 teach archive
-```diff
+```
 
 **What happens:**
 - Creates a git tag: `fall-2025` (or current semester)
@@ -474,7 +474,7 @@ teach archive
 
 ```bash
 teach config
-```sql
+```
 
 Update semester dates, week count, and topics for the new term.
 
@@ -514,7 +514,7 @@ work stat-545          # Start session
 teach week             # See today's topic
 # Edit lecture notes
 teach deploy           # Push before class
-```bash
+```
 
 ### Creating an Exam
 
@@ -522,14 +522,14 @@ teach deploy           # Push before class
 teach exam "Final" --questions 40 --duration 180
 # Review and edit generated questions
 teach deploy           # (when ready to post)
-```text
+```
 
 ### End of Semester
 
 ```bash
 teach archive          # Snapshot everything
 teach config           # Update for next semester
-```bash
+```
 
 ---
 
@@ -546,21 +546,21 @@ teach status --verbose
 # 2. Year must be 4 digits: 2026, not 26
 # 3. Dates must be YYYY-MM-DD: 2026-01-15
 # 4. Grading percentages should sum to ~100%
-```bash
+```
 
 ### "Not a teaching project"
 
 ```bash
 # Initialize first
 teach init "Course Name"
-```bash
+```
 
 ### "On production branch"
 
 ```bash
 # Switch to draft for editing
 git checkout draft
-```bash
+```
 
 ### "Scholar command failed"
 

--- a/docs/tutorials/15-nvim-quick-start.md
+++ b/docs/tutorials/15-nvim-quick-start.md
@@ -22,7 +22,7 @@ command -v nvim && echo "✅ Nvim found" || echo "❌ Install: brew install neov
 
 # Check version (should be 0.9.0+)
 nvim --version | head -1
-```diff
+```
 
 ---
 
@@ -50,7 +50,7 @@ Nvim has two essential modes:
 │  (Navigation)   │     │  (Type text)    │
 │  Press ESC here │     │  Press i here   │
 └─────────────────┘     └─────────────────┘
-```bash
+```
 
 **The panic button:** `ESC` → `:q!` → `ENTER` (quit without saving)
 
@@ -68,7 +68,7 @@ echo "Hello from nvim practice!" > /tmp/nvim-test.txt
 
 # Open it with nvim
 nvim /tmp/nvim-test.txt
-```bash
+```
 
 **What happened:** Nvim opens showing your file content. You're in **Normal mode** (can't type yet).
 
@@ -85,7 +85,7 @@ Don't want to edit? Here's how to quit immediately:
 ```bash
 nvim /tmp/nvim-test.txt
 # ESC → :q! → ENTER
-```bash
+```
 
 **What happened:** You exited nvim without saving any changes.
 
@@ -101,7 +101,7 @@ To save your work AND quit:
 nvim /tmp/nvim-test.txt
 # Make no changes
 # ESC → :wq → ENTER
-```text
+```
 
 **Checkpoint:** Can you reliably quit nvim now? ✅
 
@@ -115,7 +115,7 @@ Time to actually edit! Open the test file:
 
 ```bash
 nvim /tmp/nvim-test.txt
-```sql
+```
 
 Now press `i` to enter **Insert mode**. You should see `-- INSERT --` at the bottom.
 
@@ -150,7 +150,7 @@ Now quit with `:q` and press ENTER.
 ```bash
 nvim /tmp/nvim-test.txt
 # i → type something → ESC → :w → :q
-```text
+```
 
 **Checkpoint:** Can you open, edit, save, and quit? ✅
 
@@ -164,7 +164,7 @@ Open the test file one more time to practice:
 
 ```bash
 nvim /tmp/nvim-test.txt
-```diff
+```
 
 | Command | What It Does | When To Use |
 |---------|--------------|-------------|
@@ -209,7 +209,7 @@ work test-project
 
 # Open a file (will use nvim)
 # ...when prompted, you'll be in nvim
-```bash
+```
 
 ### Using Nvim with MCP Dispatcher
 
@@ -218,7 +218,7 @@ Edit MCP server configs:
 ```bash
 # Opens MCP config in nvim
 mcp edit statistical-research
-```bash
+```
 
 **What you'll see:** Nvim opens the config file. Use `i` to edit, `ESC :wq` to save and quit.
 
@@ -229,7 +229,7 @@ Edit dotfiles:
 ```bash
 # Opens .zshrc in nvim
 dots edit zsh
-```diff
+```
 
 **Pattern:** Whenever flow-cli needs to edit a file, it uses nvim by default!
 
@@ -258,7 +258,7 @@ dots edit zsh
 
 ```bash
 flow nvim-tutorial
-```diff
+```
 
 ---
 
@@ -299,7 +299,7 @@ nvim ~/.config/zsh/.zshrc
 # 3. Add a new line: "# Edited with nvim!"
 # 4. Press ESC
 # 5. Type :wq and press ENTER
-```text
+```
 
 Verify your edit:
 

--- a/docs/tutorials/16-vim-motions.md
+++ b/docs/tutorials/16-vim-motions.md
@@ -21,7 +21,7 @@ Before starting, you should:
 nvim /tmp/vim-motions-practice.txt
 
 # Remember: ESC → :q! to panic exit
-```diff
+```
 
 ---
 
@@ -44,7 +44,7 @@ By the end of this tutorial, you will:
 ```text
 Arrow keys:  → → → → → → → → → →  (10 keypresses)
 Vim motions: w w w                 (3 keypresses, same distance)
-```python
+```
 
 **Three types of motions:**
 
@@ -75,7 +75,7 @@ def calculate_total(items):
 EOF
 
 nvim /tmp/vim-motions-practice.txt
-```diff
+```
 
 ### Step 1.2: Forward Word Motion (w)
 
@@ -307,7 +307,7 @@ Vim commands combine:
 
 ```text
 {operator} + {motion/text-object}
-```diff
+```
 
 **Examples:**
 
@@ -407,7 +407,7 @@ nvim ~/projects/some-project/src/main.zsh
 # 3. Change a variable name (ciw)
 # 4. Copy a whole function (vap → y)
 # 5. Navigate to top/bottom without arrow keys (gg/G)
-```text
+```
 
 ### What To Learn Next
 
@@ -421,7 +421,7 @@ nvim ~/projects/some-project/src/main.zsh
 
 ```bash
 flow nvim-tutorial
-```text
+```
 
 ---
 
@@ -441,7 +441,7 @@ G      # Bottom of file
 ?text  # Search backward
 f{     # Find character forward
 t{     # Before character forward
-```bash
+```
 
 ### Editing Patterns
 

--- a/docs/tutorials/17-lazyvim-basics.md
+++ b/docs/tutorials/17-lazyvim-basics.md
@@ -23,7 +23,7 @@ ls ~/.config/nvim/lua/lazyvim.lua
 # Open nvim and check plugins are loaded
 nvim
 # Press :Lazy to see plugin manager
-```diff
+```
 
 ---
 
@@ -54,7 +54,7 @@ LazyVim is a pre-configured nvim distribution with **58 plugins** already set up
 ```text
 Vanilla Nvim:  Raw editor, configure everything yourself
 LazyVim:       Batteries included, ready to code
-```bash
+```
 
 **The `<leader>` key:** Most LazyVim commands start with `<leader>` (mapped to `SPACE` by default).
 
@@ -71,7 +71,7 @@ Neo-tree is a file explorer sidebar (like VS Code's file tree).
 ```bash
 cd ~/projects/dev-tools/flow-cli
 nvim
-```diff
+```
 
 **Open Neo-tree:**
 
@@ -287,7 +287,7 @@ Which-key shows available keybindings **as you type**.
 │ w  window commands                │
 │ ...                               │
 ╰───────────────────────────────────╯
-```diff
+```
 
 ### Step 4.2: Exploring Submenus
 
@@ -337,7 +337,7 @@ Gitsigns shows **git changes** directly in nvim.
 ```bash
 cd ~/projects/dev-tools/flow-cli
 nvim README.md
-```diff
+```
 
 **What you see:**
 - **Green +** in gutter (left side) = added lines
@@ -469,7 +469,7 @@ LazyVim has built-in terminal support.
 ```bash
 cd ~/projects/dev-tools/flow-cli
 nvim
-```bash
+```
 
 **Workflow:**
 
@@ -497,7 +497,7 @@ nvim
 │   Terminal (running tests)                │
 │                                           │
 └───────────────────────────────────────────┘
-```diff
+```
 
 ### Practice Challenge
 

--- a/docs/tutorials/18-lazyvim-showcase.md
+++ b/docs/tutorials/18-lazyvim-showcase.md
@@ -24,7 +24,7 @@ ls ~/.config/nvim/lua/lazyvim.lua
 # Check plugin count
 nvim +'Lazy' +q
 # Should show ~58 plugins
-```diff
+```
 
 ---
 
@@ -80,7 +80,7 @@ LazyVim config lives in `~/.config/nvim/`:
 │   │   └── example.lua       # Add new plugins here
 │   └── lazyvim/              # LazyVim core (don't edit)
 └── lazyvim.json              # Language extras config
-```bash
+```
 
 **Inspect your config:**
 
@@ -90,7 +90,7 @@ ls ~/.config/nvim/lua/config/
 
 # Check current options
 nvim ~/.config/nvim/lua/config/options.lua
-```diff
+```
 
 ### Step 1.2: The Plugin Manager (Lazy.nvim)
 
@@ -164,7 +164,7 @@ print(result)
 EOF
 
 nvim /tmp/test.py
-```diff
+```
 
 **What you should see:**
 - Red squiggly underline under `totla`
@@ -205,7 +205,7 @@ nvim /tmp/test.py
 [d     # Previous diagnostic
 <leader>xx    # Show all diagnostics in Trouble window
 <leader>xd    # Show document diagnostics
-```diff
+```
 
 **Try it:**
 1. Open a file with multiple issues
@@ -236,7 +236,7 @@ Mason is a **package manager for LSP servers**, formatters, and linters.
 ```bash
 nvim
 :Mason
-```diff
+```
 
 **What you see:**
 - List of available language servers
@@ -270,7 +270,7 @@ nvim /tmp/test.py
 
 # LSP should now be active
 # Check: :LspInfo (shows attached servers)
-```bash
+```
 
 ### Step 3.4: Common Language Servers
 
@@ -292,7 +292,7 @@ nvim /tmp/test.py
 :Mason
 # Search for your language
 # Press 'i' to install
-```diff
+```
 
 **Checkpoint:** Can you install language servers with Mason? ✅
 
@@ -361,7 +361,7 @@ greet("World")
 EOF
 
 nvim /tmp/test.py
-```text
+```
 
 1. Put cursor anywhere in function
 2. Press `vaf` (visual around function)
@@ -375,7 +375,7 @@ nvim /tmp/test.py
 ```bash
 nvim
 :TSInstallInfo
-```diff
+```
 
 **What you see:**
 - List of languages
@@ -388,7 +388,7 @@ nvim
 :TSInstall python
 :TSInstall r
 :TSInstall bash
-```text
+```
 
 **Checkpoint:** Can you use Treesitter selections? ✅
 
@@ -404,14 +404,14 @@ Let's add a custom keybinding to save files with `<leader>w`:
 
 ```bash
 nvim ~/.config/nvim/lua/config/keymaps.lua
-```text
+```
 
 **Add this line:**
 
 ```lua
 -- Quick save
 vim.keymap.set("n", "<leader>w", ":w<CR>", { desc = "Save file" })
-```diff
+```
 
 **What this does:**
 - `"n"` = normal mode
@@ -434,7 +434,7 @@ Let's customize some settings:
 
 ```bash
 nvim ~/.config/nvim/lua/config/options.lua
-```text
+```
 
 **Add these options:**
 
@@ -452,7 +452,7 @@ vim.opt.scrolloff = 8
 
 -- Persistent undo
 vim.opt.undofile = true
-```text
+```
 
 **Options explained:**
 
@@ -478,7 +478,7 @@ Let's add a new plugin (example: vim-surround):
 
 ```bash
 nvim ~/.config/nvim/lua/plugins/custom.lua
-```text
+```
 
 **Add this:**
 
@@ -494,7 +494,7 @@ return {
     end,
   },
 }
-```diff
+```
 
 **What this does:**
 - Adds nvim-surround plugin
@@ -533,7 +533,7 @@ LazyVim has **optional language packs** called "extras".
 ```bash
 nvim
 :LazyExtras
-```diff
+```
 
 **What you see:**
 - List of available extras
@@ -551,7 +551,7 @@ Edit `~/.config/nvim/lazyvim.json`:
 
 ```bash
 nvim ~/.config/nvim/lazyvim.json
-```text
+```
 
 **Add extras:**
 
@@ -564,7 +564,7 @@ nvim ~/.config/nvim/lazyvim.json
     "lazyvim.plugins.extras.formatting.prettier"
   ]
 }
-```bash
+```
 
 **Save and restart nvim**.
 
@@ -607,7 +607,7 @@ work test-project
 mcp edit statistical-research  # Edit MCP config
 dots edit zsh                   # Edit dotfiles
 r edit                          # Edit R package files
-```text
+```
 
 ### Step 7.2: Custom Flow Keybinding
 
@@ -625,7 +625,7 @@ end, { desc = "Flow status" })
 vim.keymap.set("n", "<leader>ft", function()
   require("lazyvim.util").float_term({ "flow", "test" })
 end, { desc = "Flow tests" })
-```bash
+```
 
 **Test it:**
 1. Save and reload config
@@ -647,7 +647,7 @@ vim.opt.shiftwidth = 2
 vim.keymap.set("n", "<leader>rt", ":!Rscript tests/testthat.R<CR>")
 vim.keymap.set("n", "<leader>rc", ":!R CMD check .<CR>")
 EOF
-```diff
+```
 
 **Now when you open nvim in that directory:**
 - Tab width = 2 (R style)
@@ -667,7 +667,7 @@ EOF
 ```bash
 cd ~/projects/app/examify
 nvim
-```text
+```
 
 **Setup:**
 1. `<leader>e` → Neo-tree (left sidebar)
@@ -688,14 +688,14 @@ nvim
 │          │  Terminal      │
 │          │  (npm dev)     │
 └──────────┴────────────────┘
-```bash
+```
 
 ### Workflow 2: R Package Development
 
 ```bash
 cd ~/projects/r-packages/active/rmediation
 nvim
-```bash
+```
 
 **Setup:**
 1. `<leader>ff` → Open `R/mediation.R`
@@ -711,7 +711,7 @@ nvim
 ```bash
 cd ~/projects/teaching/stat-440
 nvim lectures/week-01/lecture.qmd
-```diff
+```
 
 **Setup:**
 1. Open Quarto file
@@ -747,7 +747,7 @@ nvim lectures/week-01/lecture.qmd
 :LazyExtras     # Enable language extras
 :Mason          # Install LSP servers
 :TSInstallInfo  # Treesitter parsers
-```bash
+```
 
 **LSP:**
 
@@ -758,7 +758,7 @@ gr             # Find references
 <leader>ca     # Code actions
 <leader>rn     # Rename symbol
 [d / ]d        # Next/prev diagnostic
-```text
+```
 
 **Customization Files:**
 

--- a/docs/tutorials/19-teaching-git-integration.md
+++ b/docs/tutorials/19-teaching-git-integration.md
@@ -41,7 +41,7 @@ cd ~/projects/teaching
 
 # Initialize a new course WITH git
 teach init "STAT 440"
-```text
+```
 
 **What happens:**
 
@@ -59,7 +59,7 @@ teach init "STAT 440"
 │                                                             │
 │ Would you like to create a GitHub repository? (y/N)         │
 └─────────────────────────────────────────────────────────────┘
-```text
+```
 
 **Git structure created:**
 
@@ -74,7 +74,7 @@ stat-440/
 └── scripts/
     ├── quick-deploy.sh
     └── semester-archive.sh
-```bash
+```
 
 **Current branches:**
 
@@ -82,14 +82,14 @@ stat-440/
 git branch -a
 # * draft
 #   main
-```bash
+```
 
 ### Step 2: Explore Git Configuration
 
 ```bash
 # View config
 teach config
-```yaml
+```
 
 **Git settings (`.flow/teach-config.yml`):**
 
@@ -104,7 +104,7 @@ workflow:
   teaching_mode: false           # Manual workflow (default)
   auto_commit: false             # No auto-commit (default)
   auto_push: false               # Never auto-push (safety)
-```bash
+```
 
 **Exercise:** Try changing `draft_branch` to `dev` and see what happens.
 
@@ -123,7 +123,7 @@ git branch
 
 # Create exam
 teach exam "Syllabus Quiz"
-```text
+```
 
 **What you'll see:**
 
@@ -138,7 +138,7 @@ What would you like to do?
   3) Skip commit (do it manually later)
 
 Choice [1-3]:
-```text
+```
 
 ### Step 2: Try Each Option
 
@@ -153,7 +153,7 @@ Opening exams/syllabus-quiz.qmd in nvim...
 Commit this file? (y/N): y
 
 ✓ Committed: teach: add exam for Syllabus Quiz
-```text
+```
 
 **Option 2: Commit now (auto-message)**
 
@@ -169,7 +169,7 @@ Commit message:
   Course: STAT 440 (Fall 2024)
 
   Co-Authored-By: Scholar <scholar@example.com>
-```text
+```
 
 **Option 3: Skip commit**
 
@@ -180,7 +180,7 @@ Skipped. File saved, not committed.
 You can commit manually later:
   git add exams/syllabus-quiz.qmd
   git commit -m "teach: add exam for Syllabus Quiz"
-```bash
+```
 
 ### Step 3: View Your Commits
 
@@ -191,7 +191,7 @@ git log --oneline -5
 # Example output:
 # a1b2c3d teach: add exam for Syllabus Quiz
 # e4f5g6h Initial commit
-```bash
+```
 
 **Exercise:** Create 3 more exams using different options each time.
 
@@ -211,13 +211,13 @@ teach slides "Week 1 Introduction"
 # Create quiz (choose option 3 - skip)
 teach quiz "Chapter 1"
 # Choice: 3 (skip)
-```text
+```
 
 ### Step 2: Check Status
 
 ```bash
 teach status
-```text
+```
 
 **Output:**
 
@@ -239,7 +239,7 @@ teach status
 │                                                             │
 │ Choice [1-4]:                                               │
 └─────────────────────────────────────────────────────────────┘
-```text
+```
 
 ### Step 3: Try Each Status Option
 
@@ -254,7 +254,7 @@ Choice: 1
 
   - slides/week01-introduction.qmd
   - quizzes/quiz01.qmd
-```text
+```
 
 **Option 2: Stash changes**
 
@@ -262,7 +262,7 @@ Choice: 1
 Choice: 2
 
 ✓ Stashed 2 files: WIP on draft
-```text
+```
 
 **Option 3: View diff**
 
@@ -277,7 +277,7 @@ index 0000000..abcdefg
 ...
 
 (Returns to menu after showing diff)
-```bash
+```
 
 **Exercise:** Create 5 files, leave uncommitted, then use `teach status` to commit them all at once.
 
@@ -296,13 +296,13 @@ teach status
 
 # Push to GitHub (if you created remote repo)
 git push origin draft
-```text
+```
 
 ### Step 2: Deploy to Production
 
 ```bash
 teach deploy
-```text
+```
 
 **Pre-flight checks:**
 
@@ -318,7 +318,7 @@ teach deploy
 │                                                             │
 │ All checks passed. Creating PR...                           │
 └─────────────────────────────────────────────────────────────┘
-```text
+```
 
 **PR creation:**
 
@@ -346,7 +346,7 @@ Body:
 - [ ] Accessibility checked
 
 ✓ PR created: https://github.com/user/stat-440/pull/1
-```bash
+```
 
 ### Step 3: Review and Merge
 
@@ -356,7 +356,7 @@ gh pr view 1 --web
 
 # Merge when ready
 gh pr merge 1 --squash
-```bash
+```
 
 **Exercise:** Create 5 new files, commit them, and deploy to production.
 
@@ -371,7 +371,7 @@ Enable **streamlined auto-commit** for rapid content creation.
 ```bash
 # Edit config
 teach config
-```yaml
+```
 
 **Change these settings:**
 
@@ -380,7 +380,7 @@ workflow:
   teaching_mode: true      # Enable teaching mode
   auto_commit: true        # Auto-commit after generation
   auto_push: false         # Safety: never auto-push
-```bash
+```
 
 Save and close.
 
@@ -389,7 +389,7 @@ Save and close.
 ```bash
 # Create exam (no menu!)
 teach exam "Midterm 1"
-```text
+```
 
 **Output:**
 
@@ -399,7 +399,7 @@ teach exam "Midterm 1"
 🎓 Teaching Mode: Auto-committing...
 
 ✓ Committed: teach: add exam for Midterm 1
-```bash
+```
 
 **No menu, instant commit!**
 
@@ -414,7 +414,7 @@ teach assignment "Homework 2"
 
 # All auto-committed!
 git log --oneline -5
-```text
+```
 
 **Output:**
 
@@ -424,7 +424,7 @@ e0d9c8b teach: add lecture for Hypothesis Testing
 d9c8b7a teach: add slides for Week 3
 c8b7a6f teach: add quiz for Chapter 2
 b7a6d5e teach: add exam for Midterm 1
-```bash
+```
 
 ### Step 4: Deploy All Changes
 
@@ -435,7 +435,7 @@ git push origin draft
 # Deploy to production
 teach deploy
 # (Creates PR with all 5 commits)
-```bash
+```
 
 **Exercise:** Enable teaching mode and create 10 pieces of content in under 5 minutes.
 
@@ -466,7 +466,7 @@ git log --oneline -3
 # Deploy
 git push origin draft
 teach deploy
-```bash
+```
 
 ### Workflow 2: Exam Season
 
@@ -489,7 +489,7 @@ teach exam "Final Exam"
 # Create answer key
 teach exam "Final Exam - Answer Key"
 # Choice: 2 (commit now)
-```bash
+```
 
 ### Workflow 3: Collaborative Teaching
 
@@ -515,7 +515,7 @@ gh pr merge <PR-number>
 
 # Then deploy to production
 teach deploy
-```bash
+```
 
 ---
 
@@ -539,7 +539,7 @@ teach init --no-git "STAT 440"
 git init
 git add .
 git commit -m "Initial commit"
-```text
+```
 
 ### Problem: Deploy fails with uncommitted changes
 
@@ -547,7 +547,7 @@ git commit -m "Initial commit"
 
 ```text
 ❌ Deployment blocked: uncommitted changes detected
-```bash
+```
 
 **Solution:**
 
@@ -564,7 +564,7 @@ git stash
 
 # Then deploy
 teach deploy
-```yaml
+```
 
 ### Problem: Teaching mode not auto-committing
 
@@ -580,7 +580,7 @@ teach config
 workflow:
   teaching_mode: true
   auto_commit: true     # This must be true!
-```text
+```
 
 ### Problem: PR creation fails
 
@@ -588,7 +588,7 @@ workflow:
 
 ```text
 Error: gh: command not found
-```bash
+```
 
 **Solution:**
 
@@ -601,7 +601,7 @@ gh auth login
 
 # Try again
 teach deploy
-```bash
+```
 
 ---
 
@@ -615,7 +615,7 @@ git checkout draft
 
 # Keep main clean (production only)
 # Only merge to main via PR
-```bash
+```
 
 ### 2. Commit Hygiene
 
@@ -626,7 +626,7 @@ git log --oneline -10
 
 # Squash related commits if needed (before PR)
 git rebase -i HEAD~5
-```bash
+```
 
 ### 3. Deployment Timing
 
@@ -638,7 +638,7 @@ git rebase -i HEAD~5
 # Or deploy after major milestones:
 # → After creating full exam
 # → After completing week's content
-```bash
+```
 
 ### 4. Backup Strategy
 
@@ -649,7 +649,7 @@ git push origin draft
 # Even if not deploying yet
 # → Protects against data loss
 # → Enables collaboration
-```text
+```
 
 ---
 

--- a/docs/tutorials/20-teaching-dates-automation.md
+++ b/docs/tutorials/20-teaching-dates-automation.md
@@ -45,7 +45,7 @@ flowchart TD
     style Sync fill:#f9e2af
     style Status fill:#a6e3a1
     style Done fill:#a6e3a1
-```text
+```
 
 ---
 
@@ -60,7 +60,7 @@ Teaching a course means managing dates in dozens of files:
 ❌ assignments/hw1.qmd:  due: "2025-01-20"  # ← Mismatch!
 ❌ schedule.qmd:        "Week 2: January 22, 2025"
 ❌ lectures/week02.qmd: "Due: Jan 22, 2025"
-```diff
+```
 
 **Issues:**
 - 📅 40+ dates to update manually each semester
@@ -79,7 +79,7 @@ semester_info:
     hw1:
       week: 2
       offset_days: 2  # Friday of Week 2 = Jan 22
-```bash
+```
 
 Run `teach dates sync` and all files update automatically! ⚡
 
@@ -100,7 +100,7 @@ flow --version
 
 # Test teach dates command
 teach dates help
-```bash
+```
 
 **If missing:**
 
@@ -110,7 +110,7 @@ brew install yq
 
 # Install GNU date (macOS only)
 brew install coreutils
-```bash
+```
 
 !!! tip "Why yq?"
     yq is a powerful YAML processor that safely reads and updates structured data without corrupting your config files.
@@ -127,13 +127,13 @@ cd ~/projects/teaching/stat-545
 
 # Initialize dates
 teach dates init
-```text
+```
 
 **The wizard will ask:**
 
 ```text
 Semester start date (YYYY-MM-DD): 2025-01-13
-```bash
+```
 
 **What happens:**
 
@@ -147,7 +147,7 @@ Semester start date (YYYY-MM-DD): 2025-01-13
 
 ```bash
 cat .flow/teach-config.yml
-```yaml
+```
 
 **Expected output:**
 
@@ -166,7 +166,7 @@ semester_info:
   holidays: []
   deadlines: {}
   exams: []
-```yaml
+```
 
 **Demo:**
 
@@ -189,7 +189,7 @@ The `semester_info` section has 5 key parts:
 semester_info:
   start_date: "2025-01-13"
   end_date: "2025-04-28"
-```diff
+```
 
 - `start_date`: First day of classes
 - `end_date`: Last day of classes (auto-calculated: start + 15 weeks)
@@ -204,7 +204,7 @@ semester_info:
     - number: 2
       start_date: "2025-01-20"
       topic: "Data Visualization"
-```diff
+```
 
 - Auto-generated for 15 weeks
 - You can add `topic` for each week
@@ -216,7 +216,7 @@ semester_info:
   holidays:
     - name: "Spring Break"
       date: "2025-03-10"
-```diff
+```
 
 - Optional section
 - Helps explain schedule gaps
@@ -231,7 +231,7 @@ semester_info:
       offset_days: 2  # Friday of Week 2
     midterm_project:
       date: "2025-03-05"  # Absolute date
-```diff
+```
 
 **Two ways to specify:**
 - **Relative:** `week` + `offset_days` (flexible, adjusts automatically)
@@ -247,7 +247,7 @@ semester_info:
     - name: "Final Exam"
       date: "2025-05-02"
       time: "10:00-12:00"
-```bash
+```
 
 ---
 
@@ -259,7 +259,7 @@ Let's add some real deadlines and exams. Open your config:
 vim .flow/teach-config.yml
 # Or: code .flow/teach-config.yml
 # Or: open -a "iA Writer" .flow/teach-config.yml
-```yaml
+```
 
 **Add these sections:**
 
@@ -301,7 +301,7 @@ semester_info:
     - name: "Final Exam"
       date: "2025-05-02"
       time: "10:00-12:00"
-```text
+```
 
 **Save the file.**
 
@@ -313,7 +313,7 @@ semester_info:
 
 ```bash
 teach dates validate
-```text
+```
 
 **Expected output:**
 
@@ -324,7 +324,7 @@ teach dates validate
 ✓ All dates in valid format (YYYY-MM-DD)
 ✓ Week numbers sequential (1-15)
 ✓ Deadline references valid weeks
-```text
+```
 
 ---
 
@@ -334,7 +334,7 @@ Before applying changes, let's preview what would change:
 
 ```bash
 teach dates sync --dry-run
-```text
+```
 
 **Example output:**
 
@@ -360,7 +360,7 @@ teach dates sync --dry-run
 
 DRY RUN MODE - No changes applied
 Run without --dry-run to apply changes
-```text
+```
 
 **Demo:**
 
@@ -382,7 +382,7 @@ Now let's apply the changes. The command will ask for confirmation on each file:
 
 ```bash
 teach dates sync
-```text
+```
 
 **Interactive prompts:**
 
@@ -405,7 +405,7 @@ Apply changes to this file? [y/n/d/q]
   n = no, skip
   d = diff, show full changes
   q = quit
-```diff
+```
 
 **Choose your action:**
 
@@ -425,7 +425,7 @@ Applied changes to 3 files:
   ✓ schedule.md
 
 Skipped: 0 files
-```text
+```
 
 **Demo:**
 
@@ -442,7 +442,7 @@ If you're confident and want to apply all changes without prompts:
 
 ```bash
 teach dates sync --force
-```text
+```
 
 !!! warning "Use Force Carefully"
     Force mode applies all changes without asking. Only use if you've reviewed the dry-run output.
@@ -455,7 +455,7 @@ Verify everything is synchronized:
 
 ```bash
 teach dates status
-```text
+```
 
 **Expected output:**
 
@@ -483,7 +483,7 @@ Exams: 2
 
 Files checked: 25
 Mismatches: 0
-```diff
+```
 
 !!! tip "Run status anytime"
     Run `teach dates status` after editing files manually to catch any inconsistencies.
@@ -520,7 +520,7 @@ teach dates sync --syllabus
 
 # Single file
 teach dates sync --file syllabus.qmd
-```text
+```
 
 #### 2. Verbose Mode
 
@@ -528,7 +528,7 @@ See detailed processing:
 
 ```bash
 teach dates sync --verbose
-```diff
+```
 
 Shows:
 - Which files are being scanned
@@ -549,7 +549,7 @@ teach dates sync --dry-run
 
 # Step 3: Apply (5 minutes vs 2 hours manual!)
 teach dates sync --force
-```yaml
+```
 
 #### 4. Complex Date Patterns
 
@@ -566,7 +566,7 @@ deadlines:
     date: "2025-03-07"
     time: "14:00-15:50"
     location: "Room 301"
-```bash
+```
 
 ### Troubleshooting
 
@@ -579,7 +579,7 @@ pwd
 
 # Check for teaching files
 find . -name "*.qmd" -o -name "*.md" | head
-```bash
+```
 
 **Problem:** Dates not updating in file
 
@@ -591,7 +591,7 @@ teach dates sync --file syllabus.qmd --verbose
 # - YAML: due: "2025-01-22"
 # - Inline: "due Jan 22, 2025"
 # - Inline: "January 22, 2025"
-```bash
+```
 
 **Problem:** Config validation fails
 

--- a/docs/tutorials/21-teach-analyze.md
+++ b/docs/tutorials/21-teach-analyze.md
@@ -29,7 +29,7 @@ teach doctor
 
 # Check you're in a course directory
 ls lectures/*.qmd
-```diff
+```
 
 ---
 
@@ -70,7 +70,7 @@ flowchart LR
     style Phase0 fill:#2ecc71,color:#fff
     style Phase2 fill:#e67e22,color:#fff
     style Phase4 fill:#e74c3c,color:#fff
-```yaml
+```
 
 ---
 
@@ -106,7 +106,7 @@ concepts:
     - mean
     - variance
 ---
-```diff
+```
 
 **Naming conventions:**
 - Use lowercase, hyphenated names: `chi-squared` not `Chi Squared`
@@ -123,7 +123,7 @@ Now run the analysis on a single file:
 
 ```bash
 teach analyze lectures/week-03-correlation.qmd
-```text
+```
 
 **Expected output:**
 
@@ -143,7 +143,7 @@ teach analyze lectures/week-03-correlation.qmd
 ├────────────────────────────────────────────────────┤
 │ Phase: 0 (concept-validated)                       │
 ╰────────────────────────────────────────────────────╯
-```diff
+```
 
 **What to look for:**
 - Green checkmarks (✓) mean prerequisites are satisfied
@@ -159,7 +159,7 @@ After running analysis, check the generated concept graph:
 ```bash
 # View the concept graph
 cat .teach/concepts.json | jq '.'
-```diff
+```
 
 **The concept graph maps:**
 - Which week introduces each concept
@@ -172,13 +172,13 @@ cat .teach/concepts.json | jq '.'
   "variance": {"week": 1, "file": "lectures/week-01-basics.qmd"},
   "correlation": {"week": 3, "file": "lectures/week-03-correlation.qmd"}
 }
-```text
+```
 
 **Run analysis on your full course** to build the complete graph:
 
 ```bash
 teach analyze
-```text
+```
 
 This scans all `.qmd` files in `lectures/` and validates cross-file prerequisites.
 
@@ -192,7 +192,7 @@ If analysis finds violations, you'll see:
 ✗ regression (required in Week 3, introduced in Week 5)
   → Move regression introduction to Week 1-2, or
   → Remove from Week 3 requirements
-```bash
+```
 
 **Common fixes:**
 
@@ -211,7 +211,7 @@ teach analyze --mode relaxed lectures/week-05.qmd
 
 # Strict: treat warnings as errors
 teach analyze --mode strict lectures/week-05.qmd
-```text
+```
 
 ---
 
@@ -221,7 +221,7 @@ For a guided walkthrough, use interactive mode:
 
 ```bash
 teach analyze --interactive
-```text
+```
 
 **This walks you through:**
 
@@ -239,7 +239,7 @@ Select strictness mode:
   3) Strict (all issues)
 
 > 2
-```text
+```
 
 Then it shows results and offers to step through each violation:
 
@@ -248,7 +248,7 @@ Found 2 issues. Review each? (y/n)
 
 [1/2] regression used in Week 3 but taught in Week 5
   [y] Apply fix  [n] Skip  [s] Skip all  [q] Quit
-```bash
+```
 
 **Best for:** First-time analysis of a new course, or when you have many violations to triage.
 
@@ -264,7 +264,7 @@ teach analyze --report analysis-report.md
 
 # JSON report (for CI/automation)
 teach analyze --report results.json --format json
-```diff
+```
 
 **Markdown report includes:**
 - Summary statistics (concepts, weeks, violations)
@@ -279,7 +279,7 @@ teach analyze --report results.json --format json
 # Block deploys on errors
 teach analyze --report /dev/null --format json | jq '.error_count'
 # Returns 0 if no errors
-```text
+```
 
 ---
 
@@ -289,7 +289,7 @@ Before making slides, check where content is too dense:
 
 ```bash
 teach analyze --slide-breaks lectures/week-05-regression.qmd
-```text
+```
 
 **Output shows suggested breaks:**
 
@@ -304,13 +304,13 @@ SLIDE OPTIMIZATION
 
   Key concepts: regression-coefficient, residuals, r-squared
   Estimated time: 28 min
-```text
+```
 
 **For detailed preview:**
 
 ```bash
 teach analyze --preview-breaks lectures/week-05-regression.qmd
-```diff
+```
 
 This shows each suggested break with:
 - Exact location (heading and line)
@@ -326,7 +326,7 @@ Now use the slides integration for end-to-end generation:
 ```bash
 # See key concepts for callout boxes
 teach slides --optimize --key-concepts lectures/week-05-regression.qmd
-```text
+```
 
 **Output:**
 
@@ -339,19 +339,19 @@ teach slides --optimize --key-concepts lectures/week-05-regression.qmd
 
   3 concept(s) identified
   ⏱️  Estimated presentation time: 28 min
-```text
+```
 
 **Generate slides with optimizations applied:**
 
 ```bash
 teach slides --optimize --apply-suggestions lectures/week-05-regression.qmd
-```text
+```
 
 **Full workflow with callouts:**
 
 ```bash
 teach slides --optimize --key-concepts --apply-suggestions lectures/week-05-regression.qmd
-```diff
+```
 
 This generates `slides/week-05-regression_slides.qmd` with:
 - Slides split at suggested break points
@@ -372,7 +372,7 @@ teach analyze --ai lectures/week-05-regression.qmd
 
 # Check AI usage costs
 teach analyze --costs
-```diff
+```
 
 AI analysis provides:
 - Learning objective alignment scoring
@@ -388,7 +388,7 @@ teach deploy --check-prereqs
 
 # Deep validation (all layers)
 teach validate --deep
-```bash
+```
 
 ### Automation
 

--- a/docs/tutorials/22-plugin-optimization.md
+++ b/docs/tutorials/22-plugin-optimization.md
@@ -41,7 +41,7 @@ Map how files are sourced on plugin load:
 ```bash
 # Main plugin file
 cat flow.plugin.zsh | grep -n "source.*teach"
-```text
+```
 
 **Output:**
 
@@ -54,7 +54,7 @@ cat flow.plugin.zsh | grep -n "source.*teach"
 54: source "$FLOW_PLUGIN_DIR/lib/slide-optimizer.zsh"
 56: source "$FLOW_PLUGIN_DIR/commands/teach-analyze.zsh"
 63: for cmd_file in "$FLOW_PLUGIN_DIR/commands/"*.zsh(N); source
-```zsh
+```
 
 **Problem:** Line 56 sources `teach-analyze.zsh` explicitly, but the glob on line 63 sources **all** `commands/*.zsh` files again!
 
@@ -62,7 +62,7 @@ cat flow.plugin.zsh | grep -n "source.*teach"
 
 ```bash
 head -20 commands/teach-analyze.zsh | grep source
-```zsh
+```
 
 **Output:**
 
@@ -73,7 +73,7 @@ source "${0:A:h:h}/lib/analysis-cache.zsh"
 source "${0:A:h:h}/lib/report-generator.zsh"
 source "${0:A:h:h}/lib/ai-analysis.zsh"
 source "${0:A:h:h}/lib/slide-optimizer.zsh"
-```text
+```
 
 **Problem:** `teach-analyze.zsh` sources all 6 libs unconditionally!
 
@@ -86,7 +86,7 @@ flow.plugin.zsh L56:    Source teach-analyze.zsh
 flow.plugin.zsh L63:    Glob sources commands/*.zsh
   └─> teach-analyze.zsh sourced AGAIN (THIRD load)
       └─> 5 libs sourced AGAIN
-```bash
+```
 
 **Result:** ~5,500 lines of ZSH parsed **2-3 times** on every shell startup.
 
@@ -108,7 +108,7 @@ fi
 typeset -g _FLOW_CONCEPT_EXTRACTION_LOADED=1
 
 # ... rest of file
-```diff
+```
 
 **Why `2>/dev/null || true`?**
 - `return` inside a sourced file exits the source
@@ -123,7 +123,7 @@ if [[ -n "$_FLOW_CONCEPT_EXTRACTION_LOADED" ]]; then
     return 0 2>/dev/null || true
 fi
 typeset -g _FLOW_CONCEPT_EXTRACTION_LOADED=1
-```bash
+```
 
 ```bash
 # lib/prerequisite-checker.zsh
@@ -131,7 +131,7 @@ if [[ -n "$_FLOW_PREREQUISITE_CHECKER_LOADED" ]]; then
     return 0 2>/dev/null || true
 fi
 typeset -g _FLOW_PREREQUISITE_CHECKER_LOADED=1
-```diff
+```
 
 Repeat for:
 - `lib/analysis-cache.zsh` → `_FLOW_ANALYSIS_CACHE_LOADED`
@@ -155,7 +155,7 @@ source "$FLOW_PLUGIN_DIR/commands/teach-analyze.zsh"
 
 # AFTER (just rely on the glob)
 # (delete lines 49-56)
-```bash
+```
 
 The glob on line 63 sources all `commands/*.zsh`, which sources the libs (once each, thanks to guards).
 
@@ -171,7 +171,7 @@ echo "Load guards check:"
 [[ -n "$_FLOW_CONCEPT_EXTRACTION_LOADED" ]] && echo "  concept-extraction: ✅"
 [[ -n "$_FLOW_ANALYSIS_CACHE_LOADED" ]] && echo "  analysis-cache: ✅"
 '
-```text
+```
 
 **Expected output:**
 
@@ -179,7 +179,7 @@ echo "Load guards check:"
 Load guards check:
   concept-extraction: ✅
   analysis-cache: ✅
-```bash
+```
 
 ---
 
@@ -190,7 +190,7 @@ Load guards check:
 ```bash
 # Find display functions in the command file
 grep -n "^_display_" commands/teach-analyze.zsh
-```text
+```
 
 **Output:**
 
@@ -202,7 +202,7 @@ grep -n "^_display_" commands/teach-analyze.zsh
 127: _display_ai_section() {
 191: _display_slide_section() {
 235: _display_summary_section() {
-```bash
+```
 
 **Pattern:** 7 functions, ~270 lines, all pure presentation logic.
 
@@ -235,7 +235,7 @@ typeset -g _FLOW_ANALYSIS_DISPLAY_LOADED=1
 
 # ... paste the 7 _display_* functions here ...
 EOF
-```zsh
+```
 
 ### Step 9: Update the Command File
 
@@ -246,7 +246,7 @@ EOF
 ```zsh
 # Load display layer
 source "${0:A:h:h}/lib/analysis-display.zsh"
-```text
+```
 
 **Before:** 1,203 lines
 **After:** ~930 lines (extracted 270+ lines)
@@ -261,7 +261,7 @@ source "${0:A:h:h}/lib/analysis-display.zsh"
 
 ```zsh
 local slide_cache_file="$course_dir/.teach/slide-optimization-${file_path:t:r}.json"
-```bash
+```
 
 **Problem:** `${file_path:t:r}` extracts only the filename stem, ignoring the directory.
 
@@ -282,7 +282,7 @@ local cache_name="${relative_path:t:r}"          # Get filename stem
 local slide_cache_dir="$course_dir/.teach/analysis-cache/$cache_subdir"
 mkdir -p "$slide_cache_dir" 2>/dev/null
 local slide_cache_file="$slide_cache_dir/${cache_name}-slides.json"
-```bash
+```
 
 **Result:**
 
@@ -300,7 +300,7 @@ local slide_cache_file="$slide_cache_dir/${cache_name}-slides.json"
 ```bash
 # Run test suite
 ./tests/run-all.sh
-```zsh
+```
 
 **Problem:** Hangs forever on `test-work.zsh`.
 
@@ -325,7 +325,7 @@ run_test() {
         ((FAIL++))
     fi
 }
-```zsh
+```
 
 ```bash
 # AFTER
@@ -353,7 +353,7 @@ run_test() {
         ((FAIL++))
     fi
 }
-```bash
+```
 
 ### Step 14: Update Summary
 
@@ -369,13 +369,13 @@ if [[ $TIMEOUT -gt 0 ]]; then
     echo "Note: Timeout tests may require interactive/tmux context"
     exit 2  # Different exit code for timeouts vs failures
 fi
-```bash
+```
 
 ### Step 15: Verify Fix
 
 ```bash
 ./tests/run-all.sh
-```text
+```
 
 **Expected output:**
 
@@ -401,7 +401,7 @@ Running test-capture... ✅
 =========================================
 
 Note: Timeout tests may require interactive/tmux context
-```bash
+```
 
 **Before:** Infinite hang
 **After:** Completes in ~3 minutes
@@ -428,7 +428,7 @@ git commit -m "fix: mirror directory structure in slide cache paths"
 # Commit 4: Test timeout
 git add tests/run-all.sh
 git commit -m "fix: add 30s timeout to test runner"
-```bash
+```
 
 ### Step 17: Update Documentation
 
@@ -443,7 +443,7 @@ vim CHANGELOG.md
 # - Load guard double-sourcing (prevents 2-3x parsing on startup)
 # - Slide cache path collisions (directory-mirroring structure)
 # - Test runner hangs (30s timeout mechanism)
-```zsh
+```
 
 ---
 
@@ -456,7 +456,7 @@ if [[ -n "$_FLOW_*_LOADED" ]]; then
     return 0 2>/dev/null || true
 fi
 typeset -g _FLOW_*_LOADED=1
-```diff
+```
 
 **When to use:**
 - Any file that might be sourced multiple times
@@ -482,7 +482,7 @@ typeset -g _FLOW_*_LOADED=1
 ```text
 .teach/cache-file1.json
 .teach/cache-file2.json
-```text
+```
 
 **Mirrored structure (good):**
 

--- a/docs/tutorials/23-token-automation.md
+++ b/docs/tutorials/23-token-automation.md
@@ -65,7 +65,7 @@ Let's see the traditional approach:
 ```bash
 # Full health check (all categories)
 doctor
-```text
+```
 
 **Expected output:**
 
@@ -86,7 +86,7 @@ doctor
   ✓ GitHub token    Valid (expires in 45 days)
 
 ... (60+ seconds total)
-```bash
+```
 
 !!! note "Full Health Check is Valuable"
     The traditional `doctor` command is still important for comprehensive system checks. Use it weekly or after major changes.
@@ -100,7 +100,7 @@ Now let's use the new isolated token check:
 ```bash
 # Check only tokens (< 3s, cached)
 doctor --dot
-```text
+```
 
 **Expected output:**
 
@@ -114,7 +114,7 @@ doctor --dot
   ✓ Cache hit       ~/.flow/cache/doctor/token-github.cache
 
 ⏱️ Check completed in 0.85s (cache hit: 0.05s)
-```bash
+```
 
 !!! success "20x Faster!"
     Token check: **0.85s** vs **60s** full doctor run
@@ -132,13 +132,13 @@ doctor --dot
 ```bash
 # Run again immediately
 doctor --dot
-```text
+```
 
 **Expected:**
 
 ```text
 ⏱️ Check completed in 0.05s (cache hit: 0.05s)
-```bash
+```
 
 **Cache hit!** The second check is **instant** (~50ms).
 
@@ -167,7 +167,7 @@ sequenceDiagram
         Doctor->>Cache: Store result (TTL: 5 min)
         Doctor-->>User: ✓ Valid (fresh, 2.3s)
     end
-```diff
+```
 
 ### Cache Lifecycle
 
@@ -194,7 +194,7 @@ When you have token issues, use the interactive fix menu:
 ```bash
 # Interactive token fix workflow
 doctor --fix-token
-```text
+```
 
 **Expected output:**
 
@@ -217,7 +217,7 @@ GitHub Token: Expiring in 7 days
 │  ○ Skip - I'll fix this later               │
 │                                             │
 ╰─────────────────────────────────────────────╯
-```bash
+```
 
 !!! tip "ADHD-Friendly Design"
     - **Single-choice menu** (reduces decision paralysis)
@@ -244,13 +244,13 @@ Control output detail for different scenarios:
 ```bash
 # Minimal output, automation-friendly
 doctor --dot --quiet
-```text
+```
 
 **Output:**
 
 ```bash
 # (No output if successful, exit code 0)
-```diff
+```
 
 **Use cases:**
 - CI/CD pipelines
@@ -263,7 +263,7 @@ doctor --dot --quiet
 ```bash
 # Standard output
 doctor --dot
-```text
+```
 
 **Output:**
 
@@ -274,14 +274,14 @@ doctor --dot
 
 🔐 TOKENS
   ✓ GitHub token    Valid (expires in 45 days)
-```bash
+```
 
 ### Verbose Mode (Debugging)
 
 ```bash
 # Detailed output with cache status
 doctor --dot --verbose
-```text
+```
 
 **Output:**
 
@@ -303,7 +303,7 @@ doctor --dot --verbose
 ⚡ Performance:
   • Cache check: 5ms
   • Total time: 78ms
-```diff
+```
 
 **Use cases:**
 - Troubleshooting cache issues
@@ -323,7 +323,7 @@ Token validation is integrated across 9 dispatchers:
 ```bash
 # Validates token before push
 g push
-```text
+```
 
 **Output:**
 
@@ -332,7 +332,7 @@ g push
   ✓ Token valid (cached, 0.05s)
 
 Pushing to origin/main...
-```bash
+```
 
 !!! success "Automatic Validation"
     The `g` dispatcher checks your token health before remote operations (push, pull, fetch)
@@ -342,7 +342,7 @@ Pushing to origin/main...
 ```bash
 # Shows token status in dev dashboard
 dash dev
-```text
+```
 
 **Output:**
 
@@ -352,28 +352,28 @@ dash dev
 ╰─────────────────────────────────────────────╯
 
 🔐 GitHub Token: ✓ Valid (45 days remaining)
-```bash
+```
 
 ### Session Start (`work` command)
 
 ```bash
 # Checks token on session start
 work my-project
-```text
+```
 
 **Output:**
 
 ```text
 🎯 Starting session: my-project
 🔐 Token check... ✓ (cached)
-```bash
+```
 
 ### Pre-Push Validation (`finish` command)
 
 ```bash
 # Validates before committing/pushing
 finish
-```text
+```
 
 **Output:**
 
@@ -382,7 +382,7 @@ finish
   ✓ Token valid (2.1s)
 
 Committing changes...
-```yaml
+```
 
 ### Integration Summary
 
@@ -424,14 +424,14 @@ jobs:
       - name: Run tests
         if: success()
         run: ./tests/run-all.sh
-```bash
+```
 
 ### Cron Job
 
 ```bash
 # Check token health daily
 0 9 * * * /usr/local/bin/doctor --dot --quiet || echo "Token check failed!" | mail -s "flow-cli alert" you@example.com
-```bash
+```
 
 ### Shell Script
 
@@ -447,7 +447,7 @@ fi
 
 # Proceed with deployment
 echo "✓ Token valid. Deploying..."
-```diff
+```
 
 ### Exit Codes
 
@@ -516,7 +516,7 @@ doctor --dot --verbose
 
 # Full health check (all categories)
 doctor
-```bash
+```
 
 ### Common Workflows
 

--- a/docs/tutorials/24-template-management.md
+++ b/docs/tutorials/24-template-management.md
@@ -28,7 +28,7 @@ flow --version  # Should show 5.20.0+
 
 # Check you're in a course directory
 ls .flow/teach-config.yml
-```diff
+```
 
 ---
 
@@ -66,7 +66,7 @@ flowchart LR
     style Phase1 fill:#2ecc71,color:#fff
     style Phase2 fill:#e67e22,color:#fff
     style Phase3 fill:#e74c3c,color:#fff
-```diff
+```
 
 ---
 
@@ -99,7 +99,7 @@ teach templates
 
 # Or use the full command
 teach templates list
-```text
+```
 
 **Example output:**
 
@@ -119,7 +119,7 @@ teach templates list
 │                                                             │
 │ Legend: [P] = Project override exists                       │
 ╰─────────────────────────────────────────────────────────────╯
-```bash
+```
 
 **Filter by type:**
 
@@ -132,7 +132,7 @@ teach templates list --source project
 
 # Only plugin defaults
 teach templates list --source plugin
-```bash
+```
 
 ---
 
@@ -149,7 +149,7 @@ teach templates new lab week-03
 
 # Create slides
 teach templates new slides week-05
-```text
+```
 
 **What happens:**
 
@@ -168,7 +168,7 @@ $ teach templates new lecture week-05
     {{WEEK}} → 05
     {{DATE}} → 2026-01-28
     {{COURSE}} → STAT-545
-```bash
+```
 
 ---
 
@@ -194,7 +194,7 @@ teach templates new lecture week-05 --topic "Linear Regression"
 # Or be prompted
 teach templates new lecture week-05
 # → Enter topic (or press Enter to skip): Linear Regression
-```diff
+```
 
 **Example template content:**
 
@@ -212,7 +212,7 @@ By the end of this lecture, students will be able to:
 
 1. [First objective for {{TOPIC}}]
 2. [Second objective]
-```bash
+```
 
 ---
 
@@ -237,14 +237,14 @@ edit .flow/templates/content/lecture.qmd
 
 # 3. Your version is now used for all new lectures
 teach templates new lecture week-06  # Uses YOUR template
-```bash
+```
 
 **Verify override:**
 
 ```bash
 teach templates list
 # Look for [P] marker indicating project override
-```sql
+```
 
 ---
 
@@ -258,7 +258,7 @@ teach templates sync --dry-run
 
 # Apply updates
 teach templates sync
-```text
+```
 
 **Example output:**
 
@@ -278,13 +278,13 @@ teach templates sync
 │ Skipped (project override):                                 │
 │   assignment.qmd: [P] won't overwrite your customizations   │
 ╰─────────────────────────────────────────────────────────────╯
-```text
+```
 
 **Force sync (overwrite project templates):**
 
 ```bash
 teach templates sync --force
-```bash
+```
 
 ---
 
@@ -298,7 +298,7 @@ teach templates validate
 
 # Validate specific template
 teach templates validate lecture.qmd
-```diff
+```
 
 **What's checked:**
 
@@ -314,7 +314,7 @@ teach templates validate lecture.qmd
 ✓ lab.qmd - Valid
 ✗ slides.qmd - Invalid
     Line 15: Unknown variable {{WEEK_NUM}} (did you mean {{WEEK}}?)
-```bash
+```
 
 ---
 
@@ -325,7 +325,7 @@ When creating a new course:
 ```bash
 # Create course with full template structure
 teach init "STAT 545" --with-templates
-```text
+```
 
 **Creates:**
 
@@ -343,7 +343,7 @@ teach init "STAT 545" --with-templates
 │   │   └── _metadata.yml
 │   └── checklists/
 │       └── pre-publish.md
-```diff
+```
 
 ---
 
@@ -370,7 +370,7 @@ teach init "STAT 545" --with-templates
 teach templates new lecture week-05 --topic "Hypothesis Testing"
 teach templates new lab week-05 --topic "t-tests in R"
 teach templates new slides week-05
-```bash
+```
 
 ### Template Customization Workflow
 
@@ -387,7 +387,7 @@ teach templates validate
 
 # 4. Use
 teach templates new lecture week-06
-```bash
+```
 
 ---
 
@@ -401,7 +401,7 @@ teach templates list
 
 # Check path
 ls .flow/templates/content/
-```bash
+```
 
 ### Variables not substituted
 
@@ -411,7 +411,7 @@ grep '{{' .flow/templates/content/lecture.qmd
 
 # Validate template
 teach templates validate lecture.qmd
-```bash
+```
 
 ### Sync not updating
 

--- a/docs/tutorials/25-lesson-plan-migration.md
+++ b/docs/tutorials/25-lesson-plan-migration.md
@@ -22,7 +22,7 @@ yq --version
 
 # Check you have a teach-config.yml
 ls .flow/teach-config.yml
-```yaml
+```
 
 ---
 
@@ -58,7 +58,7 @@ semester_info:
       title: "Data Types"
       topics: [vectors, dataframes]
     # ... more weeks embedded here
-```yaml
+```
 
 **After (separate file):**
 
@@ -70,7 +70,7 @@ course:
 semester_info:
   semester: "Spring 2026"
   lesson_plans: "lesson-plans.yml"  # Reference to new file
-```yaml
+```
 
 ```yaml
 # .flow/lesson-plans.yml (NEW)
@@ -81,7 +81,7 @@ weeks:
   week-02:
     title: "Data Types"
     topics: [vectors, dataframes]
-```diff
+```
 
 **Why?**
 
@@ -98,7 +98,7 @@ Always preview before migrating:
 
 ```bash
 teach migrate-config --dry-run
-```text
+```
 
 **Example output:**
 
@@ -126,7 +126,7 @@ teach migrate-config --dry-run
 │                                                             │
 │ Run without --dry-run to apply changes                      │
 ╰─────────────────────────────────────────────────────────────╯
-```text
+```
 
 ---
 
@@ -136,7 +136,7 @@ When you're ready:
 
 ```bash
 teach migrate-config
-```text
+```
 
 **What happens:**
 
@@ -166,7 +166,7 @@ teach migrate-config
 │   2. Test: teach week 1                                     │
 │   3. Delete backup when satisfied                           │
 ╰─────────────────────────────────────────────────────────────╯
-```bash
+```
 
 ---
 
@@ -183,7 +183,7 @@ teach week 1
 
 # Check new file exists
 cat .flow/lesson-plans.yml
-```text
+```
 
 ---
 
@@ -193,13 +193,13 @@ cat .flow/lesson-plans.yml
 
 ```bash
 teach migrate-config --force
-```text
+```
 
 ### Skip Backup
 
 ```bash
 teach migrate-config --no-backup
-```bash
+```
 
 ### Preview + Force (careful!)
 
@@ -209,7 +209,7 @@ teach migrate-config --dry-run
 
 # Then apply without prompts
 teach migrate-config --force
-```text
+```
 
 ---
 
@@ -227,7 +227,7 @@ $ teach week 1
 
 Week 1: Introduction to Statistics
 ...
-```bash
+```
 
 **The warning reminds you to migrate** but doesn't block functionality.
 
@@ -246,7 +246,7 @@ cp .flow/teach-config.yml.bak .flow/teach-config.yml
 
 # Remove migrated file
 rm .flow/lesson-plans.yml
-```diff
+```
 
 ---
 
@@ -268,7 +268,7 @@ rm .flow/lesson-plans.yml
 ├── teach-config.yml          # Course metadata + reference
 ├── lesson-plans.yml          # Extracted lesson plans (NEW)
 └── teach-config.yml.bak      # Backup of original
-```bash
+```
 
 ---
 
@@ -284,7 +284,7 @@ ls .flow/lesson-plans.yml
 
 # Check teach-config.yml structure
 cat .flow/teach-config.yml | grep -A5 semester_info
-```bash
+```
 
 ### "yq not found"
 
@@ -292,7 +292,7 @@ Install yq:
 
 ```bash
 brew install yq
-```bash
+```
 
 ### Migration failed
 
@@ -300,7 +300,7 @@ Restore from backup:
 
 ```bash
 cp .flow/teach-config.yml.bak .flow/teach-config.yml
-```bash
+```
 
 ---
 
@@ -312,7 +312,7 @@ After migration, the Scholar plugin reads from `lesson-plans.yml` directly:
 # Scholar commands work with new format
 teach exam "Midterm" --week 1-7
 teach quiz "Week 5" --topic "Distributions"
-```text
+```
 
 ---
 
@@ -334,7 +334,7 @@ $ teach plan list
   15     Review & Synthesis                   conceptual       0
 
   15 week(s) total
-```bash
+```
 
 ### Add a New Week
 
@@ -347,7 +347,7 @@ $ teach plan create 16 --topic "Final Review" --style conceptual
   View:  teach plan show 16
   Edit:  teach plan edit 16
   List:  teach plan list
-```yaml
+```
 
 ### View Week Details
 
@@ -370,7 +370,7 @@ $ teach plan show 1
 
   Edit:   teach plan edit 1
   Delete: teach plan delete 1
-```bash
+```
 
 ### Edit a Week
 
@@ -381,7 +381,7 @@ $ teach plan edit 5
 Week 5 starts at line 42
 # (editor opens lesson-plans.yml at line 42)
 # YAML validated after saving
-```sql
+```
 
 ### Delete a Week
 
@@ -392,7 +392,7 @@ $ teach plan delete 16
   Confirm [y/N]: y
 
   ✓ Deleted Week 16: "Final Review"
-```bash
+```
 
 ### Use Plans with Scholar
 

--- a/docs/tutorials/26-latex-macros.md
+++ b/docs/tutorials/26-latex-macros.md
@@ -23,7 +23,7 @@ flow --version  # Should show 5.21.0+
 
 # Check you're in a course directory
 ls .flow/teach-config.yml
-```diff
+```
 
 ---
 
@@ -61,7 +61,7 @@ flowchart LR
     style Phase1 fill:#2ecc71,color:#fff
     style Phase2 fill:#e67e22,color:#fff
     style Phase3 fill:#e74c3c,color:#fff
-```text
+```
 
 ---
 
@@ -74,14 +74,14 @@ When you use `teach exam` or `teach quiz` to generate content via Scholar, the A
 ```latex
 E[Y] = \mu        % Generic notation
 Var(X) = \sigma^2
-```text
+```
 
 **With macros:**
 
 ```latex
 \E{Y} = \mu       % Your course notation
 \Var{X} = \sigma^2
-```sql
+```
 
 Macro management ensures **consistent notation** across all AI-generated content.
 
@@ -99,7 +99,7 @@ cat > _macros.qmd << 'EOF'
 # Included via: {{< include _macros.qmd >}}
 ---
 
-```{=tex}
+```
 % Operators
 \newcommand{\E}{\mathbb{E}}
 \newcommand{\Var}{\operatorname{Var}}
@@ -122,7 +122,7 @@ cat > _macros.qmd << 'EOF'
 
 EOF
 
-```text
+```
 
 **Alternative: LaTeX format** (`macros.tex`):
 
@@ -131,7 +131,7 @@ EOF
 \newcommand{\E}{\mathbb{E}}
 \newcommand{\Var}{\operatorname{Var}}
 \DeclareMathOperator{\Cov}{Cov}
-```bash
+```
 
 ---
 
@@ -145,7 +145,7 @@ teach macros sync
 
 # Preview without changes
 teach macros sync --dry-run
-```text
+```
 
 **Expected output:**
 
@@ -160,7 +160,7 @@ Found 12 macros:
 
 Updated .flow/macros/registry.yml
 Done in 0.23s
-```bash
+```
 
 ---
 
@@ -171,7 +171,7 @@ View all synced macros:
 ```bash
 # List all macros
 teach macros list
-```text
+```
 
 **Output:**
 
@@ -198,7 +198,7 @@ MATRICES
   \bbeta         → \boldsymbol{\beta}   Bold beta
 
 Source: _macros.qmd (synced just now)
-```bash
+```
 
 **Filter by category:**
 
@@ -208,7 +208,7 @@ teach macros list --category operators
 
 # JSON output
 teach macros list --json
-```bash
+```
 
 ---
 
@@ -227,7 +227,7 @@ teach macros export --format json > .flow/macros.json
 teach macros export --format mathjax  # For web
 teach macros export --format latex    # For .tex files
 teach macros export --format qmd      # For Quarto
-```text
+```
 
 **JSON output example:**
 
@@ -240,7 +240,7 @@ teach macros export --format qmd      # For Quarto
   "source": "_macros.qmd",
   "synced": "2026-01-28T16:30:00Z"
 }
-```yaml
+```
 
 ---
 
@@ -273,7 +273,7 @@ scholar:
     export:
       format: "json"
       include_in_prompts: true  # Include in Scholar context
-```text
+```
 
 **Key settings:**
 
@@ -292,7 +292,7 @@ The `teach doctor --full` command includes macro health checks (macros are a ful
 
 ```bash
 teach doctor --full
-```text
+```
 
 **Macros section output:**
 
@@ -303,7 +303,7 @@ MACROS
   Macro count     ✓ 12 macros defined
   CLAUDE.md       ⚠ Macro section not found
                     Consider adding to CLAUDE.md for AI context
-```bash
+```
 
 ---
 
@@ -318,7 +318,7 @@ When macros are configured, Scholar commands use your notation:
 teach exam "Hypothesis Testing"
 
 # The generated content uses \E{Y} not E[Y]
-```text
+```
 
 ### Include in Quarto Documents
 
@@ -328,7 +328,7 @@ Add to your `.qmd` files:
 {{< include _macros.qmd >}}
 
 The expected value $\E{Y}$ equals...
-```text
+```
 
 ---
 
@@ -356,7 +356,7 @@ The expected value $\E{Y}$ equals...
 % Independence
 \newcommand{\indep}{\perp\!\!\!\perp}
 \newcommand{\iid}{\stackrel{\text{iid}}{\sim}}
-```text
+```
 
 ### Linear Algebra Macros
 

--- a/docs/tutorials/27-lesson-plan-management.md
+++ b/docs/tutorials/27-lesson-plan-management.md
@@ -26,7 +26,7 @@ ls .flow/teach-config.yml
 
 # Check yq is available
 yq --version
-```diff
+```
 
 ---
 
@@ -62,7 +62,7 @@ All plans live in a single centralized file:
 
 ```text
 .flow/lesson-plans.yml
-```text
+```
 
 This is different from the old format where plans were embedded in `teach-config.yml`. If you have an existing config with embedded weeks, see [Tutorial 25: Migration](25-lesson-plan-migration.md) first.
 
@@ -74,7 +74,7 @@ Plans inform Scholar's content generation. When you run:
 teach slides --week 5
 teach lecture --week 5
 teach exam --week 5
-```text
+```
 
 Scholar reads the plan for week 5 to generate more targeted, course-specific content.
 
@@ -86,7 +86,7 @@ Scholar reads the plan for week 5 to generate more targeted, course-specific con
 
 ```bash
 teach plan create 1 --topic "Introduction to Regression" --style conceptual
-```text
+```
 
 You'll be prompted for optional objectives and subtopics:
 
@@ -95,7 +95,7 @@ Objectives (comma-separated, Enter to skip): Define regression, Identify variabl
 Subtopics (comma-separated, Enter to skip): Dependent vs independent, Scatter plots
 
 ✓ Created lesson plan for Week 1: "Introduction to Regression" (conceptual)
-```text
+```
 
 ### Fully Interactive
 
@@ -103,7 +103,7 @@ Just provide the week number:
 
 ```bash
 teach plan create 2
-```text
+```
 
 You'll be prompted for everything:
 
@@ -112,7 +112,7 @@ Topic for Week 2: Multiple Regression
 Style [conceptual/computational/rigorous/applied] (default: conceptual): computational
 Objectives (comma-separated, Enter to skip): Fit multiple regression, Interpret coefficients
 Subtopics (comma-separated, Enter to skip): Matrix formulation, Adjusted R-squared
-```bash
+```
 
 ### Auto-Populate from Config
 
@@ -121,11 +121,11 @@ If your `teach-config.yml` has week topics defined, they're used automatically:
 ```bash
 # Creates week 5 with topic from config — no --topic needed
 teach plan create 5 --style applied
-```text
+```
 
 ```text
 ℹ Auto-populated topic from config: "Polynomial Regression"
-```text
+```
 
 ---
 
@@ -135,7 +135,7 @@ teach plan create 5 --style applied
 
 ```bash
 teach plan list
-```text
+```
 
 ```text
   Week   Topic                               Style           Objectives
@@ -146,7 +146,7 @@ teach plan list
 
   3 week(s) total
   ⚠ Gaps: weeks 3 4
-```text
+```
 
 The gap detection tells you which weeks still need plans.
 
@@ -154,7 +154,7 @@ The gap detection tells you which weeks still need plans.
 
 ```bash
 teach plan list --json
-```text
+```
 
 ```json
 [
@@ -162,7 +162,7 @@ teach plan list --json
   {"number": 2, "topic": "Multiple Regression", "style": "computational", ...},
   {"number": 5, "topic": "Polynomial Regression", "style": "applied", ...}
 ]
-```text
+```
 
 ---
 
@@ -172,7 +172,7 @@ teach plan list --json
 
 ```bash
 teach plan show 1
-```text
+```
 
 ```yaml
 ╔════════════════════════════════════════════════════╗
@@ -191,19 +191,19 @@ teach plan show 1
 
   Edit:   teach plan edit 1
   Delete: teach plan delete 1
-```text
+```
 
 ### Quick View (Shortcut)
 
 ```bash
 teach plan 1    # Same as teach plan show 1
-```text
+```
 
 ### JSON Output
 
 ```bash
 teach plan show 1 --json
-```text
+```
 
 ---
 
@@ -213,24 +213,24 @@ Open a plan in your `$EDITOR` — it jumps directly to the correct line:
 
 ```bash
 teach plan edit 1
-```text
+```
 
 ```text
 ℹ Week 1 starts at line 3
-```text
+```
 
 Your editor opens `lesson-plans.yml` at the right position. After saving, YAML is validated automatically:
 
 ```text
 ✓ YAML validated successfully
-```text
+```
 
 If the YAML is invalid after editing, you get up to 3 retries:
 
 ```text
 ✗ Invalid YAML detected after edit
 Re-open editor to fix? [Y/n]:
-```bash
+```
 
 ---
 
@@ -247,7 +247,7 @@ teach lecture --week 2
 
 # Generate exam — references key concepts
 teach exam --week 5
-```diff
+```
 
 Scholar reads the plan and adjusts its output:
 
@@ -270,14 +270,14 @@ done
 
 # Review the full semester
 teach plan list
-```bash
+```
 
 ### Modify a Plan
 
 ```bash
 # Overwrite an existing week
 teach plan create 5 --topic "Updated Topic" --style rigorous --force
-```bash
+```
 
 ### Remove a Week
 
@@ -287,7 +287,7 @@ teach plan delete 8
 
 # Skip confirmation
 teach plan delete 8 --force
-```text
+```
 
 ### Review Before Content Generation
 

--- a/docs/tutorials/27-lint-quickstart.md
+++ b/docs/tutorials/27-lint-quickstart.md
@@ -33,7 +33,7 @@ title: "Lint Test"
 
 Here's some code:
 
-```text
+```
 
 x <- 1 + 1
 
@@ -50,7 +50,7 @@ This callout is never closed.
 
 Content here.
 EOF
-```text
+```
 
 ---
 
@@ -58,7 +58,7 @@ EOF
 
 ```bash
 teach validate --lint /tmp/test-lint.qmd
-```text
+```
 
 **Expected Output:**
 
@@ -77,7 +77,7 @@ teach validate --lint /tmp/test-lint.qmd
   Files checked: 1
   Validators run: 1
   Time: 0s
-```diff
+```
 
 **What happened?**
 - Detected **4 different error types**
@@ -93,21 +93,21 @@ teach validate --lint /tmp/test-lint.qmd
 **Before:**
 
 ```markdown
-```text
+```
 
 x <- 1 + 1
 
 ```text
-```text
+```
 
 **After:**
 
 ```markdown
-```{r}
+```
 x <- 1 + 1
 ```text
 
-```text
+```
 
 ---
 
@@ -118,7 +118,7 @@ x <- 1 + 1
 ::: {.callout-info}
 This is an invalid callout type.
 :::
-```text
+```
 
 **After:**
 
@@ -126,7 +126,7 @@ This is an invalid callout type.
 ::: {.callout-note}
 This is now a valid callout type.
 :::
-```text
+```
 
 ---
 
@@ -139,7 +139,7 @@ This is now a valid callout type.
 This callout is never closed.
 
 ## Another Section
-```text
+```
 
 **After:**
 
@@ -149,7 +149,7 @@ This callout is now properly closed.
 :::
 
 ## Another Section
-```bash
+```
 
 ---
 
@@ -161,7 +161,7 @@ This callout is now properly closed.
 # Main Section
 
 ### Skipped heading level
-```bash
+```
 
 **After:**
 
@@ -171,7 +171,7 @@ This callout is now properly closed.
 ## Proper heading level
 
 ### Now this is correct
-```text
+```
 
 ---
 
@@ -181,7 +181,7 @@ Run lint again after fixing:
 
 ```bash
 teach validate --lint /tmp/test-lint.qmd
-```text
+```
 
 **Expected Output:**
 
@@ -194,7 +194,7 @@ teach validate --lint /tmp/test-lint.qmd
   Files checked: 1
   Validators run: 1
   Time: 0s
-```bash
+```
 
 **Success!** ✅ All issues resolved.
 
@@ -213,7 +213,7 @@ teach validate --lint slides/*.qmd
 
 # All .qmd files (auto-discover)
 cd slides && teach validate --lint
-```bash
+```
 
 ---
 
@@ -227,7 +227,7 @@ vim slides/week-02.qmd          # Edit file
 teach validate --lint slides/week-02.qmd   # Check for issues
 git add slides/week-02.qmd      # Stage if clean
 git commit -m "Update slides"   # Commit
-```bash
+```
 
 ---
 
@@ -239,7 +239,7 @@ teach validate --lint slides/*.qmd
 
 # Save output to review later
 teach validate --lint slides/*.qmd > lint-report.txt 2>&1
-```text
+```
 
 ---
 
@@ -249,7 +249,7 @@ For faster checking (Phase 1 rules only):
 
 ```bash
 teach validate --quick-checks slides/*.qmd
-```text
+```
 
 ---
 
@@ -258,14 +258,14 @@ teach validate --quick-checks slides/*.qmd
 ### Valid Code Block Tags
 
 ```markdown
-```{r}           # R code (executable)
+```
 ```python       # Python code
-```bash         # Shell commands
+```
 ```text         # Plain text / output
-```sql          # SQL queries
+```
 ```text
 
-```text
+```
 
 ### Valid Callout Types
 
@@ -275,7 +275,7 @@ teach validate --quick-checks slides/*.qmd
 ::: {.callout-important}   # Yellow - key points
 ::: {.callout-warning}     # Orange - caution
 ::: {.callout-caution}     # Red - danger
-```text
+```
 
 ### Heading Hierarchy Rules
 
@@ -285,7 +285,7 @@ teach validate --quick-checks slides/*.qmd
 ✅ ### → # (reset is OK)
 ❌ # → ### (skip is NOT OK)
 ❌ ## → #### (skip is NOT OK)
-```yaml
+```
 
 ---
 
@@ -314,7 +314,7 @@ A: Make sure you're using `--lint` flag:
 ```bash
 teach validate --lint file.qmd  # Correct
 teach validate file.qmd          # Wrong (uses default validation)
-```bash
+```
 
 **Q: "Validator not found" error**
 
@@ -323,7 +323,7 @@ A: Copy validator to your project:
 ```bash
 mkdir -p .teach/validators
 # Copy from your flow-cli installation
-```yaml
+```
 
 **Q: Too slow on large projects**
 

--- a/docs/tutorials/28-teach-prompt.md
+++ b/docs/tutorials/28-teach-prompt.md
@@ -27,7 +27,7 @@ List all prompts across all tiers:
 
 ```bash
 teach prompt list
-```text
+```
 
 Output:
 
@@ -40,7 +40,7 @@ Available Teaching Prompts
   derivations-appendix   [P]  Mathematical Derivations Appendix
 
 Legend: [C] Course  [U] User  [P] Plugin  * = overrides lower tier
-```text
+```
 
 The `[P]` indicator means these come from the plugin defaults. You can customize any of them.
 
@@ -50,7 +50,7 @@ See what a prompt contains:
 
 ```bash
 teach prompt show lecture-notes
-```text
+```
 
 This opens the prompt in your `$PAGER` (usually `less`). You'll see the YAML frontmatter with metadata, followed by the prompt body with `{{VARIABLE}}` placeholders.
 
@@ -58,7 +58,7 @@ For quick output without a pager:
 
 ```bash
 teach prompt show lecture-notes --raw
-```text
+```
 
 ## Step 3: Create a Course Override
 
@@ -66,7 +66,7 @@ The real power is customization. Say you want to modify how lecture notes are ge
 
 ```bash
 teach prompt edit lecture-notes
-```text
+```
 
 This:
 
@@ -79,11 +79,11 @@ After saving, verify the override:
 
 ```bash
 teach prompt list
-```text
+```
 
 ```text
   lecture-notes          [C*] AI prompt for generating comprehensive lecture notes
-```text
+```
 
 The `[C*]` means it's now a **Course** override, and the `*` indicates it shadows the plugin default.
 
@@ -93,7 +93,7 @@ Check that all prompts are syntactically correct:
 
 ```bash
 teach prompt validate
-```text
+```
 
 ```text
 Validating Teaching Prompts...
@@ -103,13 +103,13 @@ Validating Teaching Prompts...
   ✓ derivations-appendix   Valid (plugin default)
 
 3 valid, 0 warnings, 0 errors
-```text
+```
 
 For stricter checking (treats warnings as errors):
 
 ```bash
 teach prompt validate --strict
-```text
+```
 
 ## Step 5: Export Rendered Output
 
@@ -117,7 +117,7 @@ See what a prompt looks like after variable substitution:
 
 ```bash
 teach prompt export lecture-notes
-```text
+```
 
 This reads your `teach-config.yml` for variable values like `{{COURSE}}`, `{{INSTRUCTOR}}`, and `{{SEMESTER}}`, then renders the prompt with those values filled in.
 
@@ -125,13 +125,13 @@ Include LaTeX macros:
 
 ```bash
 teach prompt export lecture-notes --macros
-```text
+```
 
 Export as JSON (useful for debugging Scholar integration):
 
 ```bash
 teach prompt export lecture-notes --json
-```text
+```
 
 ## Step 6: Understand Auto-Resolution
 
@@ -139,7 +139,7 @@ When you run Scholar commands like:
 
 ```bash
 teach lecture "ANOVA"
-```text
+```
 
 The system automatically:
 
@@ -164,7 +164,7 @@ Priority 2: User (~/.flow/prompts/)
 Priority 3: Plugin (lib/templates/teaching/claude-prompts/)
   → Built-in defaults
   → Updated when flow-cli updates
-```diff
+```
 
 First match wins. This means:
 

--- a/docs/tutorials/29-first-exam-walkthrough.md
+++ b/docs/tutorials/29-first-exam-walkthrough.md
@@ -31,7 +31,7 @@ ls .flow/teach-config.yml
 
 # Check your config has required fields
 teach config --view
-```yaml
+```
 
 **Minimum Required Config:**
 
@@ -41,7 +41,7 @@ course:
   full_name: 'Introduction to Statistics'
   semester: 'Fall'
   year: 2026
-```diff
+```
 
 ---
 
@@ -74,7 +74,7 @@ graph TD
     style D fill:#e1ffe1
     style E fill:#ffe1f5
     style F fill:#ffe1e1
-```text
+```
 
 ---
 
@@ -86,7 +86,7 @@ The Scholar plugin is required for all AI content generation:
 
 ```bash
 teach doctor
-```text
+```
 
 **Expected output:**
 
@@ -94,13 +94,13 @@ teach doctor
 ✓ Scholar plugin found
 ✓ teach-config.yml valid
 ✓ Configuration schema valid
-```text
+```
 
 **If Scholar is missing:**
 
 ```text
 ❌ Error: Scholar plugin not available
-```text
+```
 
 **Solution:** Install the Scholar plugin from the Claude Code plugin marketplace. See [Troubleshooting](#scholar-plugin-not-found) for details.
 
@@ -110,7 +110,7 @@ Check that your `teach-config.yml` has the required fields:
 
 ```bash
 teach config --view
-```yaml
+```
 
 **Required fields for exam generation:**
 
@@ -120,7 +120,7 @@ course:
   full_name: 'Introduction...'  # Full course title
   semester: 'Fall'              # Current semester
   year: 2026                    # Academic year
-```yaml
+```
 
 **Optional fields (enhance output):**
 
@@ -134,7 +134,7 @@ scholar:
     sources:
       - path: "_macros.qmd"
         format: "qmd"
-```text
+```
 
 ---
 
@@ -146,7 +146,7 @@ Let's create a basic 5-question exam on hypothesis testing:
 
 ```bash
 teach exam "Hypothesis Testing"
-```text
+```
 
 **What happens:**
 
@@ -170,7 +170,7 @@ teach exam "Hypothesis Testing"
   • 5 questions (default)
   • Mixed format (multiple choice, short answer, problems)
   • Estimated duration: 60 minutes
-```bash
+```
 
 ### Step 2.2: View Generated Content
 
@@ -182,7 +182,7 @@ $EDITOR exams/exam-hypothesis-testing-2026-02-02.qmd
 
 # Or preview with Quarto
 quarto preview exams/
-```diff
+```
 
 **File structure:**
 
@@ -214,7 +214,7 @@ format: pdf
 # Section 3: Problems (30 points)
 
 3. A researcher tests whether the mean exam score differs from 75...
-```text
+```
 
 ### Step 2.3: Customize with Options
 
@@ -225,7 +225,7 @@ teach exam "Hypothesis Testing" \
   --questions 10 \
   --duration 90 \
   --types "mc:4,sa:3,problem:3"
-```diff
+```
 
 **Flag breakdown:**
 
@@ -240,7 +240,7 @@ teach exam "Hypothesis Testing" \
   • 10 questions
   • Duration: 90 minutes
   • Question breakdown: 4 MC, 3 SA, 3 Problems
-```bash
+```
 
 ---
 
@@ -264,7 +264,7 @@ Use style presets to control the depth and approach:
 ```bash
 # Rigorous math-heavy exam
 teach exam "Probability" --style rigorous --questions 8
-```bash
+```
 
 ### Step 3.2: Content Toggle Flags
 
@@ -278,7 +278,7 @@ teach exam "Probability" --math --proof --examples
 
 # Computational exam with code problems
 teach exam "Linear Regression" --code --practice-problems --diagrams
-```bash
+```
 
 **Remove Content:**
 
@@ -288,7 +288,7 @@ teach exam "Regression" --style rigorous --no-proof
 
 # Computational style WITHOUT code
 teach exam "ANOVA" --style computational --no-code
-```bash
+```
 
 **Available Flags:**
 
@@ -311,7 +311,7 @@ teach exam "Hypothesis Testing" --week 4
 
 # Exam covering weeks 1-4
 teach exam "Midterm 1" --week 4 --questions 20
-```yaml
+```
 
 **What happens:**
 
@@ -335,7 +335,7 @@ weeks:
     subtopics:
       - "Type I and II errors"
       - "One-sample and two-sample tests"
-```text
+```
 
 Scholar uses this to generate questions targeting these specific objectives.
 
@@ -349,7 +349,7 @@ Quizzes are shorter, formative assessments:
 
 ```bash
 teach quiz "Descriptive Statistics"
-```sql
+```
 
 **Differences from exams:**
 
@@ -367,7 +367,7 @@ Create a quick 10-minute check quiz:
 
 ```bash
 teach quiz "Correlation" --questions 5 --time-limit 10
-```diff
+```
 
 **Output:**
 
@@ -387,7 +387,7 @@ format: html
    d) No relationship
 
    **Answer:** b)
-```text
+```
 
 ### Step 4.3: Quiz with Explanations
 
@@ -395,7 +395,7 @@ Generate a quiz with answer explanations for self-study:
 
 ```bash
 teach quiz "Regression Basics" --questions 8 --explanation
-```text
+```
 
 **Each question includes:**
 
@@ -411,7 +411,7 @@ teach quiz "Regression Basics" --questions 8 --explanation
    **Explanation:** The slope coefficient (β₁) represents the expected
    change in the response variable (Y) for each one-unit increase in the
    predictor variable (X), holding all else constant.
-```text
+```
 
 ---
 
@@ -425,25 +425,25 @@ Generated files are automatically staged for git:
 
 ```bash
 teach exam "Topic"
-```text
+```
 
 **Output:**
 
 ```text
 ✓ Created: exams/exam-topic-2026-02-02.qmd
   ✓ Staged: exams/exam-topic-2026-02-02.qmd
-```bash
+```
 
 **What was staged:**
 
 ```bash
 git status
-```text
+```
 
 ```text
 Changes to be committed:
   new file:   exams/exam-topic-2026-02-02.qmd
-```bash
+```
 
 ### Step 5.2: Commit Menu (Interactive)
 
@@ -467,7 +467,7 @@ quarto preview exams/
 
 # Commit when satisfied
 git commit -m "Add exam: Hypothesis Testing"
-```bash
+```
 
 ### Step 5.3: .STATUS File Updates
 
@@ -475,7 +475,7 @@ If your course has a `.STATUS` file, it's automatically updated:
 
 ```bash
 cat .STATUS
-```text
+```
 
 ```text
 status: Active
@@ -485,7 +485,7 @@ last_updated: 2026-02-02
 recent_activity:
   - "Generated exam: Hypothesis Testing"
   - "Generated lecture: ANOVA"
-```bash
+```
 
 ---
 
@@ -516,7 +516,7 @@ quarto preview rubrics/
 
 # 5. Commit when satisfied
 git commit -m "Add midterm exam and rubric"
-```bash
+```
 
 ### Workflow 2: Weekly Quiz Routine
 
@@ -534,7 +534,7 @@ quarto preview quizzes/
 
 # Deploy to course website
 teach deploy
-```sql
+```
 
 ### Workflow 3: Practice Exam with Explanations
 
@@ -549,7 +549,7 @@ teach exam "Practice Exam: Regression" \
   --examples
 
 # Generates exam with detailed answer explanations
-```text
+```
 
 ---
 
@@ -561,7 +561,7 @@ teach exam "Practice Exam: Regression" \
 
 ```text
 ❌ Error: Scholar plugin not available
-```bash
+```
 
 **Solution:**
 
@@ -569,7 +569,7 @@ teach exam "Practice Exam: Regression" \
 
 ```bash
 claude plugins list | grep scholar
-```text
+```
 
 1. If missing, install from Claude Code plugin marketplace:
 
@@ -582,7 +582,7 @@ claude plugins list | grep scholar
 
 ```bash
 teach doctor
-```text
+```
 
 ### Missing Configuration Fields
 
@@ -590,7 +590,7 @@ teach doctor
 
 ```text
 ❌ Error: Required field 'course.name' not found in teach-config.yml
-```yaml
+```
 
 **Solution:**
 
@@ -607,7 +607,7 @@ course:
 
 # Validate
 teach doctor
-```text
+```
 
 ### Empty or Incomplete Output
 
@@ -616,7 +616,7 @@ teach doctor
 ```text
 ✓ Generation complete
 ✓ File created: exams/exam-topic.qmd
-```bash
+```
 
 But the file is empty or contains only frontmatter.
 
@@ -640,7 +640,7 @@ teach exam "Topic" --verbose
 
 # 4. Check Scholar plugin logs
 # (See Scholar documentation for log location)
-```text
+```
 
 ### Conflicting Flags Error
 
@@ -648,7 +648,7 @@ teach exam "Topic" --verbose
 
 ```text
 ❌ Error: Conflicting flags: --math and --no-math
-```bash
+```
 
 **Solution:**
 
@@ -662,7 +662,7 @@ teach exam "Topic" --math --no-math
 teach exam "Topic" --math
 # OR
 teach exam "Topic" --no-math
-```yaml
+```
 
 ### LaTeX Macros Not Rendering
 
@@ -690,7 +690,7 @@ scholar:
 
 # 4. Regenerate content
 teach exam "Topic" --math
-```text
+```
 
 ### File Already Exists
 
@@ -698,7 +698,7 @@ teach exam "Topic" --math
 
 ```text
 ⚠️  File exists: exams/exam-topic-2026-02-02.qmd
-```text
+```
 
 **Auto-backup:**
 
@@ -707,13 +707,13 @@ flow-cli automatically backs up existing files:
 ```text
 ✓ Backed up: exams/exam-topic-2026-02-02.qmd → exams/exam-topic-2026-02-02.qmd.bak
 ✓ Created: exams/exam-topic-2026-02-02.qmd
-```bash
+```
 
 **Restore backup:**
 
 ```bash
 mv exams/exam-topic-2026-02-02.qmd.bak exams/exam-topic-2026-02-02.qmd
-```text
+```
 
 ---
 
@@ -725,12 +725,12 @@ mv exams/exam-topic-2026-02-02.qmd.bak exams/exam-topic-2026-02-02.qmd
 
 ```bash
 teach exam "Topic" --week 5
-```text
+```
 
 ```text
 ⚠️  No lesson plan found for week 5
 Continuing with topic only...
-```text
+```
 
 **Not an error**, but generation will be less targeted.
 
@@ -738,7 +738,7 @@ Continuing with topic only...
 
 ```bash
 teach plan create 5 --topic "Linear Regression" --style computational
-```bash
+```
 
 ### Mistake 2: Using --interactive Without Input
 
@@ -747,13 +747,13 @@ teach plan create 5 --topic "Linear Regression" --style computational
 ```bash
 teach exam --interactive
 # Hangs waiting for input
-```text
+```
 
 **Solution:** Follow the wizard prompts or provide a topic:
 
 ```bash
 teach exam "Topic" --interactive
-```bash
+```
 
 ### Mistake 3: Forgetting to Commit
 
@@ -764,19 +764,19 @@ Files are staged but never committed:
 ```bash
 git status
 # Shows: Changes to be committed
-```bash
+```
 
 **Solution:** Commit after reviewing:
 
 ```bash
 git commit -m "Add exam: Hypothesis Testing"
-```bash
+```
 
 Or unstage if not ready:
 
 ```bash
 git reset HEAD exams/exam-*.qmd
-```diff
+```
 
 ---
 

--- a/docs/tutorials/30-new-instructor-complete-workflow.md
+++ b/docs/tutorials/30-new-instructor-complete-workflow.md
@@ -28,7 +28,7 @@ quarto --version
 
 # Check git
 git config user.name
-```diff
+```
 
 ---
 
@@ -68,7 +68,7 @@ graph LR
     style F fill:#0366d6,color:#fff
     style G fill:#0366d6,color:#fff
     style H fill:#28a745,color:#fff
-```bash
+```
 
 ---
 
@@ -80,14 +80,14 @@ graph LR
 # Create a new directory for your course
 mkdir stat-201-spring-2026
 cd stat-201-spring-2026
-```bash
+```
 
 ### Step 1.2: Initialize Teaching Project
 
 ```bash
 # Initialize with interactive setup
 teach init "STAT-201"
-```diff
+```
 
 **What this does:**
 - Creates `.flow/teach-config.yml` with default settings
@@ -111,7 +111,7 @@ teach init "STAT-201"
     1. Review config: teach config
     2. Check environment: teach doctor
     3. Generate content: teach exam "Topic"
-```text
+```
 
 ### Step 1.3: Initialize with Templates (Optional)
 
@@ -119,7 +119,7 @@ If you prefer working with content templates:
 
 ```bash
 teach init "STAT-201" --with-templates
-```diff
+```
 
 This adds:
 - `.flow/templates/content/` - Content starters (lecture, lab, slides)
@@ -135,7 +135,7 @@ ls -la .flow/teach-config.yml
 
 # Should show: .flow/teach-config.yml exists
 # If not, run: teach init again
-```bash
+```
 
 **Expected result:** `.flow/teach-config.yml` file exists
 
@@ -148,7 +148,7 @@ ls -la .flow/teach-config.yml
 ```bash
 # Open config in your default editor
 teach config
-```sql
+```
 
 This opens `.flow/teach-config.yml` in your `$EDITOR` (defaults to `code` if not set).
 
@@ -192,7 +192,7 @@ backups:
     syllabi: archive         # Keep syllabus backups forever
     lectures: semester       # Delete lecture backups at semester end
   archive_dir: .flow/archives
-```yaml
+```
 
 ### Step 2.3: Add Scholar Settings (If Using AI)
 
@@ -206,7 +206,7 @@ scholar:
       - path: "_macros.qmd"
         format: "qmd"
     auto_discover: false
-```yaml
+```
 
 ### Step 2.4: Add Semester Calendar
 
@@ -217,7 +217,7 @@ semester_info:
   start_date: '2026-01-15'
   end_date: '2026-05-10'
   break_weeks: [9]  # Spring break
-```bash
+```
 
 ### ✅ Verification: Checkpoint 2
 
@@ -227,7 +227,7 @@ teach doctor
 
 # Expected output: All checks should be green
 # If errors, fix them: teach doctor --fix
-```text
+```
 
 **Expected result:**
 
@@ -247,7 +247,7 @@ Git Setup:
 Dependencies:
   ✓ Quarto installed (v1.4.550)
   ✓ yq installed (v4.35.1)
-```bash
+```
 
 ---
 
@@ -260,7 +260,7 @@ Lesson plans define your weekly topics and serve as the source of truth for AI c
 ```bash
 # Create week 1 with conceptual style
 teach plan create 1 --topic "Introduction to Statistics" --style conceptual
-```diff
+```
 
 **What this does:**
 - Creates `.flow/lesson-plans.yml` (if it doesn't exist)
@@ -277,7 +277,7 @@ teach plan create 1 --topic "Introduction to Statistics" --style conceptual
   Date: 2026-01-15 (auto-calculated from start_date)
 
   View: teach plan show 1
-```bash
+```
 
 ### Step 3.2: Create Multiple Weeks
 
@@ -290,7 +290,7 @@ teach plan create 3 --topic "Hypothesis Testing" --style rigorous
 
 # Week 4 - Applied style (real-world applications)
 teach plan create 4 --topic "Simple Linear Regression" --style applied
-```bash
+```
 
 ### Step 3.3: Understanding Styles
 
@@ -306,7 +306,7 @@ teach plan create 4 --topic "Simple Linear Regression" --style applied
 ```bash
 # List all weeks in a table
 teach plan list
-```text
+```
 
 **Output:**
 
@@ -319,7 +319,7 @@ Week | Topic                        | Style         | Date       | Status
 4    | Simple Linear Regression    | applied       | 2026-02-05 | ✓
 
 4 weeks defined, 0 gaps detected
-```bash
+```
 
 ### Step 3.5: View Week Details
 
@@ -329,7 +329,7 @@ teach plan show 1
 
 # Shortcut
 teach plan 1
-```bash
+```
 
 ### ✅ Verification: Checkpoint 3
 
@@ -341,7 +341,7 @@ cat .flow/lesson-plans.yml
 teach plan list
 
 # Expected: 4 weeks defined with no gaps
-```bash
+```
 
 **Expected result:** `.flow/lesson-plans.yml` exists with 4 week entries
 
@@ -360,14 +360,14 @@ If you initialized with `--with-templates`:
 teach templates new lecture week-01 --topic "Introduction"
 
 # This creates: lectures/week-01.qmd with boilerplate
-```bash
+```
 
 Then edit `lectures/week-01.qmd` in your editor:
 
 ```bash
 # Open for editing
 code lectures/week-01.qmd
-```bash
+```
 
 ### Option B: AI-Assisted Generation with Scholar
 
@@ -379,7 +379,7 @@ teach lecture 1
 
 # Or specify custom topic
 teach lecture 1 --topic "Getting Started with Statistics"
-```diff
+```
 
 **What this does:**
 - Reads lesson plan for week 1
@@ -406,7 +406,7 @@ Include sections:
 Generating... (this takes 1-2 minutes)
 
 ✅ Created: lectures/week-01.qmd
-```bash
+```
 
 ### Step 4.3: Create Additional Content Types
 
@@ -419,7 +419,7 @@ teach assignment 1 --topic "Descriptive Statistics Lab"
 
 # Generate quiz
 teach quiz 1 --questions 10
-```bash
+```
 
 ### ✅ Verification: Checkpoint 4
 
@@ -431,7 +431,7 @@ ls -la lectures/week-01.qmd
 head -n 20 lectures/week-01.qmd
 
 # Expected: Valid Quarto document with YAML header
-```bash
+```
 
 **Expected result:** `lectures/week-01.qmd` exists with proper YAML frontmatter
 
@@ -447,7 +447,7 @@ teach templates list
 
 # Filter by type
 teach templates list --type content
-```text
+```
 
 **Output:**
 
@@ -466,7 +466,7 @@ Prompt Templates (.flow/templates/prompts/):
   - quiz-prompt.md     (Quiz generation)
 
 Total: 7 templates (4 content, 3 prompts)
-```bash
+```
 
 ### Step 5.2: Create from Template
 
@@ -479,7 +479,7 @@ teach templates new lecture week-02 --topic "Probability"
 #   - {{TOPIC}} replaced with "Probability"
 #   - {{COURSE}} replaced with "STAT-201"
 #   - {{DATE}} auto-calculated
-```bash
+```
 
 ### Step 5.3: Set Up LaTeX Macros (If Using Math)
 
@@ -498,7 +498,7 @@ teach macros list
 # Category: distributions
 #   \Normal     - Normal distribution
 #   \Binom      - Binomial distribution
-```sql
+```
 
 Create `_macros.qmd` in your project root:
 
@@ -513,14 +513,14 @@ $$
 \newcommand{\Cov}[2]{\text{Cov}\left(#1, #2\right)}
 \newcommand{\Normal}{\mathcal{N}}
 $$
-```bash
+```
 
 Then sync macros to your config:
 
 ```bash
 # Update teach-config.yml with macro sources
 teach macros sync
-```bash
+```
 
 ### ✅ Verification: Checkpoint 5
 
@@ -532,7 +532,7 @@ teach templates validate
 teach macros list
 
 # Expected: No validation errors
-```bash
+```
 
 ---
 
@@ -548,7 +548,7 @@ teach deploy --preview
 
 # Or use Quarto directly
 quarto preview
-```diff
+```
 
 **What happens:**
 - Quarto starts a local web server
@@ -564,7 +564,7 @@ teach validate lectures/*.qmd
 
 # Validate specific file
 teach validate lectures/week-01.qmd
-```diff
+```
 
 **Validation checks:**
 - YAML frontmatter is valid
@@ -588,7 +588,7 @@ main branch (production/live site)
     │
     ▼
 GitHub Pages (students see this)
-```diff
+```
 
 **Benefits:**
 - Test changes on `draft` before going live
@@ -602,7 +602,7 @@ First time only - create GitHub repository:
 ```bash
 # Create GitHub repo and push (requires gh CLI)
 gh repo create stat-201-spring-2026 --public --source=. --push
-```bash
+```
 
 Enable GitHub Pages:
 1. Go to your repo on GitHub
@@ -616,7 +616,7 @@ Enable GitHub Pages:
 ```bash
 # Deploy to production (creates PR from draft → main)
 teach deploy
-```text
+```
 
 **What this does:**
 1. Validates you're on `draft` branch
@@ -656,7 +656,7 @@ Pushing to GitHub:
 
 ✅ Deployed! Site will be live in ~2 minutes
    https://yourusername.github.io/stat-201-spring-2026
-```bash
+```
 
 ### Step 6.6: Partial Deployment (Advanced)
 
@@ -671,7 +671,7 @@ teach deploy lectures/
 
 # Deploy with flags
 teach deploy lectures/week-01.qmd --skip-index --auto-commit
-```bash
+```
 
 ### ✅ Verification: Checkpoint 6
 
@@ -684,7 +684,7 @@ git branch -a
 # Check GitHub Pages
 # Visit: https://yourusername.github.io/stat-201-spring-2026
 # Expected: Your course website is live!
-```diff
+```
 
 **Success indicators:**
 - ✅ PR created and merged on GitHub
@@ -713,7 +713,7 @@ teach deploy
 
 # 4. Check it's live
 open https://yourusername.github.io/stat-201-spring-2026
-```bash
+```
 
 ### 2. Generate Assessments
 
@@ -726,7 +726,7 @@ teach quiz 3 --questions 10
 
 # Create homework assignment
 teach assignment 3 --topic "Regression Analysis"
-```bash
+```
 
 ### 3. Use Scholar AI Integration
 
@@ -737,7 +737,7 @@ If you have Claude Code + Scholar:
 teach lecture 5 --style rigorous
 teach slides 5 --format "revealjs"
 teach exam "Final Exam" --questions 50 --difficulty hard
-```bash
+```
 
 ### 4. Archive at Semester End
 
@@ -750,7 +750,7 @@ teach archive --semester "Spring 2026"
 #   - All assessments
 #   - Lesson plans
 #   - Configuration snapshot
-```sql
+```
 
 ### 5. Set Up Weekly Routine
 
@@ -761,7 +761,7 @@ Create an alias in your `.zshrc`:
 alias teach-week='teach lecture $1 && teach slides $1 && teach deploy --preview'
 
 # Usage: teach-week 5
-```bash
+```
 
 ---
 
@@ -781,7 +781,7 @@ teach doctor --verbose
 # - Missing yq: brew install yq
 # - Invalid YAML: teach config (fix syntax)
 # - Missing branches: git branch draft
-```bash
+```
 
 ### "deploy fails with 'not in git repository'"
 
@@ -795,7 +795,7 @@ git init
 git add .
 git commit -m "Initial commit"
 git branch draft
-```bash
+```
 
 ### "Scholar not found"
 
@@ -809,7 +809,7 @@ git branch draft
 
 # Alternative: Use manual content creation
 teach templates new lecture week-01
-```bash
+```
 
 ### "GitHub Pages shows 404"
 
@@ -834,7 +834,7 @@ teach config
 
 # Option 2: Manually merge PR
 gh pr merge --merge
-```bash
+```
 
 ### "LaTeX macros not working in Scholar output"
 
@@ -852,7 +852,7 @@ teach macros sync
 
 # Verify Scholar can see them
 teach macros export --format json
-```diff
+```
 
 ---
 

--- a/docs/tutorials/31-teach-deploy-v2.md
+++ b/docs/tutorials/31-teach-deploy-v2.md
@@ -34,7 +34,7 @@ The traditional PR workflow takes 45-90 seconds:
 ```bash
 # The old way (slow)
 teach deploy
-```bash
+```
 
 This creates a PR, waits for GitHub checks, merges, and deploys. For quick updates, this is overkill.
 
@@ -43,7 +43,7 @@ Try the new direct deploy:
 ```bash
 # The new way (fast - 8-15 seconds)
 teach deploy --direct
-```text
+```
 
 Expected output:
 
@@ -72,7 +72,7 @@ Expected output:
 │  🌐 URL:      https://example.github.io/stat-101/    │
 │  ⚙  Actions:  https://github.com/user/stat-101/actions│
 ╰──────────────────────────────────────────────────────╯
-```bash
+```
 
 Use `-d` as a shortcut for `--direct`.
 
@@ -86,7 +86,7 @@ Edit a lecture file:
 # After editing lectures/week-05.qmd
 teach deploy -d
 # → "content: week-05 lecture"
-```bash
+```
 
 Edit a config file:
 
@@ -94,7 +94,7 @@ Edit a config file:
 # After editing _quarto.yml
 teach deploy -d
 # → "config: quarto settings"
-```bash
+```
 
 Edit multiple files:
 
@@ -102,14 +102,14 @@ Edit multiple files:
 # After editing 3 different files
 teach deploy -d
 # → "deploy: 3 file updates"
-```bash
+```
 
 Override with a custom message:
 
 ```bash
 teach deploy -d -m "Fix typo in regression notes"
 # → Uses your custom message
-```text
+```
 
 ## Step 3: Preview with Dry-Run
 
@@ -117,7 +117,7 @@ Always preview before deploying to production:
 
 ```bash
 teach deploy --dry-run --direct
-```text
+```
 
 Expected output:
 
@@ -137,7 +137,7 @@ Would execute:
   3. Trigger GitHub Pages
 
 🔹 No changes made (dry-run mode)
-```text
+```
 
 This shows exactly what would happen without actually deploying.
 
@@ -147,7 +147,7 @@ View your past deployments:
 
 ```bash
 teach deploy --history
-```text
+```
 
 Output:
 
@@ -163,19 +163,19 @@ Recent Deployments
   4  2026-02-02 09:00    d8b2c33     Weekly content update       12   pr
 
 Recent: 4 deploys (3 direct, 1 PR) | Avg time: 11s
-```text
+```
 
 Limit results:
 
 ```bash
 teach deploy --history --limit 10
-```text
+```
 
 View specific deployment:
 
 ```bash
 teach deploy --history --show 1
-```text
+```
 
 The history is stored in `.flow/deploy-history.yml`.
 
@@ -185,7 +185,7 @@ Made a mistake? Roll back to the previous state:
 
 ```bash
 teach deploy --rollback 1
-```text
+```
 
 This performs a **forward rollback** using `git revert`:
 
@@ -203,7 +203,7 @@ Creating revert commit...
 [✓] Rollback recorded in history
 
 🎉 Rollback complete
-```diff
+```
 
 Safety guarantees:
 
@@ -216,7 +216,7 @@ Roll back an older deployment:
 ```bash
 teach deploy --rollback 3
 # Reverts deployment #3 from history (use --history to see index)
-```text
+```
 
 ## Step 6: CI Mode for Automation
 
@@ -224,7 +224,7 @@ Run deployments in scripts or CI without interactive prompts:
 
 ```bash
 teach deploy --ci -d -m "Automated weekly deploy"
-```diff
+```
 
 The `--ci` flag:
 
@@ -237,7 +237,7 @@ Example GitHub Actions workflow:
 ```yaml
 - name: Deploy course website
   run: teach deploy --ci -d -m "Automated deploy from CI"
-```bash
+```
 
 ## Step 7: Combining Flags
 
@@ -248,28 +248,28 @@ Quick deploy with automatic tagging:
 ```bash
 teach deploy -d --auto-tag
 # Deploys and creates a git tag (v1.2.0, v1.2.1, etc.)
-```bash
+```
 
 CI direct deploy with custom message:
 
 ```bash
 teach deploy --ci -d -m "Weekly content update"
 # Non-interactive, direct, custom message
-```bash
+```
 
 Preview partial deploy:
 
 ```bash
 teach deploy --dry-run lectures/week-05.qmd
 # Preview deploying just one file
-```bash
+```
 
 Safe production deploy:
 
 ```bash
 teach deploy --dry-run -d && teach deploy -d
 # Preview first, then deploy
-```text
+```
 
 ## Step 8: Understanding Deploy Modes
 
@@ -279,7 +279,7 @@ Deploy v2 supports two modes:
 
 ```bash
 teach deploy --direct
-```diff
+```
 
 - ✅ No PR created
 - ✅ Direct push to production branch
@@ -290,7 +290,7 @@ teach deploy --direct
 
 ```bash
 teach deploy
-```diff
+```
 
 - ✅ Creates PR for review
 - ✅ Runs GitHub checks
@@ -316,7 +316,7 @@ No need to commit manually first. If you have unsaved work:
 # Edit a file, then deploy without committing
 vim lectures/week-05.qmd
 teach deploy -d
-```text
+```
 
 Deploy detects the dirty tree and prompts:
 
@@ -325,7 +325,7 @@ Deploy detects the dirty tree and prompts:
   Suggested: content: week-05 lecture
 
   Commit and continue? [Y/n]:
-```text
+```
 
 Press Enter to auto-commit and deploy in one step.
 
@@ -342,7 +342,7 @@ If your Quarto pre-commit hook fails during the auto-commit:
     3. Force: git commit --no-verify -m "message"
 
   Changes are still staged.
-```diff
+```
 
 Option 2 is useful for urgent deploys when you know the content is correct.
 

--- a/docs/tutorials/32-teach-doctor.md
+++ b/docs/tutorials/32-teach-doctor.md
@@ -25,7 +25,7 @@ The default `teach doctor` runs a **quick check** targeting < 3 seconds:
 
 ```bash
 teach doctor
-```text
+```
 
 **Output:**
 
@@ -63,7 +63,7 @@ Git Setup:
 ────────────────────────────────────────────────────────────
 Passed: 17  [0s]
 ────────────────────────────────────────────────────────────
-```text
+```
 
 **Quick mode checks 4 categories:**
 
@@ -82,7 +82,7 @@ Add `--full` to run all 11 check categories:
 
 ```bash
 teach doctor --full
-```text
+```
 
 This adds 7 more categories with a spinner for slower checks:
 
@@ -121,7 +121,7 @@ Warnings: 3 | Passed: 28  [5s]
 
   Run teach doctor --fix to auto-fix issues
 ────────────────────────────────────────────────────────────
-```text
+```
 
 ---
 
@@ -131,7 +131,7 @@ Use `--fix` to interactively resolve issues:
 
 ```bash
 teach doctor --fix
-```text
+```
 
 This implies `--full` and prompts for each fixable issue:
 
@@ -146,7 +146,7 @@ R Packages:
   ⚠ 3/5 R packages installed | Missing: tidyr, knitr
     Install via renv or system? [r/s]: r
     → renv::install(c("tidyr", "knitr"))
-```diff
+```
 
 **What `--fix` can resolve:**
 
@@ -165,7 +165,7 @@ Show only warnings and failures:
 
 ```bash
 teach doctor --brief
-```text
+```
 
 ```text
   ⚠ Config validation failed
@@ -175,7 +175,7 @@ teach doctor --brief
 ────────────────────────────────────────────────────────────
 Warnings: 2  [0s]
 ────────────────────────────────────────────────────────────
-```text
+```
 
 ### Verbose Mode
 
@@ -183,7 +183,7 @@ Show expanded detail for every check (implies `--full`):
 
 ```bash
 teach doctor --verbose
-```diff
+```
 
 Verbose adds:
 
@@ -197,7 +197,7 @@ Machine-readable output for scripting:
 
 ```bash
 teach doctor --json --full | jq '.summary'
-```text
+```
 
 ```json
 {
@@ -206,7 +206,7 @@ teach doctor --json --full | jq '.summary'
   "failures": 0,
   "status": "yellow"
 }
-```text
+```
 
 ### CI Mode
 
@@ -214,7 +214,7 @@ No colors, machine-readable key=value, exits with code 1 on failure:
 
 ```bash
 teach doctor --ci --full
-```text
+```
 
 ```text
 doctor:status=pass
@@ -223,7 +223,7 @@ doctor:warnings=3
 doctor:failures=0
 doctor:mode=full
 doctor:elapsed=5s
-```diff
+```
 
 ---
 
@@ -247,7 +247,7 @@ Run `teach doctor` to refresh the dot.
 
 ```bash
 teach doctor --brief
-```bash
+```
 
 ### Pre-Deploy Full Audit
 
@@ -256,7 +256,7 @@ teach doctor --full
 # Fix any issues before deploying
 teach doctor --fix
 teach deploy --direct
-```bash
+```
 
 ### CI/CD Pipeline
 
@@ -264,7 +264,7 @@ teach deploy --direct
 # GitHub Actions example
 - name: Health check
   run: teach doctor --ci --full || exit 1
-```bash
+```
 
 Or with JSON parsing:
 
@@ -274,14 +274,14 @@ if [ "$status" = "red" ]; then
   echo "Health check failed"
   exit 1
 fi
-```text
+```
 
 ### First-Time Setup
 
 ```bash
 teach init
 teach doctor --fix
-```bash
+```
 
 ### Debugging Issues
 

--- a/docs/tutorials/33-himalaya-email.md
+++ b/docs/tutorials/33-himalaya-email.md
@@ -45,7 +45,7 @@ Press `<leader>mr` on any email. You'll be prompted:
 
 ```text
 Reply instructions (Enter=default):
-```text
+```
 
 Type your instruction (e.g., "accept but suggest next Thursday instead") and press Enter. The AI generates a reply shaped by your instruction.
 
@@ -84,7 +84,7 @@ Press `<leader>mw` anywhere. You'll be prompted:
 
 ```text
 What to write about:
-```diff
+```
 
 Type your topic (e.g., "reschedule tomorrow's meeting to Friday 2pm") and the AI generates a full email.
 
@@ -107,7 +107,7 @@ Change settings at runtime:
 :HimalayaAi set backend gemini
 :HimalayaAi set result_display tab
 :HimalayaAi set todo_target obsidian
-```text
+```
 
 ## Architecture Overview
 
@@ -119,7 +119,7 @@ himalaya CLI (Rust)           Email protocol (IMAP/SMTP)
 himalaya-vim (VimScript)      Buffer management, keybinds, job control
     |
 himalaya-ai.lua (Lua)         AI actions, result display, chaining
-```text
+```
 
 ### himalaya-ai.lua Module Structure
 

--- a/docs/tutorials/35-em-cli-email.md
+++ b/docs/tutorials/35-em-cli-email.md
@@ -31,7 +31,7 @@ Run `em` with no arguments for an instant summary of what's waiting:
 
 ```zsh
 em
-```text
+```
 
 This shows your unread count and the 10 latest messages — a pulse check before diving in.
 
@@ -39,7 +39,7 @@ The same view is available as a named subcommand:
 
 ```zsh
 em dash
-```text
+```
 
 **Tip:** Put `em` at the top of a morning workflow alias to start every session with inbox awareness.
 
@@ -51,13 +51,13 @@ Read any email by ID:
 
 ```zsh
 em read 42
-```text
+```
 
 Shortcut: a bare number works without the `read` keyword:
 
 ```zsh
 em 42
-```text
+```
 
 **Rendering options** — choose the format that works best for the message:
 
@@ -65,7 +65,7 @@ em 42
 em read --html 42     # Render HTML in w3m or lynx
 em read --md 42       # Convert to Markdown via pandoc
 em read --raw 42      # Show raw MIME source
-```text
+```
 
 | Flag | Renderer | Best For |
 |------|----------|----------|
@@ -86,19 +86,19 @@ List recent messages:
 em inbox          # Default page size (25)
 em inbox 50       # Show 50 messages
 em -n 5           # Shortcut: same as em inbox 5
-```text
+```
 
 Check only the unread count:
 
 ```zsh
 em unread
-```text
+```
 
 See all available mail folders:
 
 ```zsh
 em folders
-```text
+```
 
 **How pagination works:** `em inbox N` fetches the N most recent messages from your default folder. Increase N to look further back. The default page size is controlled by `FLOW_EMAIL_PAGE_SIZE` (see Configuration below).
 
@@ -110,14 +110,14 @@ Search by keyword across your mailbox:
 
 ```zsh
 em find "quarterly report"
-```text
+```
 
 For interactive browsing with a live preview pane, use `pick`:
 
 ```zsh
 em pick              # Browse default folder (INBOX)
 em pick Archive      # Browse a specific folder
-```text
+```
 
 `em pick` opens fzf with a preview of each message. Navigate with arrow keys, press Enter to open the selected email in full, or press Escape to cancel.
 
@@ -131,7 +131,7 @@ Open `$EDITOR` to write a new email:
 
 ```zsh
 em send
-```text
+```
 
 Reply to an existing email with an AI-generated draft:
 
@@ -140,13 +140,13 @@ em reply 42              # AI draft opened in $EDITOR
 em reply 42 --no-ai      # Plain reply template, no AI
 em reply 42 --all        # Reply-all
 em reply 42 --batch      # Non-interactive: preview then confirm
-```text
+```
 
 Every send operation requires explicit confirmation:
 
 ```text
 Send this email? [y/N]:
-```text
+```
 
 The default is **N** (no). Press `y` to send, anything else to cancel.
 
@@ -163,7 +163,7 @@ Generate AI reply drafts for all actionable emails at once:
 ```zsh
 em respond             # Draft AI replies for actionable emails
 em respond --review    # Review and send drafts interactively
-```text
+```
 
 ### Per-email AI actions
 
@@ -173,21 +173,21 @@ em summarize 42        # One-line AI summary
 em catch 42            # Capture email as a flow task
 em todo 42             # Extract action items
 em event 42            # Extract calendar event details
-```text
+```
 
 ### AI backend management
 
 ```zsh
 em ai                  # Show current AI backend
 em ai toggle           # Cycle through configured backends
-```text
+```
 
 ### Cache management
 
 ```zsh
 em cache stats         # Show cache size and hit rate
 em cache clear         # Wipe cached AI results
-```text
+```
 
 AI results are cached by default (TTL-based). Clearing the cache forces fresh AI calls on the next run.
 
@@ -199,7 +199,7 @@ Verify that all dependencies are installed and configured:
 
 ```zsh
 em doctor
-```bash
+```
 
 This checks: `himalaya`, `jq`, `fzf`, `pandoc`, `w3m` (or `lynx`), and AI backend availability.
 
@@ -219,7 +219,7 @@ export FLOW_EMAIL_PAGE_SIZE=25        # Default inbox page size
 export FLOW_EMAIL_FOLDER=INBOX        # Default folder
 export FLOW_EMAIL_TRASH_FOLDER=Trash  # Trash folder (Exchange: "Deleted Items")
 export FLOW_EMAIL_AI_TIMEOUT=30       # AI draft timeout in seconds
-```diff
+```
 
 Project-level overrides are supported: create `.flow/email.conf` in a project root and `em` will load those settings automatically when you are inside that project.
 
@@ -250,7 +250,7 @@ Exchange typically uses `"Deleted Items"` instead of `Trash` as the trash folder
 
 ```zsh
 export FLOW_EMAIL_TRASH_FOLDER="Deleted Items"
-```bash
+```
 
 Also make sure your `~/.config/himalaya/config.toml` uses the correct IMAP host and OAuth2 or password credentials for your Exchange account. See the [himalaya documentation](https://pimalaya.org/himalaya/) for account setup details.
 

--- a/docs/tutorials/scholar-enhancement/01-getting-started.md
+++ b/docs/tutorials/scholar-enhancement/01-getting-started.md
@@ -38,7 +38,7 @@ Let's check that Scholar Enhancement is available.
 
 ```bash
 teach slides --help
-```html
+```
 
 **Expected Output:**
 You should see a help message with a "Universal Flags" section listing style presets and content flags.
@@ -63,7 +63,7 @@ Let's generate slides for "Linear Regression" using the computational style.
 
 ```bash
 teach slides "Linear Regression" --style computational
-```html
+```
 
 **What happens:**
 1. Scholar validates the command
@@ -110,7 +110,7 @@ teach slides "Probability Theory" --style conceptual
 
 # Rigorous style (math-heavy)
 teach exam "Hypothesis Testing" --style rigorous
-```bash
+```
 
 Each preset automatically includes the appropriate content types for that teaching style.
 
@@ -128,7 +128,7 @@ teach slides "ANOVA" --style computational --diagrams
 
 # Add references to conceptual preset
 teach lecture "Statistics History" --style conceptual --references
-```bash
+```
 
 **Remove Content:**
 
@@ -138,7 +138,7 @@ teach exam "Regression" --style rigorous --no-proof
 
 # Computational without practice problems
 teach slides "Topic" --style computational --no-practice-problems
-```html
+```
 
 <div align="center">
 
@@ -176,7 +176,7 @@ teach exam help
 
 # General teach help
 teach help
-```diff
+```
 
 The help system shows:
 - Universal flags (work with all commands)
@@ -189,7 +189,7 @@ The help system shows:
 ```bash
 teach slides --[TAB]
 # Shows all available flags
-```diff
+```
 
 ---
 
@@ -226,7 +226,7 @@ Congratulations! You've learned the basics of Scholar Enhancement.
 
 ```text
 Solution: Use one of: conceptual, computational, rigorous, applied
-```text
+```
 
 **Issue:** "Conflicting flags" error
 
@@ -234,7 +234,7 @@ Solution: Use one of: conceptual, computational, rigorous, applied
 Solution: Don't use both --flag and --no-flag
 Example: --math --no-math ❌
 Correct: --math ✓ or --no-math ✓
-```text
+```
 
 **Issue:** Scholar takes a long time
 

--- a/docs/tutorials/scholar-enhancement/02-intermediate.md
+++ b/docs/tutorials/scholar-enhancement/02-intermediate.md
@@ -74,7 +74,7 @@ prerequisites:
   - "Simple linear regression (Week 6)"
   - "Matrix notation basics (Week 7)"
 EOF
-```html
+```
 
 <div align="center">
 
@@ -95,7 +95,7 @@ Now generate slides using the lesson plan.
 
 ```bash
 teach slides -w 8
-```bash
+```
 
 **What happens:**
 1. Loads `.flow/lesson-plans/week-08.yml`
@@ -112,7 +112,7 @@ teach slides "Multiple Regression" --style computational
 
 # With lesson plan (short command)
 teach slides -w 8
-```html
+```
 
 Same result, but lesson plan is faster and more consistent!
 
@@ -133,13 +133,13 @@ You can override the lesson plan's style.
 ```bash
 # Lesson plan says "computational", but generate rigorous instead
 teach slides -w 8 --style rigorous
-```text
+```
 
 **Precedence:**
 
 ```text
 Command-line style > Lesson plan style > No style
-```text
+```
 
 **Use Case:** Create different versions of the same week's content for different audiences.
 
@@ -151,7 +151,7 @@ What happens if no lesson plan exists?
 
 ```bash
 teach slides -w 12
-```text
+```
 
 **Fallback Flow:**
 
@@ -166,7 +166,7 @@ graph TD
     F -->|Yes| H[Generate slides]
     F -->|No| I[Cancel]
     C --> H
-```text
+```
 
 **Example Prompt:**
 
@@ -176,7 +176,7 @@ graph TD
 Topic from config: "Time Series"
 
 Continue with this topic? [Y/n]:
-```yaml
+```
 
 Press Enter to continue, or `n` to cancel and create a lesson plan first.
 
@@ -198,7 +198,7 @@ semester_info:
     # ...
     - week: 12
       topic: "Time Series"
-```diff
+```
 
 **When to use:**
 - Quick semester setup
@@ -228,7 +228,7 @@ Let's try fully interactive mode.
 
 ```bash
 teach slides -i
-```text
+```
 
 **Wizard Flow:**
 
@@ -259,7 +259,7 @@ What style should this content use?
 Your choice [1-4]: 2
 
 → Generating slides for Week 8 with computational style
-```html
+```
 
 <div align="center">
 
@@ -282,21 +282,21 @@ You can skip either wizard by providing flags.
 ```bash
 teach exam -i -w 8
 # → Shows style menu only
-```bash
+```
 
 **Skip style wizard (style known):**
 
 ```bash
 teach quiz -i --style rigorous
 # → Shows topic menu only
-```bash
+```
 
 **Skip both (just use interactive flag for verbose output):**
 
 ```bash
 teach lecture -i -w 8 --style computational
 # → No menus, proceeds with provided values
-```bash
+```
 
 ---
 
@@ -313,7 +313,7 @@ teach exam -w 8 --no-practice-problems --math
 
 # Interactive + week hint + style hint
 teach quiz -i -w 8 --style computational --examples
-```diff
+```
 
 **Best Practice:**
 - Use lesson plans for semester structure
@@ -355,7 +355,7 @@ You've mastered intermediate Scholar features!
 ├── week-02.yml
 ├── ...
 └── week-16.yml
-```diff
+```
 
 ### 2. Required vs Optional Fields
 
@@ -378,14 +378,14 @@ Choose styles that match your teaching philosophy:
 ```yaml
 style: rigorous  # Most weeks
 # Occasionally use conceptual for intro weeks
-```bash
+```
 
 **Applied Course:**
 
 ```yaml
 style: computational  # Most weeks
 # Occasionally use applied for case studies
-```bash
+```
 
 ### 4. Reusability
 
@@ -408,7 +408,7 @@ EOF
 done
 
 # Fill in topics as you go
-```bash
+```
 
 ### Pattern 2: Quick Generation
 
@@ -417,7 +417,7 @@ done
 teach slides -w 8   # Uses lesson plan
 teach exam -w 8     # Same topic, same style
 teach quiz -w 8     # Consistent across materials
-```bash
+```
 
 ### Pattern 3: Interactive Exploration
 
@@ -426,7 +426,7 @@ teach quiz -w 8     # Consistent across materials
 teach lecture -i
 # → See full schedule
 # → Pick the topic you want
-```bash
+```
 
 ---
 
@@ -439,7 +439,7 @@ teach lecture -i
 brew install yq
 
 # Or continue with fallback (limited functionality)
-```bash
+```
 
 **Issue:** Lesson plan not loading
 
@@ -452,7 +452,7 @@ yq . .flow/lesson-plans/week-08.yml
 
 # Check required field (topic)
 yq '.topic' .flow/lesson-plans/week-08.yml
-```bash
+```
 
 **Issue:** Interactive mode shows no weeks
 

--- a/docs/tutorials/scholar-enhancement/03-advanced.md
+++ b/docs/tutorials/scholar-enhancement/03-advanced.md
@@ -53,7 +53,7 @@ teach slides "Linear Regression" --style computational -o test-slides.qmd
 
 # Now revise them
 teach slides --revise test-slides.qmd
-```text
+```
 
 **Revision Flow:**
 
@@ -71,7 +71,7 @@ sequenceDiagram
     S->>A: Generate improvements
     A->>S: Improved content
     S->>U: Save to file
-```html
+```
 
 **What happens:**
 1. **Analyzes** file to detect type (slides, exam, quiz, etc.)
@@ -107,7 +107,7 @@ What would you like to improve?
   [6] Custom instructions          Your own guidance
 
 Your choice [1-6]:
-```diff
+```
 
 **Each Option:**
 
@@ -155,7 +155,7 @@ teach exam --revise exam.qmd --math --examples
 
 # Remove practice problems, add references
 teach lecture --revise lecture.md --no-practice-problems --references
-```bash
+```
 
 **Workflow:**
 1. Select revision option (e.g., "Add missing content")
@@ -168,7 +168,7 @@ teach lecture --revise lecture.md --no-practice-problems --references
 teach slides --revise slides.qmd --diagrams
 # → Select "Add missing content"
 # → Adds missing sections + diagrams throughout
-```yaml
+```
 
 ---
 
@@ -189,7 +189,7 @@ title: "*Quiz*" → quiz
 "# Homework" → assignment
 "Course: " → syllabus
 "Criteria" → rubric
-```diff
+```
 
 **Detected Types:**
 - slides
@@ -214,7 +214,7 @@ Before revising, Scholar shows what's changed.
 
 ```bash
 teach slides --revise slides/week-08.qmd
-```text
+```
 
 **Preview Output:**
 
@@ -233,7 +233,7 @@ Git diff:
 ───────────────────────────────────────
 
 [Preview helps you decide which revision to apply]
-```text
+```
 
 **No Git Repo?**
 
@@ -242,7 +242,7 @@ Git diff:
 📅 Last modified: 2026-01-17 14:30
 
 (File is not tracked by git)
-```diff
+```
 
 ---
 
@@ -277,7 +277,7 @@ teach exam "Multiple Regression" --context --style rigorous
 
 # Revise with course awareness
 teach lecture --revise lecture.md --context
-```yaml
+```
 
 **Context Example:**
 
@@ -288,7 +288,7 @@ course:
   semester: "Spring"
   year: 2026
   level: "Undergraduate"
-```bash
+```
 
 **With Context:**
 
@@ -298,7 +298,7 @@ course:
 This lecture covers multiple regression analysis as part of
 STAT 440 (Spring 2026). We build on linear regression from
 Week 6 and prepare for time series in Week 12.
-```bash
+```
 
 **Without Context:**
 
@@ -306,7 +306,7 @@ Week 6 and prepare for time series in Week 12.
 # Multiple Regression
 
 This lecture covers multiple regression analysis.
-```html
+```
 
 <div align="center">
 
@@ -324,7 +324,7 @@ Combine all three for maximum power.
 
 ```bash
 teach slides --revise slides.qmd --context --diagrams --references
-```yaml
+```
 
 **What Happens:**
 1. Loads course context (STAT 440, objectives)
@@ -350,7 +350,7 @@ Master advanced flag patterns.
 
 ```bash
 teach exam "Topic" --style rigorous --no-proof --diagrams --examples
-```text
+```
 
 **Resolution:**
 
@@ -363,13 +363,13 @@ teach exam "Topic" --style rigorous --no-proof --diagrams --examples
 
 3. Add: --diagrams, --examples
    → definitions, explanation, math, diagrams, examples
-```text
+```
 
 ### Pattern 2: Multiple Removals
 
 ```bash
 teach slides -w 8 --style computational --no-code --no-practice-problems
-```text
+```
 
 **Use Case:** Lecture slides (concepts only, no hands-on)
 
@@ -377,19 +377,19 @@ teach slides -w 8 --style computational --no-code --no-practice-problems
 
 ```bash
 teach quiz "ANOVA" -e -m -x -c -d
-```text
+```
 
 **Expands to:**
 
 ```text
 --explanation --math --examples --code --diagrams
-```text
+```
 
 ### Pattern 4: Context-Aware Customization
 
 ```bash
 teach lecture -w 8 --context --style rigorous --diagrams --no-proof
-```bash
+```
 
 **Result:** Math-heavy lecture (no proofs) aligned with course, with visuals
 
@@ -406,7 +406,7 @@ Process multiple files or weeks efficiently.
 for file in week-08-*.qmd; do
   teach slides --revise "$file" --context --diagrams
 done
-```bash
+```
 
 ### Batch Generation
 
@@ -415,7 +415,7 @@ done
 for week in {1..16}; do
   teach assignment -w $week -o "hw/hw-$week.qmd"
 done
-```bash
+```
 
 ### Batch Style Override
 
@@ -424,7 +424,7 @@ done
 for week in {1..16}; do
   teach exam -w $week --style rigorous -o "exams/exam-$week.qmd"
 done
-```bash
+```
 
 **Pro Tip:** Add `--dry-run` to preview first!
 
@@ -454,7 +454,7 @@ teach slides "Multiple Linear Regression with Diagnostics" --style computational
 
 # Fast (short command via lesson plan)
 teach slides -w 8
-```bash
+```
 
 **2. Batch Non-Interactive**
 
@@ -464,7 +464,7 @@ for week in {1..16}; do teach slides -i -w $week; done  # Slow
 
 # Non-interactive is faster
 for week in {1..16}; do teach slides -w $week; done  # Fast
-```bash
+```
 
 **3. Cache Context**
 Scholar reads context files each time. Keep them small (<500 chars) for speed.
@@ -475,7 +475,7 @@ Preview commands without calling Scholar:
 ```bash
 teach exam -w 8 --style rigorous --dry-run
 # Shows what would be generated (instant)
-```sql
+```
 
 ---
 
@@ -506,7 +506,7 @@ teach quiz -w $WEEK --questions 10 -o "quizzes/quiz-$WEEK.qmd"
 teach assignment -w $WEEK -o "homework/hw-$WEEK.qmd"
 
 echo "Week $WEEK complete!"
-```bash
+```
 
 ### Workflow 2: Revision Pipeline
 
@@ -527,7 +527,7 @@ for file in exams/*.qmd; do
 done
 
 echo "Revision complete!"
-```bash
+```
 
 ### Workflow 3: Style Variant Generator
 
@@ -545,7 +545,7 @@ teach slides -w $WEEK --style computational -o "slides/week-$WEEK-main.qmd"
 
 # Rigorous (honors section)
 teach slides -w $WEEK --style rigorous -o "slides/week-$WEEK-honors.qmd"
-```bash
+```
 
 ---
 
@@ -567,7 +567,7 @@ teach slides --revise slides.qmd --diagrams
 
 # 4. Polish formatting
 teach slides --revise slides.qmd  # Select option 5
-```bash
+```
 
 ### Pattern 2: Cross-Format Consistency
 
@@ -579,7 +579,7 @@ teach slides -w 8     # Slides
 teach lecture -w 8    # Detailed notes
 teach exam -w 8       # Assessment
 teach quiz -w 8       # Quick check
-```bash
+```
 
 ### Pattern 3: Collaborative Teaching
 
@@ -594,7 +594,7 @@ teach slides -w 8 --style conceptual -o week-8-ta.qmd
 
 # Honors section (rigorous)
 teach slides -w 8 --style rigorous -o week-8-honors.qmd
-```yaml
+```
 
 ---
 
@@ -608,7 +608,7 @@ teach slides -w 8 --style rigorous -o week-8-honors.qmd
 title: "Week 8 Slides"  # Add "slides" keyword
 format: revealjs        # Explicit format
 ---
-```bash
+```
 
 ### Issue: Context Not Applied
 
@@ -619,7 +619,7 @@ ls .flow/teach-config.yml syllabus.md README.md
 # Check context building
 teach slides -w 8 --context --verbose
 # Should show context in command
-```bash
+```
 
 ### Issue: Too Many Flags
 
@@ -628,7 +628,7 @@ teach slides -w 8 --context --verbose
 teach slides "Topic" --explanation --examples --code --practice-problems
 # → Same as:
 teach slides "Topic" --style computational
-```diff
+```
 
 ---
 
@@ -680,7 +680,7 @@ Built a useful workflow script? Share it with the community!
 teach slides --revise slides.qmd
 # Select option 6 (Custom)
 # Type: "Add more real-world examples from recent research"
-```bash
+```
 
 ### Tip 2: Context from Multiple Sources
 
@@ -691,7 +691,7 @@ syllabus.md            # Objectives
 README.md              # Overview
 
 # All used when --context flag present
-```bash
+```
 
 ### Tip 3: Quick Style Preview
 
@@ -702,7 +702,7 @@ for style in conceptual computational rigorous applied; do
 done
 
 # Review previews, pick best style
-```bash
+```
 
 ### Tip 4: Incremental Improvement
 

--- a/docs/workflows/WORKFLOW-LINT.md
+++ b/docs/workflows/WORKFLOW-LINT.md
@@ -29,7 +29,7 @@ This workflow integrates `teach validate --lint` into your daily course developm
 
 ```bash
 brew install Data-Wise/tap/flow-cli
-```bash
+```
 
 **2. Copy validator to course:**
 
@@ -37,7 +37,7 @@ brew install Data-Wise/tap/flow-cli
 cd ~/projects/teaching/my-course
 mkdir -p .teach/validators
 cp $(brew --prefix flow-cli)/share/validators/lint-shared.zsh .teach/validators/
-```bash
+```
 
 **3. Create git pre-commit hook:**
 
@@ -66,7 +66,7 @@ fi
 EOF
 
 chmod +x .git/hooks/pre-commit
-```bash
+```
 
 ### Daily Workflow
 
@@ -84,7 +84,7 @@ git add slides/week-03.qmd
 git commit -m "Add week 3 slides"
 
 # 5. Lint runs automatically, shows warnings but doesn't block
-```bash
+```
 
 ### Weekly Audit
 
@@ -99,7 +99,7 @@ less lint-audit.txt
 
 # Count issues
 grep "✗ Line" lint-audit.txt | wc -l
-```bash
+```
 
 ---
 
@@ -118,7 +118,7 @@ cp lint-shared.zsh .teach/validators/
 git add .teach/validators/lint-shared.zsh
 git commit -m "Add lint validator"
 git push
-```bash
+```
 
 **2. Document lint rules in README:**
 
@@ -129,7 +129,7 @@ cat >> README.md <<'EOF'
 
 Before committing `.qmd` files, run:
 
-```bash
+```
 teach validate --lint your-file.qmd
 ```diff
 
@@ -149,7 +149,7 @@ All code blocks need language tags:
 See `docs/guides/LINT-GUIDE.md` for full details.
 EOF
 
-```bash
+```
 
 **3. Create CI check (`.github/workflows/lint.yml`):**
 ```yaml
@@ -178,7 +178,7 @@ jobs:
           teach validate --lint $CHANGED_FILES
         fi
       continue-on-error: true
-```bash
+```
 
 ### Collaborator Onboarding
 
@@ -198,7 +198,7 @@ chmod +x .git/hooks/pre-commit
 
 # 4. Test lint
 teach validate --lint slides/week-01.qmd
-```bash
+```
 
 ### Pull Request Workflow
 
@@ -223,7 +223,7 @@ git push origin add-week-05-slides
 
 # 6. Create PR
 gh pr create
-```bash
+```
 
 **Reviewer:**
 
@@ -233,7 +233,7 @@ gh pr view 123
 
 # Look for CI check:
 # ✅ Lint Quarto Files passed
-```yaml
+```
 
 ---
 
@@ -283,7 +283,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_site
-```yaml
+```
 
 ### GitLab CI
 
@@ -303,7 +303,7 @@ lint:
   only:
     changes:
       - "**/*.qmd"
-```sql
+```
 
 ---
 
@@ -340,7 +340,7 @@ while true; do
 
     sleep $INTERVAL
 done
-```bash
+```
 
 ### Usage
 
@@ -358,7 +358,7 @@ chmod +x watch-lint.sh
 #
 # → lint-shared (v1.0.0)
 #   ✓ All files passed
-```bash
+```
 
 ---
 
@@ -378,14 +378,14 @@ chmod +x watch-lint.sh
 # Count current issues
 teach validate --lint **/*.qmd 2>&1 | grep "✗ Line" | wc -l
 # Output: 243 issues
-```bash
+```
 
 **2. Set goal:**
 
 ```bash
 # Fix 10 issues per week
 echo "Goal: Reduce from 243 to 0 by end of semester"
-```bash
+```
 
 **3. Track progress:**
 
@@ -394,7 +394,7 @@ echo "Goal: Reduce from 243 to 0 by end of semester"
 teach validate --lint **/*.qmd 2>&1 | grep "✗ Line" | wc -l > lint-count.txt
 git add lint-count.txt
 git commit -m "Lint audit: $(cat lint-count.txt) issues remaining"
-```bash
+```
 
 **4. Fix as you edit:**
 
@@ -408,14 +408,14 @@ teach validate --lint slides/week-01.qmd
 # Commit clean file
 git add slides/week-01.qmd
 git commit -m "Update week 1 slides (lint-clean)"
-```bash
+```
 
 **5. Celebrate progress:**
 
 ```bash
 # Gamify the cleanup
 echo "🎉 Down to $(cat lint-count.txt) issues! (was 243)"
-```text
+```
 
 ---
 
@@ -450,7 +450,7 @@ graph LR
     J -->|Yes| K[Merge to main]
     J -->|No| L[Request changes]
     L --> D
-```text
+```
 
 ### Weekly Sync
 
@@ -469,7 +469,7 @@ Week 5 Sync:
   → Reminder: Use .callout-note instead
 - 💡 New rule suggestion: Check for empty code blocks
   → Professor approves, adding to Phase 2
-```bash
+```
 
 ---
 
@@ -490,7 +490,7 @@ mkdir -p .teach/validators
 cp lint-shared.zsh .teach/validators/
 git add .teach/
 git commit -m "Initial setup with lint"
-```bash
+```
 
 ### 2. Document Exceptions
 
@@ -504,7 +504,7 @@ If you must violate a rule (rare), document it:
 # Title
 
 ### Subtitle (intentional skip)
-```bash
+```
 
 ### 3. Automate Everything
 
@@ -512,7 +512,7 @@ If you must violate a rule (rare), document it:
 # Pre-commit hook (auto-run)
 # CI checks (auto-run)
 # Weekly reports (auto-generate)
-```diff
+```
 
 ### 4. Educate Team
 
@@ -527,7 +527,7 @@ If you must violate a rule (rare), document it:
 - Lint issues per week
 - Clean files vs total files
 - Time to fix (decreases over time)
-```diff
+```
 
 ---
 

--- a/tests/DOG-FEEDING-TEST-README.md
+++ b/tests/DOG-FEEDING-TEST-README.md
@@ -13,7 +13,7 @@ This gamified test validates your flow-cli setup by having you "feed a virtual d
 ````bash
 cd /path/to/flow-cli
 ./tests/interactive-dog-feeding.zsh
-```diff
+```
 
 ## How It Works
 
@@ -120,7 +120,7 @@ Command to run:
 
 The dog sees all your projects! 😊
 🥩 Fed the dog! 😊
-```diff
+```
 
 ## Exit Codes
 
@@ -138,14 +138,14 @@ cd flow-cli
 
 # Validate everything works
 ./tests/interactive-dog-feeding.zsh
-```bash
+```
 
 ### 2. After Major Refactor
 
 ```bash
 # Made big changes? Feed the dog!
 ./tests/interactive-dog-feeding.zsh
-```bash
+```
 
 ### 3. Teaching New Users
 
@@ -153,7 +153,7 @@ cd flow-cli
 # Perfect onboarding experience
 # Shows all major features in fun way
 ./tests/interactive-dog-feeding.zsh
-```bash
+```
 
 ### 4. CI/CD Integration
 
@@ -163,7 +163,7 @@ yes '' | ./tests/interactive-dog-feeding.zsh
 
 # Check exit code
 echo $?  # 0 = success, 1 = failure
-```diff
+```
 
 ## ADHD-Friendly Design
 
@@ -202,7 +202,7 @@ HUNGER=100          # Decreases as you feed (0-100)
 HAPPINESS=50        # Increases with success (0-100)
 TASKS_COMPLETED=0   # Increments per task (0-7)
 TOTAL_TASKS=7       # Fixed at 7
-```zsh
+```
 
 ## Troubleshooting
 
@@ -213,13 +213,13 @@ TOTAL_TASKS=7       # Fixed at 7
 ```bash
 source ~/projects/dev-tools/flow-cli/flow.plugin.zsh
 type dash  # Should show function
-```bash
+```
 
 **Check session directory:**
 
 ```bash
 ls -la ~/.local/share/flow/
-```text
+```
 
 **Run individual commands:**
 
@@ -228,7 +228,7 @@ dash
 work flow-cli
 catch "test idea"
 finish
-```yaml
+```
 
 ### No Emoji Support
 


### PR DESCRIPTION
## Summary
- Strip language tags from closing code fences across 220 docs files
- Fixes 139+ broken internal anchor links reported by MkDocs build
- Root cause: `pymdownx.superfences` treats closing fences with language tags as openers, swallowing all subsequent headings

## Test plan
- [x] `mkdocs build` reports 0 broken anchor warnings (was 139+)
- [x] Docs deployed and verified at https://Data-Wise.github.io/flow-cli/
- [x] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)