### PR TITLE
chore: bump version to v7.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management. Zero dependencies. Standalone (works without Oh-My-Zsh or any plugin manager).
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Current Version:** v7.4.2
+- **Current Version:** v7.5.0
 - **Install:** Homebrew (recommended), or any plugin manager
 - **Source:** `source /opt/homebrew/opt/flow-cli/flow.plugin.zsh` (via Homebrew)
 - **Optional:** Atlas integration for enhanced state management
@@ -289,8 +289,8 @@ export FLOW_DEBUG=1                          # Debug mode
 
 ## Current Status
 
-**Version:** v7.4.2 | **Tests:** 12000+ (46/46 suite) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.5.0 | **Tests:** 12000+ (47/47 suite) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 
-**Last Updated:** 2026-02-22 (v7.4.2)
+**Last Updated:** 2026-02-26 (v7.5.0)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ Context-aware commands that adapt to your project:
 
 Each dispatcher has built-in help: `cc help`, `dots help`, `r help`, `em help`, `at help`, etc.
 
-**✨ New in v7.4.2:** Atlas bridge (`at`) — project intelligence, context parking, quick capture
+**✨ New in v7.5.0:** em v2.0 safety gate, ICS calendar, IMAP watch, folder CRUD + 8 integration test fixes
+**✨ v7.4.2:** Atlas bridge (`at`) — project intelligence, context parking, quick capture
 **✨ v7.4.0:** 31 email commands — organize, manage, AI, plus 10 tutorials
 **✨ v7.1.0:** Dispatcher split — `dot` → `dots` (dotfiles) + `sec` (secrets) + `tok` (tokens)
 **✨ 15 dispatchers + Atlas bridge** with unified grammar, built-in help, and fzf integration

--- a/docs/commands/at.md
+++ b/docs/commands/at.md
@@ -370,5 +370,5 @@ Or when not installed:
 ---
 
 **Last Updated:** 2026-02-22
-**Command Version:** v7.4.2
+**Command Version:** v7.5.0
 **Status:** Production ready (Atlas optional)

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -228,7 +228,7 @@ flow doctor --verbose
   ✓ completions
 
 🌊 FLOW-CLI
-  ✓ Plugin loaded    v7.4.2
+  ✓ Plugin loaded    v7.5.0
   ✓ Plugin directory ~/projects/dev-tools/flow-cli
 
 ────────────────────────────────────────────────
@@ -532,5 +532,5 @@ The `doctor` command follows these principles:
 ---
 
 **Last Updated:** 2026-02-12
-**Command Version:** v7.4.2 (doctor v2.0 — email integration)
+**Command Version:** v7.5.0 (doctor v2.0 — email integration)
 **Status:** ✅ Production ready with interactive install + email diagnostics

--- a/docs/commands/work.md
+++ b/docs/commands/work.md
@@ -263,5 +263,5 @@ flow nvim-tutorial
 ---
 
 **Last Updated:** 2026-02-16
-**Command Version:** v7.4.2
+**Command Version:** v7.5.0
 **Status:** ✅ Production ready with session tracking and optional editor integration

--- a/docs/guides/ATLAS-INTEGRATION-GUIDE.md
+++ b/docs/guides/ATLAS-INTEGRATION-GUIDE.md
@@ -335,4 +335,4 @@ export FLOW_ATLAS_ENABLED=no
 ---
 
 **Last Updated:** 2026-02-22
-**Version:** v7.4.2
+**Version:** v7.5.0

--- a/docs/guides/EMAIL-COOKBOOK.md
+++ b/docs/guides/EMAIL-COOKBOOK.md
@@ -2,7 +2,7 @@
 
 > Copy-paste workflows for common email tasks.
 >
-> **Dispatcher:** `em` | **Version:** v2.0 (flow-cli v7.4.2+)
+> **Dispatcher:** `em` | **Version:** v2.0 (flow-cli v7.5.0+)
 > **Last Updated:** 2026-02-26
 
 Each recipe follows the same structure: **Problem** — **Solution** — **Explanation** — **Pro tip**.
@@ -526,5 +526,5 @@ em h     # em help
 
 ---
 
-**Version:** v2.0 (em dispatcher) — flow-cli v7.4.2+
+**Version:** v2.0 (em dispatcher) — flow-cli v7.5.0+
 **Last Updated:** 2026-02-26

--- a/docs/guides/EMAIL-DISPATCHER-GUIDE.md
+++ b/docs/guides/EMAIL-DISPATCHER-GUIDE.md
@@ -1,6 +1,6 @@
 # Email Dispatcher Guide
 
