### PR TITLE
chore: source flow-cli from Homebrew

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1039,8 +1039,8 @@ export PATH="/opt/homebrew/opt/imagemagick@6/bin:$PATH"
 # ============================================
 # Modern ZSH plugin architecture with single source location
 # Replaces old ~/.config/zsh/functions/ and .zshenv loading
-[[ -f ~/.zsh/plugins/flow-cli/flow.plugin.zsh ]] && \
-    source ~/.zsh/plugins/flow-cli/flow.plugin.zsh
+[[ -f /opt/homebrew/opt/flow-cli/flow.plugin.zsh ]] && \
+    source /opt/homebrew/opt/flow-cli/flow.plugin.zsh
 
 # obs CLI completion
 fpath=(~/.zsh/completions $fpath)


### PR DESCRIPTION
## Summary
- Switch .zshrc to source flow-cli from Homebrew cellar (`/opt/homebrew/opt/flow-cli/`) instead of repo symlink (`~/.zsh/plugins/flow-cli/`)

## Test plan
- [x] Clean env test: all commands load from brew path
- [x] Verified brew cellar matches source repo (v7.4.1, identical files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)