### PR TITLE
Release: v7.4.2 — Atlas Integration + Homebrew Cleanup

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -4,7 +4,7 @@
 ## Project: flow-cli
 ## Type: zsh-plugin
 ## Status: active
-## Focus: v7.4.1 release
+## Focus: v7.4.2 release
 ## Phase: Active Development
 ## Priority: 2
 ## Progress: 90
@@ -179,7 +179,7 @@
 ---
 
 **Last Updated:** 2026-02-22
-**Status:** v7.4.1 | 46/46 tests passing (1 expected timeout) | 15 dispatchers + at bridge | 196 test files | 12000+ test functions | 0 lint errors | 0 broken anchors
-## wins: v7.4.1 release (2026-02-22), Atlas integration update (2026-02-22), Brew sourcing switch (2026-02-22), 139 broken anchors → 0 (2026-02-22), Homebrew 75MB→3.5MB (2026-02-21)
+**Status:** v7.4.2 | 46/46 tests passing (1 expected timeout) | 15 dispatchers + at bridge | 196 test files | 12000+ test functions | 0 lint errors | 0 broken anchors
+## wins: v7.4.2 release (2026-02-22), Atlas integration update (2026-02-22), Brew sourcing switch (2026-02-22), 139 broken anchors → 0 (2026-02-22), Homebrew 75MB→3.5MB (2026-02-21)
 ## streak: 5
 ## last_active: 2026-02-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [v7.4.1] — 2026-02-22 — Atlas Integration + Homebrew Cleanup
+## [v7.4.2] — 2026-02-22 — Atlas Integration + Homebrew Cleanup
 
 ### Added
+
 - **Atlas bridge (`at`)** — Enhanced bridge with styled help, 10 warm-path commands, 4 ZSH fallbacks
 - **Atlas API contract** — Formal interface spec (`docs/ATLAS-CONTRACT.md`)
 - **77 new tests** — Contract (18), e2e (30), dogfood (29) for Atlas bridge
 - **CI version guard**: new workflow blocks releases when FLOW_VERSION mismatches tag
 
 ### Fixed
+
 - **Help browser** — All 15 dispatchers + at in regex and commands (was 8)
 - **Help compliance** — Added missing `em` dispatcher to checker
 - **Dispatcher counts** — "12 dispatchers" → "15 dispatchers" across docs/tests
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Repo cleanup**: delete 62 stale root-level files
 
 ### Documentation
+
 - New: `docs/commands/at.md`, `docs/guides/ATLAS-INTEGRATION-GUIDE.md`
 - Updated: QUICK-REFERENCE, MASTER-DISPATCHER-GUIDE, MASTER-ARCHITECTURE, README, CLAUDE.md, CONTRIBUTING, doctor, mkdocs.yml
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management. Zero dependencies. Standalone (works without Oh-My-Zsh or any plugin manager).
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Current Version:** v7.4.1
+- **Current Version:** v7.4.2
 - **Install:** Homebrew (recommended), or any plugin manager
 - **Source:** `source /opt/homebrew/opt/flow-cli/flow.plugin.zsh` (via Homebrew)
 - **Optional:** Atlas integration for enhanced state management
@@ -289,8 +289,8 @@ export FLOW_DEBUG=1                          # Debug mode
 
 ## Current Status
 
-**Version:** v7.4.1 | **Tests:** 12000+ (46/46 suite) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.4.2 | **Tests:** 12000+ (46/46 suite) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 
-**Last Updated:** 2026-02-21 (v7.4.1)
+**Last Updated:** 2026-02-22 (v7.4.2)

--- a/README.md
+++ b/README.md
@@ -207,12 +207,12 @@ Context-aware commands that adapt to your project:
 | `em inbox`         | Browse inbox with fzf          |
 | `em pick`          | Interactive email picker       |
 | `flow sync`        | Sync data across devices       |
-| `at catch "idea"`  | Quick capture via Atlas bridge  |
-| `at stats`         | Project stats (requires Atlas)  |
+| `at catch "idea"`  | Quick capture via Atlas bridge |
+| `at stats`         | Project stats (requires Atlas) |
 
 Each dispatcher has built-in help: `cc help`, `dots help`, `r help`, `em help`, `at help`, etc.
 