-**Available Since:** v7.0.0 | **v2.0 Since:** v7.4.2
+**Available Since:** v7.0.0 | **v2.0 Since:** v7.5.0
 **Status:** Production Ready
 **Last Updated:** 2026-02-26
 

--- a/docs/guides/EMAIL-TUTORIAL.md
+++ b/docs/guides/EMAIL-TUTORIAL.md
@@ -2035,5 +2035,5 @@ After this tutorial, you should be able to:
 ---
 
 *Last updated: 2026-02-26*
-*flow-cli version: 7.4.2 (em dispatcher v2.0)*
+*flow-cli version: 7.5.0 (em dispatcher v2.0)*
 *Tutorial version: 2.0*

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -85,4 +85,4 @@ tags:
 
 ---
 
-**v7.4.2** | [Home](../index.md)
+**v7.5.0** | [Home](../index.md)

--- a/docs/help/QUICK-REFERENCE.md
+++ b/docs/help/QUICK-REFERENCE.md
@@ -8,7 +8,7 @@ tags:
 
 **Purpose:** Single-page command lookup for all flow-cli features
 **Format:** Copy-paste ready with expected outputs
-**Version:** v7.4.2
+**Version:** v7.5.0
 **Last Updated:** 2026-02-21
 
 ---
@@ -1404,6 +1404,6 @@ mcp help
 
 ---
 