-**✨ New in v7.4.1:** Atlas bridge (`at`) — project intelligence, context parking, quick capture
+**✨ New in v7.4.2:** Atlas bridge (`at`) — project intelligence, context parking, quick capture
 **✨ v7.4.0:** 31 email commands — organize, manage, AI, plus 10 tutorials
 **✨ v7.1.0:** Dispatcher split — `dot` → `dots` (dotfiles) + `sec` (secrets) + `tok` (tokens)
 **✨ 15 dispatchers + Atlas bridge** with unified grammar, built-in help, and fzf integration

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ---
 
-## [7.4.1] - 2026-02-22
+## [7.4.2] - 2026-02-22
 
 ### Added
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -426,4 +426,4 @@ All new features demonstrated with optimized tutorial GIFs (5.7MB total):
 
 **Maintained by:** Data-Wise
 **Last updated:** 2026-02-21
-**Current version:** v7.4.1
+**Current version:** v7.4.2

--- a/docs/commands/at.md
+++ b/docs/commands/at.md
@@ -370,5 +370,5 @@ Or when not installed:
 ---
 
 **Last Updated:** 2026-02-22
-**Command Version:** v7.4.1
+**Command Version:** v7.4.2
 **Status:** Production ready (Atlas optional)

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -228,7 +228,7 @@ flow doctor --verbose
   ✓ completions
 
 🌊 FLOW-CLI
-  ✓ Plugin loaded    v7.4.1
+  ✓ Plugin loaded    v7.4.2
   ✓ Plugin directory ~/projects/dev-tools/flow-cli
 
 ────────────────────────────────────────────────
@@ -532,5 +532,5 @@ The `doctor` command follows these principles:
 ---
 
 **Last Updated:** 2026-02-12
-**Command Version:** v7.4.1 (doctor v2.0 — email integration)
+**Command Version:** v7.4.2 (doctor v2.0 — email integration)
 **Status:** ✅ Production ready with interactive install + email diagnostics

--- a/docs/commands/work.md
+++ b/docs/commands/work.md
@@ -263,5 +263,5 @@ flow nvim-tutorial
 ---
 
 **Last Updated:** 2026-02-16
-**Command Version:** v7.4.1
+**Command Version:** v7.4.2
 **Status:** ✅ Production ready with session tracking and optional editor integration

--- a/docs/guides/ATLAS-INTEGRATION-GUIDE.md
+++ b/docs/guides/ATLAS-INTEGRATION-GUIDE.md
@@ -335,4 +335,4 @@ export FLOW_ATLAS_ENABLED=no
 ---
 
 **Last Updated:** 2026-02-22
-**Version:** v7.4.1
+**Version:** v7.4.2

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -85,4 +85,4 @@ tags:
 
 ---
 
-**v7.4.1** | [Home](../index.md)
+**v7.4.2** | [Home](../index.md)

--- a/docs/help/QUICK-REFERENCE.md
+++ b/docs/help/QUICK-REFERENCE.md
@@ -8,7 +8,7 @@ tags:
 
 **Purpose:** Single-page command lookup for all flow-cli features
 **Format:** Copy-paste ready with expected outputs
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-21
 
 ---
@@ -1358,6 +1358,6 @@ mcp help
 
 ---
 
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-21
 **Contributors:** See [CHANGELOG.md](../CHANGELOG.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ tags:
 
 !!! success "🎉 What's New in v7.4"
     **31 Email Commands:** `em star`, `em thread`, `em snooze`, `em digest`, `em delete`, `em move`, `em flag`, `em todo` — full inbox management with `--pick` multi-select and AI backends.
-    **v7.4.1:** Homebrew install reduced from 75MB to 3.5MB. CI version guard prevents release mismatches.
+    **v7.4.2:** Homebrew install reduced from 75MB to 3.5MB. CI version guard prevents release mismatches.
     [→ Email Guide](guides/EMAIL-DISPATCHER-GUIDE.md){ .md-button }
     [→ Quick Reference](reference/REFCARD-EMAIL-DISPATCHER.md){ .md-button }
     [→ Changelog](CHANGELOG.md){ .md-button }
@@ -281,4 +281,4 @@ catch "idea"      # Quick capture
 
 ---
 
-**v7.4.1** · Pure ZSH · Zero Dependencies · MIT License
+**v7.4.2** · Pure ZSH · Zero Dependencies · MIT License

--- a/docs/reference/MASTER-API-REFERENCE.md
+++ b/docs/reference/MASTER-API-REFERENCE.md
@@ -8,7 +8,7 @@ tags:
 **Purpose:** Complete API documentation for all flow-cli library functions
 **Audience:** Developers, contributors, advanced users
 **Format:** Function signatures, parameters, return values, examples
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-21
 
 ---
@@ -6879,7 +6879,7 @@ URL line is omitted when `$url` is empty or `"null"`.
 
 ---
 
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-21
 **Auto-Generation:** Run `./scripts/generate-api-docs.sh` to update function index
 **Total Functions:** 880 (428 documented, 452 pending)

--- a/docs/reference/MASTER-ARCHITECTURE.md
+++ b/docs/reference/MASTER-ARCHITECTURE.md
@@ -3,7 +3,7 @@
 **Purpose:** Complete system architecture documentation for flow-cli
 **Audience:** Contributors, maintainers, advanced users
 **Format:** Design decisions, diagrams, implementation details
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-21
 
 ---
@@ -1020,7 +1020,7 @@ graph TD
 
 ---
 
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-21
 **Diagrams:** 8 Mermaid diagrams
 **Total:** 2,500+ lines

--- a/docs/reference/MASTER-DISPATCHER-GUIDE.md
+++ b/docs/reference/MASTER-DISPATCHER-GUIDE.md
@@ -10,7 +10,7 @@ tags:
 **Purpose:** Complete reference for all flow-cli dispatchers (15 + at bridge)
 **Audience:** All users (beginner → intermediate → advanced)
 **Format:** Progressive disclosure (basics → advanced features)
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-21
 
 ---
@@ -3072,7 +3072,7 @@ als           # List all aliases by category
 
 **Domain:** Email management via himalaya CLI
 **File:** `lib/dispatchers/email-dispatcher.zsh` + `lib/em-himalaya.zsh`, `lib/em-ai.zsh`, `lib/em-cache.zsh`, `lib/em-render.zsh`
-**Version:** v7.4.1
+**Version:** v7.4.2
 
 ### Overview
 
@@ -3320,6 +3320,6 @@ at stats
 
 ---
 
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-22
 **Total:** 15 dispatchers + at bridge fully documented

--- a/docs/reference/REFCARD-DOCTOR.md
+++ b/docs/reference/REFCARD-DOCTOR.md
@@ -319,5 +319,5 @@ teach doctor --verbose
 
 ---
 
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-21

--- a/docs/reference/REFCARD-EMAIL-DISPATCHER.md
+++ b/docs/reference/REFCARD-EMAIL-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `em` subcommands at a glance. For detailed guides, see linked documentation.
 >
-> **Version:** v7.4.1 | **Dispatcher:** `lib/dispatchers/email-dispatcher.zsh`
+> **Version:** v7.4.2 | **Dispatcher:** `lib/dispatchers/email-dispatcher.zsh`
 >
 > **Two interfaces, one backend:** `em` (keyboard-driven, fzf, sub-second) and
 > [himalaya-mcp](https://github.com/Data-Wise/himalaya-mcp) (conversation-driven, Claude as interface)
@@ -825,6 +825,6 @@ em ai claude                   # Use a known backend
 
 ---
 
-**Version:** v7.4.1
+**Version:** v7.4.2
 **Last Updated:** 2026-02-21
 **Commands:** 34 total (4 core + 2 search + 5 AI + 7 organize + 7 manage + 3 info + 3 util + 2 infra + 1 help)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -93,4 +93,4 @@ tags:
 
 ---
 
-**v7.4.1** | [Home](../index.md)
+**v7.4.2** | [Home](../index.md)

--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -139,7 +139,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="7.4.1"
+export FLOW_VERSION="7.4.2"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

- **Atlas bridge (`at`)** — Enhanced bridge with styled help, 10 warm-path commands, 4 ZSH fallbacks
- **Atlas API contract** — Formal interface spec (`docs/ATLAS-CONTRACT.md`)
- **77 new tests** — Contract (18), e2e (30), dogfood (29) for Atlas bridge
- **Help browser fix** — All 15 dispatchers + at in regex and commands (was 8)
- **Homebrew formula** — Selective install reduces 74MB Cellar to ~4MB
- **Markdown lint** — 10295 errors → 0 across 331 files
- **CI version guard** — New workflow blocks releases when FLOW_VERSION mismatches tag
- **Doc count sync** — 196 test files, 46/46 suites passing

## Stats

- **Tests:** 47 passed, 0 failed, 2 timeouts (expected)
- **Dispatchers:** 15 + at bridge
- **Test files:** 196 | **Functions:** 12000+

## Test plan
- [x] `./tests/run-all.sh` — 47 passed, 0 failed
- [x] Plugin sources without error
- [x] Version bumped in 21 files (flow.plugin.zsh, package.json, docs)
- [x] All doc links verified (0 broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)