-**Version:** v7.4.2
+**Version:** v7.5.0
 **Last Updated:** 2026-02-21
 **Contributors:** See [CHANGELOG.md](../CHANGELOG.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,9 +26,9 @@ tags:
     ```
     **That's it!** No configuration required.
 
-!!! success "🎉 What's New in v7.4"
-    **31 Email Commands:** `em star`, `em thread`, `em snooze`, `em digest`, `em delete`, `em move`, `em flag`, `em todo` — full inbox management with `--pick` multi-select and AI backends.
-    **v7.4.2:** Homebrew install reduced from 75MB to 3.5MB. CI version guard prevents release mismatches.
+!!! success "🎉 What's New in v7.5"
+    **em v2.0:** Two-phase safety gate for send/reply, ICS calendar integration, IMAP watch, folder CRUD, enhanced attachments — plus 8 integration test fixes.
+    **v7.5.0:** Safety-first email with `em send --confirm`, `em calendar`, `em watch`, `em create-folder`.
     [→ Email Guide](guides/EMAIL-DISPATCHER-GUIDE.md){ .md-button }
     [→ Quick Reference](reference/REFCARD-EMAIL-DISPATCHER.md){ .md-button }
     [→ Changelog](CHANGELOG.md){ .md-button }
@@ -281,4 +281,4 @@ catch "idea"      # Quick capture
 
 ---
 
-**v7.4.2** · Pure ZSH · Zero Dependencies · MIT License
+**v7.5.0** · Pure ZSH · Zero Dependencies · MIT License

--- a/docs/reference/MASTER-API-REFERENCE.md
+++ b/docs/reference/MASTER-API-REFERENCE.md
@@ -8,7 +8,7 @@ tags:
 **Purpose:** Complete API documentation for all flow-cli library functions
 **Audience:** Developers, contributors, advanced users
 **Format:** Function signatures, parameters, return values, examples
-**Version:** v7.4.2
+**Version:** v7.5.0
 **Last Updated:** 2026-02-21
 
 ---
@@ -6420,7 +6420,7 @@ _em_ai_validate_extra_args <args_string>
 
 ## Change Log
 
-### em v2.0 (Current — flow-cli v7.4.2+)
+### em v2.0 (Current — flow-cli v7.5.0+)
 
 **Added:**
 - `_em_safety_gate` - Two-phase preview + `[y/N/e]` gate for all outgoing email
@@ -7412,7 +7412,7 @@ URL line is omitted when `$url` is empty or `"null"`.
 
 ---
 
-**Version:** v7.4.2
+**Version:** v7.5.0
 **Last Updated:** 2026-02-21
 **Auto-Generation:** Run `./scripts/generate-api-docs.sh` to update function index
 **Total Functions:** 880 (428 documented, 452 pending)

--- a/docs/reference/MASTER-ARCHITECTURE.md
+++ b/docs/reference/MASTER-ARCHITECTURE.md
@@ -3,7 +3,7 @@
 **Purpose:** Complete system architecture documentation for flow-cli
 **Audience:** Contributors, maintainers, advanced users
 **Format:** Design decisions, diagrams, implementation details
-**Version:** v7.4.2
+**Version:** v7.5.0
 **Last Updated:** 2026-02-21
 
 ---
@@ -1020,7 +1020,7 @@ graph TD
 
 ---
 
-**Version:** v7.4.2
+**Version:** v7.5.0
 **Last Updated:** 2026-02-21
 **Diagrams:** 8 Mermaid diagrams
 **Total:** 2,500+ lines

--- a/docs/reference/MASTER-DISPATCHER-GUIDE.md
+++ b/docs/reference/MASTER-DISPATCHER-GUIDE.md
@@ -10,7 +10,7 @@ tags:
 **Purpose:** Complete reference for all flow-cli dispatchers (15 + at bridge)
 **Audience:** All users (beginner → intermediate → advanced)
 **Format:** Progressive disclosure (basics → advanced features)
-**Version:** v7.4.2
+**Version:** v7.5.0
 **Last Updated:** 2026-02-21
 
 ---
@@ -3072,7 +3072,7 @@ als           # List all aliases by category
 
 **Domain:** Email management via himalaya CLI
 **File:** `lib/dispatchers/email-dispatcher.zsh` + `lib/em-himalaya.zsh`, `lib/em-ai.zsh`, `lib/em-cache.zsh`, `lib/em-render.zsh`, `lib/email-helpers.zsh`
-**Version:** v2.0 (flow-cli v7.4.2+)
+**Version:** v2.0 (flow-cli v7.5.0+)
 
 > **BREAKING CHANGE (v2.0):** `em send` and `em reply` now show a full preview before sending.
 > The confirmation prompt is `[y/N/e]` where `e` re-opens the editor. Use `--force` to bypass.
@@ -3339,6 +3339,6 @@ at stats
 
 ---
 
-**Version:** v7.4.2
+**Version:** v7.5.0
 **Last Updated:** 2026-02-22
 **Total:** 15 dispatchers + at bridge fully documented

--- a/docs/reference/REFCARD-DOCTOR.md
+++ b/docs/reference/REFCARD-DOCTOR.md
@@ -319,5 +319,5 @@ teach doctor --verbose
 
 ---
 
-**Version:** v7.4.2
+**Version:** v7.5.0
 **Last Updated:** 2026-02-21

--- a/docs/reference/REFCARD-EMAIL-DISPATCHER.md
+++ b/docs/reference/REFCARD-EMAIL-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `em` subcommands at a glance. For detailed guides, see linked documentation.
 >
-> **Version:** v2.0 (flow-cli v7.4.2+) | **Dispatcher:** `lib/dispatchers/email-dispatcher.zsh`
+> **Version:** v2.0 (flow-cli v7.5.0+) | **Dispatcher:** `lib/dispatchers/email-dispatcher.zsh`
 >
 > **BREAKING CHANGE (v2.0):** `em send` and `em reply` now show a full preview before sending.
 > Use `--force` to bypass and send without the confirmation step.
@@ -906,7 +906,7 @@ em ai claude                   # Use a known backend
 
 ---
 
-**Version:** v2.0 (em dispatcher) — flow-cli v7.4.2+
+**Version:** v2.0 (em dispatcher) — flow-cli v7.5.0+
 **Last Updated:** 2026-02-26
 **Commands:** 37 total (4 core + 2 search + 5 AI + 7 organize + 9 manage + 3 info + 6 util + 2 infra + 1 help)
 **Breaking Change:** `em send` / `em reply` preview before send. Use `--force` to bypass.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -93,4 +93,4 @@ tags:
 
 ---
 
-**v7.4.2** | [Home](../index.md)
+**v7.5.0** | [Home](../index.md)

--- a/docs/tutorials/37-em-v2-features.md
+++ b/docs/tutorials/37-em-v2-features.md
@@ -9,7 +9,7 @@ tags:
 
 em v2.0 ships five new capabilities on top of the core email workflow: a safety gate that previews every outbound email before it leaves, calendar event parsing from ICS attachments, a background IMAP IDLE watcher for desktop notifications, granular attachment handling, and folder management. This tutorial walks through each feature with real commands you can run.
 
-**Time:** 15 minutes | **Level:** Intermediate | **Requires:** flow-cli v7.4.2+, himalaya
+**Time:** 15 minutes | **Level:** Intermediate | **Requires:** flow-cli v7.5.0+, himalaya
 
 ## What You'll Learn
 

--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -141,7 +141,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="7.4.2"
+export FLOW_VERSION="7.5.0"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "7.4.2",
+  "version": "7.5.0",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Version bump from v7.4.2 to v7.5.0 across 21 files
- Required for GitHub release tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)