### PR TITLE
Release: v7.8.1 — full man-page set + version-sync guard

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -8,7 +8,7 @@
 ## Phase: v7.8.0 shipped → man-page refresh in progress
 ## Priority: 2
 ## Progress: 100
-## WIP: feature/manpage-refresh — spec + ORCHESTRATE committed (f0d4f378), awaiting implementation in a worktree session
+## WIP: feature/manpage-refresh — Waves 0-3 done (anti-drift guard + full v7.8.0 man-page set for all 15 dispatchers + at + release.sh .TH bump); Wave 4 (verify/docs/counts) in progress. ⚠ CLAUDE.md edited in both this dev session + worktree → expect a rebase conflict to resolve.
 
 ## Current Session (2026-06-03) — tok auto-sync spec + craft drive spec
 
@@ -303,7 +303,7 @@
 | Worktree | Branch | Status |
 |----------|--------|--------|
 | Main repo | `dev` | v7.8.0 released; index/QUICK-REF refreshed |
-| `~/.git-worktrees/flow-cli/manpage-refresh` | `feature/manpage-refresh` | ORCHESTRATE committed (f0d4f378) — man-page full refresh, awaiting impl in new session |
+| `~/.git-worktrees/flow-cli/manpage-refresh` | `feature/manpage-refresh` | Waves 0-3 done (f24760aa) — guard + full man-page set + release.sh bump; Wave 4 in progress |
 
 ---
 

--- a/.STATUS
+++ b/.STATUS
@@ -23,6 +23,10 @@
 - CI green → **squash-merged PR #452 to dev** (93ee5edd, one-time merge override of standing rule) → worktree + remote branch removed, dev synced
 - Diagnosed (separate) systemic fzf→exec hygiene gap: `cc wt pick`/`ccy`/`work+ccy` bypass v7.7.1 cleanup → SPEC-fzf-handoff-hygiene + test plan on dev
 - **Fixed hygiene gap on dev** (af1bf685, TDD): shared `_flow_tty_handoff_cleanup` in lib/core.zsh (/dev/tty-guarded), wired into all 3 pickers (pick/_proj_pick_worktree_path/_flow_pick_project); refactored pick() to use it; tok completion gh/push/repos; regression guard rewritten 9/9
+- Fixed pre-existing `test-cc-wt` stale assertion (checked `cc help` not `cc wt help`) → 20/20 (c22e1721)
+- Full suite verified: 58/58 suites (1 expected IMAP timeout)
+- `/craft:docs:update`: CHANGELOG [Unreleased] (both files, mirrored) + CLAUDE.md Principle #5 → shared helper (17fb5a14)
+- **Released v7.8.0** (token auto-sync + fzf terminal-hygiene): bump (927ac591) → PR #453 → merged to main (2d21b136) → tag + GitHub release → docs deployed (site=v7.8.0) → Homebrew formula v7.8.0 → CI green on main → dev synced. All downstream verified.
 
 ## Previous Session (2026-06-02) — v7.7.1 shipped
 

--- a/.STATUS
+++ b/.STATUS
@@ -3,12 +3,11 @@
 
 ## Project: flow-cli
 ## Type: zsh-plugin
-## Status: WIP
-## Focus: man-page full refresh (feature/manpage-refresh)
-## Phase: v7.8.0 shipped → man-page refresh in progress
+## Status: active
+## Focus: --help
+## Phase: Released (v7.8.1)
 ## Priority: 2
 ## Progress: 100
-## WIP: feature/manpage-refresh — Waves 0-3 done (anti-drift guard + full v7.8.0 man-page set for all 15 dispatchers + at + release.sh .TH bump); Wave 4 (verify/docs/counts) in progress. ⚠ CLAUDE.md edited in both this dev session + worktree → expect a rebase conflict to resolve.
 
 ## Current Session (2026-06-03) — tok auto-sync spec + craft drive spec
 
@@ -302,8 +301,7 @@
 
 | Worktree | Branch | Status |
 |----------|--------|--------|
-| Main repo | `dev` | v7.8.0 released; index/QUICK-REF refreshed |
-| `~/.git-worktrees/flow-cli/manpage-refresh` | `feature/manpage-refresh` | Waves 0-3 done (f24760aa) — guard + full man-page set + release.sh bump; Wave 4 in progress |
+| Main repo | `dev` | v7.8.1 — man-page set merged (#454); releasing |
 
 ---
 
@@ -338,7 +336,7 @@
 ---
 
 **Last Updated:** 2026-06-02
-**Status:** v7.8.0 SHIPPED | 59/59 tests passing (1 expected interactive/tmux timeout) | 15 dispatchers + at bridge | 211 test files | 12000+ test functions | 0 lint errors | 0 broken links
+**Status:** v7.8.1 SHIPPED | 59/59 tests passing (1 expected interactive/tmux timeout) | 15 dispatchers + at bridge | 211 test files | 12000+ test functions | 0 lint errors | 0 broken links
 ## wins: Fixed the regression bug (2026-06-03), --category fix squashed the bug (2026-06-03), fixed the bug (2026-06-03), Fixed the regression bug (2026-05-15), --category fix squashed the bug (2026-05-15)
 ## streak: 1
 ## last_active: 2026-06-03 23:12

--- a/.STATUS
+++ b/.STATUS
@@ -3,11 +3,12 @@
 
 ## Project: flow-cli
 ## Type: zsh-plugin
-## Status: active
-## Focus: --help
-## Phase: Released
+## Status: WIP
+## Focus: man-page full refresh (feature/manpage-refresh)
+## Phase: v7.8.0 shipped → man-page refresh in progress
 ## Priority: 2
 ## Progress: 100
+## WIP: feature/manpage-refresh — spec + ORCHESTRATE committed (f0d4f378), awaiting implementation in a worktree session
 
 ## Current Session (2026-06-03) — tok auto-sync spec + craft drive spec
 
@@ -337,7 +338,7 @@
 ---
 
 **Last Updated:** 2026-06-02
-**Status:** v7.8.0 SHIPPED | 58/58 tests passing (1 expected interactive/tmux timeout) | 15 dispatchers + at bridge | 210 test files | 12000+ test functions | 0 lint errors | 0 broken links
+**Status:** v7.8.0 SHIPPED | 🔄 WIP: man-page full refresh (feature/manpage-refresh) | 58/58 tests passing (1 expected interactive/tmux timeout) | 15 dispatchers + at bridge | 210 test files | 12000+ test functions | 0 lint errors | 0 broken links
 ## wins: Fixed the regression bug (2026-05-15), --category fix squashed the bug (2026-05-15), fixed the bug (2026-05-15), Fixed the regression bug (2026-05-14), --category fix squashed the bug (2026-05-14)
 ## streak: 1
 ## last_active: 2026-05-15 11:22

--- a/.STATUS
+++ b/.STATUS
@@ -338,7 +338,7 @@
 ---
 
 **Last Updated:** 2026-06-02
-**Status:** v7.8.0 SHIPPED | 🔄 WIP: man-page full refresh (feature/manpage-refresh) | 58/58 tests passing (1 expected interactive/tmux timeout) | 15 dispatchers + at bridge | 210 test files | 12000+ test functions | 0 lint errors | 0 broken links
-## wins: Fixed the regression bug (2026-05-15), --category fix squashed the bug (2026-05-15), fixed the bug (2026-05-15), Fixed the regression bug (2026-05-14), --category fix squashed the bug (2026-05-14)
+**Status:** v7.8.0 SHIPPED | 59/59 tests passing (1 expected interactive/tmux timeout) | 15 dispatchers + at bridge | 211 test files | 12000+ test functions | 0 lint errors | 0 broken links
+## wins: Fixed the regression bug (2026-06-03), --category fix squashed the bug (2026-06-03), fixed the bug (2026-06-03), Fixed the regression bug (2026-05-15), --category fix squashed the bug (2026-05-15)
 ## streak: 1
-## last_active: 2026-05-15 11:22
+## last_active: 2026-06-03 23:12

--- a/.STATUS
+++ b/.STATUS
@@ -301,7 +301,8 @@
 
 | Worktree | Branch | Status |
 |----------|--------|--------|
-| Main repo | `dev` | synced — tok auto-sync merged (93ee5edd) |
+| Main repo | `dev` | v7.8.0 released; index/QUICK-REF refreshed |
+| `~/.git-worktrees/flow-cli/manpage-refresh` | `feature/manpage-refresh` | ORCHESTRATE committed (f0d4f378) — man-page full refresh, awaiting impl in new session |
 
 ---
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,12 @@ jobs:
           zsh ./tests/test-flow.zsh
           bash ./tests/test-install.sh
 
+      - name: Man-page version-sync guard
+        run: |
+          cd ~/projects/dev-tools/flow-cli
+          # Anti-drift: fail if any flow-cli man page .TH version != FLOW_VERSION
+          zsh ./tests/test-manpage-version-sync.zsh
+
       - name: Performance Summary
         if: always()
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Full man-page set for all 15 dispatchers + the `at` bridge** — `man/man1/`
+  brought from a partial set frozen at flow-cli 3.0.0 up to v7.8.0. New pages:
+  `cc`, `wt`, `tm`, `v`, `prompt`, `tok`, `sec`, `dots`, `teach`, `em`, `at` (1).
+  `flow.1` SMART DISPATCHERS rebuilt to list all 15 dispatchers + `at`;
+  `g`/`r`/`qu`/`mcp`/`obs` refreshed and de-drifted. `tok.1` documents
+  `tok sync push/repos/gh`, `--no-sync`, and `FLOW_TOK_AUTOSYNC`.
+- **Man-page version-sync CI guard** (`tests/test-manpage-version-sync.zsh`) —
+  source-scan test (wired into `run-all.sh` + the CI workflow) that fails if any
+  flow-cli man page's `.TH` version diverges from `FLOW_VERSION`, preventing the
+  silent re-freeze that left the pages five releases stale. Scopes to `flow-cli`
+  pages so vendored pages (`scribe.1`) are ignored. `release.sh` now auto-bumps
+  the `.TH` lines, making the guard a backstop rather than the primary path. The
+  same guard also enforces man-page **coverage**: every dispatcher (derived from
+  the public command functions, aliases excluded) must have a `man/man1/<cmd>.1`,
+  and no flow-cli page may be an orphan — so adding a dispatcher without its page
+  (or removing one but leaving the page) fails CI.
+
 ## [7.8.0] — 2026-06-04 — token auto-sync + fzf terminal-hygiene
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.8.1] — 2026-06-04 — full man-page set + version-sync guard
+
 ### Added
 
 - **Full man-page set for all 15 dispatchers + the `at` bridge** — `man/man1/`
-  brought from a partial set frozen at flow-cli 3.0.0 up to v7.8.0. New pages:
+  brought from a partial set frozen at flow-cli 3.0.0 up to v7.8.1. New pages:
   `cc`, `wt`, `tm`, `v`, `prompt`, `tok`, `sec`, `dots`, `teach`, `em`, `at` (1).
   `flow.1` SMART DISPATCHERS rebuilt to list all 15 dispatchers + `at`;
   `g`/`r`/`qu`/`mcp`/`obs` refreshed and de-drifted. `tok.1` documents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,23 +112,9 @@ at <cmd>      # Atlas bridge (project intelligence, optional)
 
 ### Teaching Subcommands
 
-`teach analyze`, `teach init`, `teach deploy`, `teach doctor`, `teach exam`, `teach macros`, `teach map`, `teach plan`, `teach style`, `teach templates`, `teach prompt`, `teach cache`, `teach profiles`, `teach migrate`, `teach validate`, `teach solution`, `teach sync`, `teach validate-r`, `teach config check`, `teach config diff`, `teach config show`, `teach config scaffold`
+`teach` has 20+ subcommands (analyze, init, deploy, doctor, exam, macros, map, plan, style, templates, prompt, cache, profiles, migrate, validate, solution, sync, validate-r, config check/diff/show/scaffold). Doctor is two-mode (quick < 3s / `--full` 11 categories); deploy supports `--direct`/`--dry-run`/`--sync`/`--rollback` with `$$` math preflight.
 
-- **Doctor (v2):** Two-mode architecture — quick (default, < 3s) and full (`--full`, 11 categories)
-  - Quick mode: CLI deps, R + renv, config, git, Scholar config (5 categories)
-  - Full mode: + per-package R checks, quarto ext, scholar, hooks, cache, macros, style
-  - Flags: `--full`, `--brief`, `--fix`, `--json`, `--ci`, `--verbose`
-  - `--fix` offers renv vs system install choice for R packages
-  - `--ci` exits non-zero on failure, no color, machine-readable output
-  - Health dot shown on `teach` startup (refreshed on next `teach doctor` run)
-- **Deploy:** `teach deploy --direct` (8-15s direct merge) or `teach deploy` (PR workflow)
-- **Deploy preflight:** Display math `$$` validation (blank lines, unclosed blocks) — also runs at pre-commit via lint-staged
-- **Deploy extras:** `--dry-run`, `--ci`, `--history [N]`, `--rollback [N]`, `--sync`
-- **Deploy sync:** `teach deploy --sync` merges production into draft (ff-only first, then regular merge). Auto back-merge runs after `--direct` deploys to prevent false conflict detection.
-- **Templates:** `.flow/templates/` (content, prompts, metadata, checklists)
-- **Macros:** `teach macros list|sync|export` (LaTeX notation consistency)
-- **Plans:** `teach plan create|list|show|edit|delete` (lesson plan CRUD)
-- **Prompts:** `teach prompt list|show|edit|validate|export` (3-tier resolution)
+→ Full reference: [`docs/guides/TEACH-DEPLOY-GUIDE.md`](docs/guides/TEACH-DEPLOY-GUIDE.md), [`docs/reference/REFCARD-DOCTOR.md`](docs/reference/REFCARD-DOCTOR.md)
 
 ---
 
@@ -173,36 +159,11 @@ flow-cli/
 
 ## Development
 
-### Adding New Commands
+**Add a command:** core → `commands/<name>.zsh`; dispatcher subcommand → `lib/dispatchers/<name>-dispatcher.zsh`. Use helpers (`_flow_log_*`, `_flow_find_project_root`, `_flow_detect_project_type`); add `completions/_<name>`; every dispatcher MUST have a `_<cmd>_help()` using `lib/core.zsh` colors. New dispatcher = a `command + keyword + options` case block.
 
-1. Core command -> `commands/<name>.zsh`; Dispatcher subcommand -> `lib/dispatchers/<name>-dispatcher.zsh`
-2. Use helpers: `_flow_log_success`, `_flow_log_error`, `_flow_find_project_root`, `_flow_detect_project_type`
-3. Add completion in `completions/_<commandname>`
-4. Every dispatcher MUST have `_<cmd>_help()` function using color scheme from `lib/core.zsh`
+**After changes:** update `MASTER-DISPATCHER-GUIDE.md` + `QUICK-REFERENCE.md` + `mkdocs.yml`. **Release:** `./scripts/release.sh X.Y.Z` → commit → tag → push (bumps `flow.plugin.zsh` FLOW_VERSION, `package.json`, `README.md`, `CLAUDE.md`). Docs deploy automatically (don't run `mkdocs gh-deploy`).
 
-### Adding New Dispatcher
-
-```bash
-x() {
-    case "$1" in
-        action1) shift; _x_action1 "$@" ;;
-        help|--help|-h) _x_help ;;
-        *) _x_help ;;
-    esac
-}
-```
-
-Update: `MASTER-DISPATCHER-GUIDE.md`, `QUICK-REFERENCE.md`, `mkdocs.yml`
-
-### Common Tasks
-
-| Task              | Steps                                                                                          |
-| ----------------- | ---------------------------------------------------------------------------------------------- |
-| Update dispatcher | Edit `lib/dispatchers/<name>-dispatcher.zsh` -> update `_<name>_help()` -> test -> update docs |
-| Deploy docs       | `mkdocs gh-deploy --force`                                                                     |
-| Create release    | `./scripts/release.sh X.Y.Z` -> commit -> tag -> push                                          |
-
-**Release script updates:** `flow.plugin.zsh` (FLOW_VERSION), `package.json`, `README.md`, `CLAUDE.md`, `CC-DISPATCHER-REFERENCE.md`
+→ Dispatcher template + patterns: [`docs/reference/MASTER-DISPATCHER-GUIDE.md`](docs/reference/MASTER-DISPATCHER-GUIDE.md)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ flow-cli/
 ├── docs/                     # Documentation (MkDocs)
 │   └── internal/             # Internal conventions & contributor templates
 ├── scripts/                  # Standalone validators (check-math.zsh)
-├── tests/                    # 210 test files, 12000+ test functions
+├── tests/                    # 211 test files, 12000+ test functions
 │   └── fixtures/demo-course/ # STAT-101 demo course for E2E
 └── .archive/                 # Archived Node.js CLI
 ```
@@ -165,6 +165,8 @@ flow-cli/
 
 → Dispatcher template + patterns: [`docs/reference/MASTER-DISPATCHER-GUIDE.md`](docs/reference/MASTER-DISPATCHER-GUIDE.md)
 
+**New dispatcher = new man page:** add `man/man1/<cmd>.1` (model `g.1`); the guard `tests/test-manpage-version-sync.zsh` fails CI on a missing page or `.TH` version drift. Details: [`ZSH-COMMANDS-HELP.md`](docs/internal/conventions/code/ZSH-COMMANDS-HELP.md) (Man Pages).
+
 ---
 
 ## Architecture Principles
@@ -179,7 +181,7 @@ flow-cli/
 
 ## Testing
 
-**210 test files, 12000+ test functions.** Run: `./tests/run-all.sh` (58/58 passing, 1 expected interactive/tmux timeout) or individual suites in `tests/`.
+**211 test files, 12000+ test functions.** Run: `./tests/run-all.sh` (59/59 passing, 1 expected interactive/tmux timeout) or individual suites in `tests/`.
 
 See `docs/guides/TESTING.md` for patterns, mocks, assertions, TDD workflow.
 
@@ -207,7 +209,7 @@ export FLOW_DEBUG=1                          # Debug mode
 
 ## Current Status
 
-**Version:** v7.8.0 | **Tests:** 12000+ (58/58 suite, 1 interactive timeout) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.8.0 | **Tests:** 12000+ (59/59 suite, 1 interactive timeout) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,56 +37,12 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 ### Mandatory Workflow Steps
 
-#### 1. Plan on `dev` Branch
-
-**Before writing any code:**
-
-````bash
-git checkout dev && git pull origin dev
-```diff
-
-- Analyze requirements on `dev` branch
-- Create comprehensive implementation plan
-- Document in `docs/specs/SPEC-*.md`
-- **Wait for user approval**
-- Commit approved plan to `dev`
-
-**Constraint:** Never write feature code on `dev` branch
-
-#### 2. Create Worktree + Orchestration Plan
-
-```bash
-git worktree add ~/.git-worktrees/flow-cli/<feature> -b feature/<feature> dev
-git worktree list
-```zsh
-
-After creating the worktree, write an `ORCHESTRATE-<feature>.md` file **to the worktree** with the full implementation plan (task list, file changes, verification steps). Commit it to the feature branch.
-
-#### 3. STOP - NEW Session Required
-
-**CRITICAL:** Do NOT start implementing in the worktree from the dev/planning session. The dev session's job ends after creating the worktree and committing the orchestration plan. Tell user to `cd` into worktree and start a new `claude` session.
-
-#### 4. Atomic Development (In Worktree)
-
-**Conventional Commits:** `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
-
-**Before each commit:** Run `./tests/run-all.sh`, verify `source flow.plugin.zsh`
-
-#### 5. Integration (feature -> dev)
-
-```bash
-git fetch origin dev && git rebase origin/dev
-./tests/run-all.sh
-gh pr create --base dev
-# After merge: git worktree remove ~/.git-worktrees/flow-cli/<feature>
-```bash
-
-#### 6. Release (dev -> main)
-
-```bash
-gh pr create --base main --head dev --title "Release vX.Y.Z"
-git tag -a vX.Y.Z -m "vX.Y.Z" && git push --tags
-```diff
+1. **Plan on `dev`** — `git checkout dev && git pull origin dev`. Analyze, write a `docs/specs/SPEC-*.md`, wait for approval, commit the spec to `dev`. **Never write feature code on `dev`.**
+2. **Worktree + plan** — `git worktree add ~/.git-worktrees/flow-cli/<feature> -b feature/<feature> dev`, then write `ORCHESTRATE-<feature>.md` **to the worktree** (task list, file changes, verification) and commit it to the feature branch.
+3. **STOP — new session required.** The dev/planning session's job ends after the worktree + ORCHESTRATE commit. Do NOT implement from it; tell the user to `cd` into the worktree and start a new `claude` session.
+4. **Atomic development (in worktree)** — conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`). Before each commit: `./tests/run-all.sh` + verify `source flow.plugin.zsh`.
+5. **Integrate** — `git fetch origin dev && git rebase origin/dev` → `./tests/run-all.sh` → `gh pr create --base dev`. After merge: `git worktree remove ...`.
+6. **Release (dev → main)** — `gh pr create --base main --head dev --title "Release vX.Y.Z"`, then tag `vX.Y.Z` and push tags.
 
 ### ABORT Conditions
 
@@ -120,7 +76,7 @@ catch <text>      # Quick capture
 js                # Just start (auto-picks project)
 flow doctor       # Health check
 flow doctor --fix # Interactive install missing tools
-```text
+```
 
 ### Dopamine Features
 
@@ -129,7 +85,7 @@ win <text>        # Log accomplishment (auto-categorized)
 yay               # Show recent wins
 yay --week        # Weekly summary + graph
 flow goal set 3   # Set daily win target
-```text
+```
 
 ### Active Dispatchers (15)
 
@@ -144,7 +100,7 @@ tm <cmd>      # Terminal manager
 wt <cmd>      # Worktree management
 dots <cmd>    # Dotfile management (chezmoi)
 sec <cmd>     # Secret management (Keychain/Bitwarden)
-tok <cmd>     # Token management (create/rotate/expire)
+tok <cmd>     # Token management (create/rotate/expire/sync→GH secrets)
 teach <cmd>   # Teaching workflow
 prompt <cmd>  # Prompt engine switcher
 v <cmd>       # Vibe coding mode
@@ -197,7 +153,7 @@ flow-cli/
 ├── tests/                    # 210 test files, 12000+ test functions
 │   └── fixtures/demo-course/ # STAT-101 demo course for E2E
 └── .archive/                 # Archived Node.js CLI
-```zsh
+```
 
 ### Key Files
 
@@ -234,7 +190,7 @@ x() {
         *) _x_help ;;
     esac
 }
-```diff
+```
 
 Update: `MASTER-DISPATCHER-GUIDE.md`, `QUICK-REFERENCE.md`, `mkdocs.yml`
 
@@ -271,7 +227,7 @@ See `docs/guides/TESTING.md` for patterns, mocks, assertions, TDD workflow.
 ## Documentation
 
 **Site:** https://Data-Wise.github.io/flow-cli/
-**Build:** `mkdocs serve` (local) | `mkdocs gh-deploy --force` (deploy)
+**Build:** `mkdocs serve` (local). **Deploy is automatic** — `docs.yml` CI deploys to gh-pages on push to `main` (don't run `mkdocs gh-deploy`; the branch guard blocks the gh-pages push).
 **Key docs:** `docs/guides/`, `docs/reference/`, `docs/help/QUICK-REFERENCE.md`, `docs/CONVENTIONS.md`
 **Internal:** `docs/internal/` (conventions, contributor templates — excluded from site nav)
 
@@ -284,7 +240,7 @@ export FLOW_PROJECTS_ROOT="$HOME/projects"  # Project root
 export FLOW_ATLAS_ENABLED="auto"             # Atlas (auto|yes|no)
 export FLOW_QUIET=1                          # Suppress welcome
 export FLOW_DEBUG=1                          # Debug mode
-````
+```
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management. Zero dependencies. Standalone (works without Oh-My-Zsh or any plugin manager).
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Current Version:** v7.8.0
+- **Current Version:** v7.8.1
 - **Install:** Homebrew (recommended), or any plugin manager
 - **Source:** `source /opt/homebrew/opt/flow-cli/flow.plugin.zsh` (via Homebrew)
 - **Optional:** Atlas integration for enhanced state management
@@ -209,8 +209,8 @@ export FLOW_DEBUG=1                          # Debug mode
 
 ## Current Status
 
-**Version:** v7.8.0 | **Tests:** 12000+ (59/59 suite, 1 interactive timeout) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.8.1 | **Tests:** 12000+ (59/59 suite, 1 interactive timeout) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 
-**Last Updated:** 2026-06-04 (v7.8.0)
+**Last Updated:** 2026-06-04 (v7.8.1)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ## [Unreleased]
 
+## [7.8.1] — 2026-06-04 — full man-page set + version-sync guard
+
+### Added
+
+- **Full man-page set for all 15 dispatchers + the `at` bridge** — `man/man1/`
+  brought from a partial set frozen at flow-cli 3.0.0 up to v7.8.1. New pages:
+  `cc`, `wt`, `tm`, `v`, `prompt`, `tok`, `sec`, `dots`, `teach`, `em`, `at` (1).
+  `flow.1` SMART DISPATCHERS rebuilt to list all 15 dispatchers + `at`;
+  `g`/`r`/`qu`/`mcp`/`obs` refreshed and de-drifted. `tok.1` documents
+  `tok sync push/repos/gh`, `--no-sync`, and `FLOW_TOK_AUTOSYNC`.
+- **Man-page version-sync CI guard** (`tests/test-manpage-version-sync.zsh`) —
+  source-scan test (wired into `run-all.sh` + the CI workflow) that fails if any
+  flow-cli man page's `.TH` version diverges from `FLOW_VERSION`, preventing the
+  silent re-freeze that left the pages five releases stale. Scopes to `flow-cli`
+  pages so vendored pages (`scribe.1`) are ignored. `release.sh` now auto-bumps
+  the `.TH` lines, making the guard a backstop rather than the primary path. The
+  same guard also enforces man-page **coverage**: every dispatcher must have a
+  `man/man1/<cmd>.1`, and no flow-cli page may be an orphan.
+
 ## [7.8.0] — 2026-06-04 — token auto-sync + fzf terminal-hygiene
 
 ### Added

--- a/docs/architecture/SCHOLAR-ENHANCEMENT-ARCHITECTURE.md
+++ b/docs/architecture/SCHOLAR-ENHANCEMENT-ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Scholar Enhancement Architecture
 
 **Feature:** Teaching Content Generation System
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Date:** 2026-01-17
 
 ---
@@ -747,4 +747,4 @@ teach slides -w 8 --style computational
 
 **Last Updated:** 2026-02-27
 **Status:** Production Ready
-**Version:** v7.7.1
+**Version:** v7.8.0

--- a/docs/architecture/SCHOLAR-ENHANCEMENT-ARCHITECTURE.md
+++ b/docs/architecture/SCHOLAR-ENHANCEMENT-ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Scholar Enhancement Architecture
 
 **Feature:** Teaching Content Generation System
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Date:** 2026-01-17
 
 ---
@@ -747,4 +747,4 @@ teach slides -w 8 --style computational
 
 **Last Updated:** 2026-02-27
 **Status:** Production Ready
-**Version:** v7.8.0
+**Version:** v7.8.1

--- a/docs/architecture/TEACHING-DATES-ARCHITECTURE.md
+++ b/docs/architecture/TEACHING-DATES-ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Teaching Dates Architecture
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Status:** Complete
 **Last Updated:** 2026-02-27
 
@@ -966,5 +966,5 @@ teach dates import-calendar university-calendar.ics
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Status:** Complete

--- a/docs/architecture/TEACHING-DATES-ARCHITECTURE.md
+++ b/docs/architecture/TEACHING-DATES-ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Teaching Dates Architecture
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Status:** Complete
 **Last Updated:** 2026-02-27
 
@@ -966,5 +966,5 @@ teach dates import-calendar university-calendar.ics
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Status:** Complete

--- a/docs/diagrams/TEACHING-V3-WORKFLOWS.md
+++ b/docs/diagrams/TEACHING-V3-WORKFLOWS.md
@@ -470,7 +470,7 @@ flowchart TD
 ---
 
 **Generated:** 2026-02-09
-**Version:** v7.7.1 (Teaching Workflow v3.0)
+**Version:** v7.8.0 (Teaching Workflow v3.0)
 **Total Diagrams:** 8
 
 These diagrams provide comprehensive visual documentation for all major Teaching Workflow features.

--- a/docs/diagrams/TEACHING-V3-WORKFLOWS.md
+++ b/docs/diagrams/TEACHING-V3-WORKFLOWS.md
@@ -470,7 +470,7 @@ flowchart TD
 ---
 
 **Generated:** 2026-02-09
-**Version:** v7.8.0 (Teaching Workflow v3.0)
+**Version:** v7.8.1 (Teaching Workflow v3.0)
 **Total Diagrams:** 8
 
 These diagrams provide comprehensive visual documentation for all major Teaching Workflow features.

--- a/docs/guides/ATLAS-INTEGRATION-GUIDE.md
+++ b/docs/guides/ATLAS-INTEGRATION-GUIDE.md
@@ -335,4 +335,4 @@ export FLOW_ATLAS_ENABLED=no
 ---
 
 **Last Updated:** 2026-02-22
-**Version:** v7.7.1
+**Version:** v7.8.0

--- a/docs/guides/ATLAS-INTEGRATION-GUIDE.md
+++ b/docs/guides/ATLAS-INTEGRATION-GUIDE.md
@@ -335,4 +335,4 @@ export FLOW_ATLAS_ENABLED=no
 ---
 
 **Last Updated:** 2026-02-22
-**Version:** v7.8.0
+**Version:** v7.8.1

--- a/docs/guides/ATLAS-INTEGRATION-GUIDE.md
+++ b/docs/guides/ATLAS-INTEGRATION-GUIDE.md
@@ -17,7 +17,7 @@ flow-cli and Atlas CLI are separate tools that work together:
 
 flow-cli handles the hot path (session start, capture, breadcrumbs) with ZSH-native code. Atlas handles the warm path (stats, planning, parking) with its richer data model.
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────┐
 │                        User Shell                            │
 ├──────────────────────────────────────────────────────────────┤
@@ -108,7 +108,7 @@ The `at()` function is an **enhanced bridge**, not a dispatcher. This distinctio
 
 ### Command Routing
 
-```
+```text
 at <command>
     │
     ├── help/--help/-h ──► _at_help()         [Always local]
@@ -177,7 +177,7 @@ The interactive help browser (`flow help --browse`) includes `at` in the command
 
 `_flow_list_projects()` tries Atlas first:
 
-```
+```text
 atlas project list --format=names
     │
     ├── Returns plain text ──► Use it

--- a/docs/guides/BACKUP-SYSTEM-GUIDE.md
+++ b/docs/guides/BACKUP-SYSTEM-GUIDE.md
@@ -1,6 +1,6 @@
 # Backup System Guide
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-01-21
 
 ---
@@ -959,5 +959,5 @@ See `lib/backup-helpers.zsh` for implementation details.
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-01-21

--- a/docs/guides/BACKUP-SYSTEM-GUIDE.md
+++ b/docs/guides/BACKUP-SYSTEM-GUIDE.md
@@ -1,6 +1,6 @@
 # Backup System Guide
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-01-21
 
 ---
@@ -959,5 +959,5 @@ See `lib/backup-helpers.zsh` for implementation details.
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-01-21

--- a/docs/guides/CONFIG-MANAGEMENT-WORKFLOW.md
+++ b/docs/guides/CONFIG-MANAGEMENT-WORKFLOW.md
@@ -730,5 +730,5 @@ flow config profile load adhd
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Related:** [flow.md](../commands/flow.md), [plugin guide](./PLUGIN-MANAGEMENT-WORKFLOW.md)

--- a/docs/guides/CONFIG-MANAGEMENT-WORKFLOW.md
+++ b/docs/guides/CONFIG-MANAGEMENT-WORKFLOW.md
@@ -730,5 +730,5 @@ flow config profile load adhd
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Related:** [flow.md](../commands/flow.md), [plugin guide](./PLUGIN-MANAGEMENT-WORKFLOW.md)

--- a/docs/guides/COURSE-PLANNING-BEST-PRACTICES.md
+++ b/docs/guides/COURSE-PLANNING-BEST-PRACTICES.md
@@ -1,6 +1,6 @@
 # Course Planning Best Practices: A Research-Based Guide
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-01-19
 **Target Audience:** Instructors using flow-cli for systematic course design
 **Status:** Phase 1 Complete (Sections 1-2)
@@ -2498,7 +2498,7 @@ teach analytics --outcomes         # Outcome achievement analysis
 
 # Document Metadata
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Created:** 2026-01-19
 **Last Updated:** 2026-01-19
 **Authors:** flow-cli development team

--- a/docs/guides/COURSE-PLANNING-BEST-PRACTICES.md
+++ b/docs/guides/COURSE-PLANNING-BEST-PRACTICES.md
@@ -1,6 +1,6 @@
 # Course Planning Best Practices: A Research-Based Guide
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-01-19
 **Target Audience:** Instructors using flow-cli for systematic course design
 **Status:** Phase 1 Complete (Sections 1-2)
@@ -2498,7 +2498,7 @@ teach analytics --outcomes         # Outcome achievement analysis
 
 # Document Metadata
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Created:** 2026-01-19
 **Last Updated:** 2026-01-19
 **Authors:** flow-cli development team

--- a/docs/guides/DEVELOPER-GUIDE.md
+++ b/docs/guides/DEVELOPER-GUIDE.md
@@ -1,6 +1,6 @@
 # flow-cli Developer Guide
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 **Audience:** Contributors, Plugin Developers, Advanced Users
 
@@ -961,4 +961,4 @@ test: add regression test for worktree detection
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.8.0
+**Version:** v7.8.1

--- a/docs/guides/DEVELOPER-GUIDE.md
+++ b/docs/guides/DEVELOPER-GUIDE.md
@@ -1,6 +1,6 @@
 # flow-cli Developer Guide
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 **Audience:** Contributors, Plugin Developers, Advanced Users
 
@@ -961,4 +961,4 @@ test: add regression test for worktree detection
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.7.1
+**Version:** v7.8.0

--- a/docs/guides/DOCTOR-TOKEN-USER-GUIDE.md
+++ b/docs/guides/DOCTOR-TOKEN-USER-GUIDE.md
@@ -1,6 +1,6 @@
 # Doctor Token Enhancement - User Guide
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 
 ---
@@ -633,5 +633,5 @@ Found a bug or have a feature request?
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Maintainer:** flow-cli team

--- a/docs/guides/DOCTOR-TOKEN-USER-GUIDE.md
+++ b/docs/guides/DOCTOR-TOKEN-USER-GUIDE.md
@@ -1,6 +1,6 @@
 # Doctor Token Enhancement - User Guide
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 
 ---
@@ -633,5 +633,5 @@ Found a bug or have a feature request?
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Maintainer:** flow-cli team

--- a/docs/guides/DOT-WORKFLOW.md
+++ b/docs/guides/DOT-WORKFLOW.md
@@ -507,5 +507,5 @@ Run: sec unlock
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **See Also:** [Dispatcher Reference](../reference/MASTER-DISPATCHER-GUIDE.md#dots-dispatcher) | [Tutorial](../tutorials/12-dot-dispatcher.md)

--- a/docs/guides/DOT-WORKFLOW.md
+++ b/docs/guides/DOT-WORKFLOW.md
@@ -507,5 +507,5 @@ Run: sec unlock
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **See Also:** [Dispatcher Reference](../reference/MASTER-DISPATCHER-GUIDE.md#dots-dispatcher) | [Tutorial](../tutorials/12-dot-dispatcher.md)

--- a/docs/guides/INTELLIGENT-CONTENT-ANALYSIS.md
+++ b/docs/guides/INTELLIGENT-CONTENT-ANALYSIS.md
@@ -1,6 +1,6 @@
 # Intelligent Content Analysis Guide
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-01-22
 
 ---

--- a/docs/guides/INTELLIGENT-CONTENT-ANALYSIS.md
+++ b/docs/guides/INTELLIGENT-CONTENT-ANALYSIS.md
@@ -1,6 +1,6 @@
 # Intelligent Content Analysis Guide
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-01-22
 
 ---

--- a/docs/guides/QUALITY-GATES.md
+++ b/docs/guides/QUALITY-GATES.md
@@ -9,7 +9,7 @@ tags:
 
 > Every validation layer in flow-cli, from keystroke to production.
 >
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 
 ---
 
@@ -132,7 +132,7 @@ npm run lint:fix
 | Runner | Ubuntu latest |
 | Tests | `test-flow.zsh` (smoke), `test-install.sh` |
 
-Runs core smoke tests in a clean Ubuntu environment with mock project structure. Full test suite (205 files, 12000+ functions) runs locally via `./tests/run-all.sh`.
+Runs core smoke tests in a clean Ubuntu environment with mock project structure. Full test suite (210 files, 12000+ functions) runs locally via `./tests/run-all.sh`.
 
 ### Install Script Tests (`release.yml`)
 
@@ -239,4 +239,4 @@ Areas where validation could be added in the future:
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.7.1
+**Version:** v7.8.0

--- a/docs/guides/QUALITY-GATES.md
+++ b/docs/guides/QUALITY-GATES.md
@@ -9,7 +9,7 @@ tags:
 
 > Every validation layer in flow-cli, from keystroke to production.
 >
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 
 ---
 
@@ -239,4 +239,4 @@ Areas where validation could be added in the future:
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.8.0
+**Version:** v7.8.1

--- a/docs/guides/QUARTO-WORKFLOW-PHASE-2-GUIDE.md
+++ b/docs/guides/QUARTO-WORKFLOW-PHASE-2-GUIDE.md
@@ -6,7 +6,7 @@ tags:
 
 # Quarto Workflow Phase 2 Guide
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 **Status:** Production Ready
 

--- a/docs/guides/QUARTO-WORKFLOW-PHASE-2-GUIDE.md
+++ b/docs/guides/QUARTO-WORKFLOW-PHASE-2-GUIDE.md
@@ -6,7 +6,7 @@ tags:
 
 # Quarto Workflow Phase 2 Guide
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 **Status:** Production Ready
 

--- a/docs/guides/SCHOLAR-WRAPPERS-GUIDE.md
+++ b/docs/guides/SCHOLAR-WRAPPERS-GUIDE.md
@@ -2,7 +2,7 @@
 
 > Complete documentation for the 9 AI content generation commands in the teach system.
 >
-> **Version:** v7.7.1 | **Prerequisites:** Scholar plugin, teach-config.yml
+> **Version:** v7.8.0 | **Prerequisites:** Scholar plugin, teach-config.yml
 
 ## Table of Contents
 
@@ -1311,6 +1311,6 @@ teach lecture "Topic" --week 5 --math
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-02
 **Commands Documented:** 9 Scholar wrappers

--- a/docs/guides/SCHOLAR-WRAPPERS-GUIDE.md
+++ b/docs/guides/SCHOLAR-WRAPPERS-GUIDE.md
@@ -2,7 +2,7 @@
 
 > Complete documentation for the 9 AI content generation commands in the teach system.
 >
-> **Version:** v7.8.0 | **Prerequisites:** Scholar plugin, teach-config.yml
+> **Version:** v7.8.1 | **Prerequisites:** Scholar plugin, teach-config.yml
 
 ## Table of Contents
 
@@ -1311,6 +1311,6 @@ teach lecture "Topic" --week 5 --math
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-02
 **Commands Documented:** 9 Scholar wrappers

--- a/docs/guides/TEACH-DEPLOY-GUIDE.md
+++ b/docs/guides/TEACH-DEPLOY-GUIDE.md
@@ -8,7 +8,7 @@ tags:
 
 > Deploy your course website from local preview to production with confidence.
 >
-> **Version:** v7.7.1 | **Command:** `teach deploy`
+> **Version:** v7.8.0 | **Command:** `teach deploy`
 
 ![teach deploy v2 Demo](../demos/tutorials/tutorial-teach-deploy.gif)
 
@@ -1237,4 +1237,4 @@ The deployment summary box now includes a direct link to your GitHub Actions pag
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.7.1
+**Version:** v7.8.0

--- a/docs/guides/TEACH-DEPLOY-GUIDE.md
+++ b/docs/guides/TEACH-DEPLOY-GUIDE.md
@@ -8,7 +8,7 @@ tags:
 
 > Deploy your course website from local preview to production with confidence.
 >
-> **Version:** v7.8.0 | **Command:** `teach deploy`
+> **Version:** v7.8.1 | **Command:** `teach deploy`
 
 ![teach deploy v2 Demo](../demos/tutorials/tutorial-teach-deploy.gif)
 
@@ -1237,4 +1237,4 @@ The deployment summary box now includes a direct link to your GitHub Actions pag
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.8.0
+**Version:** v7.8.1

--- a/docs/guides/TEACHING-TROUBLESHOOTING.md
+++ b/docs/guides/TEACHING-TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 > Quick fixes for common issues with the teach dispatcher.
 >
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 > **Last Updated:** 2026-02-27
 
 ---

--- a/docs/guides/TEACHING-TROUBLESHOOTING.md
+++ b/docs/guides/TEACHING-TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 > Quick fixes for common issues with the teach dispatcher.
 >
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 > **Last Updated:** 2026-02-27
 
 ---

--- a/docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md
+++ b/docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md
@@ -6,7 +6,7 @@ tags:
 
 # Teaching Workflow v3.0 Guide
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 **Target Audience:** Instructors using flow-cli for course management
 
@@ -2128,5 +2128,5 @@ teach init --config template.yml
 
 ---
 
-**Version:** v7.8.0 (Teaching Workflow v3.0)
+**Version:** v7.8.1 (Teaching Workflow v3.0)
 **Last Updated:** 2026-02-27

--- a/docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md
+++ b/docs/guides/TEACHING-WORKFLOW-V3-GUIDE.md
@@ -6,7 +6,7 @@ tags:
 
 # Teaching Workflow v3.0 Guide
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 **Target Audience:** Instructors using flow-cli for course management
 
@@ -2128,5 +2128,5 @@ teach init --config template.yml
 
 ---
 
-**Version:** v7.7.1 (Teaching Workflow v3.0)
+**Version:** v7.8.0 (Teaching Workflow v3.0)
 **Last Updated:** 2026-02-27

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -263,7 +263,7 @@ zsh tests/test-work.zsh
 ./tests/run-all.sh
 ```
 
-59 suites, ~12000 assertions. Expected: 58/58 pass, 1 timeout (IMAP connectivity).
+60 suites, ~12000 assertions. Expected: 59/59 pass, 1 timeout (IMAP connectivity).
 
 ### Dogfood Quality Check
 
@@ -359,4 +359,4 @@ When adding new functionality:
 
 **Established:** v5.0.0 (2026-01-11)
 **Overhauled:** v7.4.0 (2026-02-16) — shared framework, mock registry, dogfood scanner
-**Test Count:** 210 test files, 12000+ assertions, 58/58 suites passing
+**Test Count:** 211 test files, 12000+ assertions, 59/59 suites passing

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -85,4 +85,4 @@ tags:
 
 ---
 
-**v7.7.1** | [Home](../index.md)
+**v7.8.0** | [Home](../index.md)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -85,4 +85,4 @@ tags:
 
 ---
 
-**v7.8.0** | [Home](../index.md)
+**v7.8.1** | [Home](../index.md)

--- a/docs/help/QUICK-REFERENCE.md
+++ b/docs/help/QUICK-REFERENCE.md
@@ -11,8 +11,8 @@ tags:
 
 **Purpose:** Single-page command lookup for all flow-cli features
 **Format:** Copy-paste ready with expected outputs
-**Version:** v7.7.1
-**Last Updated:** 2026-02-21
+**Version:** v7.8.0
+**Last Updated:** 2026-06-04
 
 ---
 
@@ -1578,6 +1578,6 @@ mcp help
 
 ---
 
-**Version:** v7.7.1
-**Last Updated:** 2026-02-21
+**Version:** v7.8.0
+**Last Updated:** 2026-06-04
 **Contributors:** See [CHANGELOG.md](../CHANGELOG.md)

--- a/docs/help/QUICK-REFERENCE.md
+++ b/docs/help/QUICK-REFERENCE.md
@@ -11,7 +11,7 @@ tags:
 
 **Purpose:** Single-page command lookup for all flow-cli features
 **Format:** Copy-paste ready with expected outputs
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-06-04
 
 ---
@@ -1578,6 +1578,6 @@ mcp help
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-06-04
 **Contributors:** See [CHANGELOG.md](../CHANGELOG.md)

--- a/docs/help/TROUBLESHOOTING.md
+++ b/docs/help/TROUBLESHOOTING.md
@@ -3,7 +3,7 @@
 **Purpose:** Common issues and solutions for flow-cli
 **Audience:** All users experiencing problems
 **Format:** Problem → Diagnosis → Solution
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 
 ---
@@ -1048,6 +1048,6 @@ ls -la ~/.cache/flow/
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 **Need more help?** https://github.com/Data-Wise/flow-cli/issues

--- a/docs/help/TROUBLESHOOTING.md
+++ b/docs/help/TROUBLESHOOTING.md
@@ -3,7 +3,7 @@
 **Purpose:** Common issues and solutions for flow-cli
 **Audience:** All users experiencing problems
 **Format:** Problem → Diagnosis → Solution
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 
 ---
@@ -1048,6 +1048,6 @@ ls -la ~/.cache/flow/
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 **Need more help?** https://github.com/Data-Wise/flow-cli/issues

--- a/docs/help/WORKFLOWS.md
+++ b/docs/help/WORKFLOWS.md
@@ -6,7 +6,7 @@
 **Purpose:** Real-world workflow patterns for flow-cli
 **Audience:** All users (beginners → advanced)
 **Format:** Step-by-step instructions with examples
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 
 ---
@@ -1071,6 +1071,6 @@ pick              # Interactive project picker
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 **Contributors:** See [CHANGELOG.md](../CHANGELOG.md)

--- a/docs/help/WORKFLOWS.md
+++ b/docs/help/WORKFLOWS.md
@@ -6,7 +6,7 @@
 **Purpose:** Real-world workflow patterns for flow-cli
 **Audience:** All users (beginners → advanced)
 **Format:** Step-by-step instructions with examples
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 
 ---
@@ -1071,6 +1071,6 @@ pick              # Interactive project picker
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 **Contributors:** See [CHANGELOG.md](../CHANGELOG.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ tags:
 !!! success "🎉 What's New in v7.8"
     **Token auto-sync:** `tok sync push` / `tok sync repos` fan a token out to GitHub Actions secrets across repos (`gh secret set`) — confirm-once gate, OIDC "use Trusted Publishing" nudge, chezmoi-managed config. Auto-runs after `tok` create/rotate (`--no-sync` to opt out).
     **Terminal hygiene fix:** a shared cleanup helper ends the garbled-prompt corruption when launching Claude via `cc wt pick` / `ccy` / `work`.
-    **58 test suites** passing (210 files, 12000+ assertions).
+    **59 test suites** passing (211 files, 12000+ assertions).
     [→ Token Cookbook](guides/TOKEN-COOKBOOK.md){ .md-button }
     [→ Tutorial: tok auto-sync](tutorials/47-tok-auto-sync.md){ .md-button }
     [→ Changelog](CHANGELOG.md){ .md-button }
@@ -292,4 +292,4 @@ catch "idea"      # Quick capture
 
 ---
 
-**v7.8.0** · Pure ZSH · Zero Dependencies · MIT License
+**v7.8.1** · Pure ZSH · Zero Dependencies · MIT License

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,13 +26,12 @@ tags:
     ```
     **That's it!** No configuration required.
 
-!!! success "🎉 What's New in v7.6"
-    **Email polish:** `em --prompt` AI-guided composition, `--backend` provider override, `em forward`, help guards on all 34 em subcommands.
-    **Scholar Config Sync:** `teach config check/diff/show/scaffold`, `teach solution`, `teach sync`, `teach validate-r` — 4-layer config auto-injection.
-    **Docs overhaul:** 4 new dispatcher refcards (g, wt, dots, sec), stale version sweep, broken anchor fixes.
-    **53 test suites** passing (205 files, 12000+ assertions).
-    [→ Email Guide](guides/EMAIL-DISPATCHER-GUIDE.md){ .md-button }
-    [→ Scholar Guide](guides/SCHOLAR-INTEGRATION-GUIDE.md){ .md-button }
+!!! success "🎉 What's New in v7.8"
+    **Token auto-sync:** `tok sync push` / `tok sync repos` fan a token out to GitHub Actions secrets across repos (`gh secret set`) — confirm-once gate, OIDC "use Trusted Publishing" nudge, chezmoi-managed config. Auto-runs after `tok` create/rotate (`--no-sync` to opt out).
+    **Terminal hygiene fix:** a shared cleanup helper ends the garbled-prompt corruption when launching Claude via `cc wt pick` / `ccy` / `work`.
+    **58 test suites** passing (210 files, 12000+ assertions).
+    [→ Token Cookbook](guides/TOKEN-COOKBOOK.md){ .md-button }
+    [→ Tutorial: tok auto-sync](tutorials/47-tok-auto-sync.md){ .md-button }
     [→ Changelog](CHANGELOG.md){ .md-button }
 
 ---
@@ -184,6 +183,16 @@ Choose your path based on what you need right now:
 
     [→ CLI Guide](guides/EMAIL-DISPATCHER-GUIDE.md) ·
     [→ Neovim Setup](guides/HIMALAYA-NVIM-SETUP.md)
+
+-   :key:{ .lg .middle }
+    **Tokens & Secrets**
+
+    ---
+
+    Auto-sync tokens to GitHub Actions secrets
+
+    [→ Token Cookbook](guides/TOKEN-COOKBOOK.md) ·
+    [→ Auto-sync Tutorial](tutorials/47-tok-auto-sync.md)
 
 -   :compass:{ .lg .middle }
     **Command Reference**

--- a/docs/internal/conventions/code/ZSH-COMMANDS-HELP.md
+++ b/docs/internal/conventions/code/ZSH-COMMANDS-HELP.md
@@ -423,6 +423,44 @@ EOF
 
 ---
 
+## Man Pages (Dispatchers)
+
+> **TL;DR:** Every dispatcher ships a `man/man1/<cmd>.1`. CI fails if it's
+> missing or its version drifts.
+
+In-shell `<cmd> help` is the primary surface, but each dispatcher also has a
+hand-written troff man page so `man <cmd>` works offline. **When you add a
+dispatcher, add its man page** — model it on `man/man1/g.1` (sections: `.TH`,
+NAME, SYNOPSIS, DESCRIPTION, COMMANDS, EXAMPLES, SEE ALSO, AUTHOR). Source the
+COMMANDS content from the dispatcher's `case` block, de-ANSI/de-emoji'd (the
+colored/box-drawn `help` output is not copy-pasteable into troff).
+
+The `.TH` line's version field must match `FLOW_VERSION`:
+
+```troff
+.TH TOK 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+```
+
+A single guard — `tests/test-manpage-version-sync.zsh`, wired into
+`run-all.sh` and CI — enforces three invariants:
+
+- **Version sync:** every `flow-cli` page's `.TH` version == `FLOW_VERSION`
+  (vendored pages like `scribe.1` are skipped by product token).
+- **Coverage:** every dispatcher (derived from the public command functions in
+  `lib/dispatchers/*.zsh` + `lib/atlas-bridge.zsh`, aliases excluded) has a
+  `man/man1/<cmd>.1`.
+- **No orphans:** no `flow-cli` page exists without a matching dispatcher.
+
+You don't hand-bump versions at release time — `scripts/release.sh` seds the
+`.TH` lines to the new version; the guard is the backstop. Verify locally:
+
+```bash
+zsh tests/test-manpage-version-sync.zsh   # the guard (12 checks)
+man -l man/man1/<cmd>.1                    # render check
+```
+
+---
+
 ## Checklist for New Commands
 
 - [ ] `--help` and `-h` both work
@@ -432,3 +470,4 @@ EOF
 - [ ] Exit codes: 0 for success/help, 1 for errors
 - [ ] Help fits in 80 columns
 - [ ] Descriptions use consistent verb tense
+- [ ] New dispatcher: add `man/man1/<cmd>.1` (the man-page guard enforces this)

--- a/docs/reference/MASTER-API-REFERENCE.md
+++ b/docs/reference/MASTER-API-REFERENCE.md
@@ -8,7 +8,7 @@ tags:
 **Purpose:** Complete API documentation for all flow-cli library functions
 **Audience:** Developers, contributors, advanced users
 **Format:** Function signatures, parameters, return values, examples
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-21
 
 ---
@@ -7559,7 +7559,7 @@ URL line is omitted when `$url` is empty or `"null"`.
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-21
 **Auto-Generation:** Run `./scripts/generate-api-docs.sh` to update function index
 **Total Functions:** 880 (428 documented, 452 pending)

--- a/docs/reference/MASTER-API-REFERENCE.md
+++ b/docs/reference/MASTER-API-REFERENCE.md
@@ -8,7 +8,7 @@ tags:
 **Purpose:** Complete API documentation for all flow-cli library functions
 **Audience:** Developers, contributors, advanced users
 **Format:** Function signatures, parameters, return values, examples
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-21
 
 ---
@@ -7559,7 +7559,7 @@ URL line is omitted when `$url` is empty or `"null"`.
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-21
 **Auto-Generation:** Run `./scripts/generate-api-docs.sh` to update function index
 **Total Functions:** 880 (428 documented, 452 pending)

--- a/docs/reference/MASTER-ARCHITECTURE.md
+++ b/docs/reference/MASTER-ARCHITECTURE.md
@@ -3,7 +3,7 @@
 **Purpose:** Complete system architecture documentation for flow-cli
 **Audience:** Contributors, maintainers, advanced users
 **Format:** Design decisions, diagrams, implementation details
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-21
 
 ---
@@ -1020,7 +1020,7 @@ graph TD
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-21
 **Diagrams:** 8 Mermaid diagrams
 **Total:** 2,500+ lines

--- a/docs/reference/MASTER-ARCHITECTURE.md
+++ b/docs/reference/MASTER-ARCHITECTURE.md
@@ -3,7 +3,7 @@
 **Purpose:** Complete system architecture documentation for flow-cli
 **Audience:** Contributors, maintainers, advanced users
 **Format:** Design decisions, diagrams, implementation details
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-21
 
 ---
@@ -1020,7 +1020,7 @@ graph TD
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-21
 **Diagrams:** 8 Mermaid diagrams
 **Total:** 2,500+ lines

--- a/docs/reference/MASTER-DISPATCHER-GUIDE.md
+++ b/docs/reference/MASTER-DISPATCHER-GUIDE.md
@@ -10,7 +10,7 @@ tags:
 **Purpose:** Complete reference for all flow-cli dispatchers (15 + at bridge)
 **Audience:** All users (beginner → intermediate → advanced)
 **Format:** Progressive disclosure (basics → advanced features)
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-21
 
 ---
@@ -3483,6 +3483,6 @@ at stats
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-22
 **Total:** 15 dispatchers + at bridge fully documented

--- a/docs/reference/MASTER-DISPATCHER-GUIDE.md
+++ b/docs/reference/MASTER-DISPATCHER-GUIDE.md
@@ -10,7 +10,7 @@ tags:
 **Purpose:** Complete reference for all flow-cli dispatchers (15 + at bridge)
 **Audience:** All users (beginner → intermediate → advanced)
 **Format:** Progressive disclosure (basics → advanced features)
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-21
 
 ---
@@ -3483,6 +3483,6 @@ at stats
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-22
 **Total:** 15 dispatchers + at bridge fully documented

--- a/docs/reference/REFCARD-ANALYSIS.md
+++ b/docs/reference/REFCARD-ANALYSIS.md
@@ -189,5 +189,5 @@ teach analyze --slide-breaks lectures/week-02-probability.qmd
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-02

--- a/docs/reference/REFCARD-ANALYSIS.md
+++ b/docs/reference/REFCARD-ANALYSIS.md
@@ -189,5 +189,5 @@ teach analyze --slide-breaks lectures/week-02-probability.qmd
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-02

--- a/docs/reference/REFCARD-DATES.md
+++ b/docs/reference/REFCARD-DATES.md
@@ -271,5 +271,5 @@ teach dates status
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-02

--- a/docs/reference/REFCARD-DATES.md
+++ b/docs/reference/REFCARD-DATES.md
@@ -271,5 +271,5 @@ teach dates status
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-02

--- a/docs/reference/REFCARD-DOCTOR.md
+++ b/docs/reference/REFCARD-DOCTOR.md
@@ -320,5 +320,5 @@ teach doctor --verbose
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-21

--- a/docs/reference/REFCARD-DOCTOR.md
+++ b/docs/reference/REFCARD-DOCTOR.md
@@ -320,5 +320,5 @@ teach doctor --verbose
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-21

--- a/docs/reference/REFCARD-DOTFILE-DISPATCHER.md
+++ b/docs/reference/REFCARD-DOTFILE-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `dots` subcommands at a glance.
 >
-> **Version:** v7.8.0 (v3.0.0 dispatcher) | **Dispatcher:** `lib/dispatchers/dots-dispatcher.zsh`
+> **Version:** v7.8.1 (v3.0.0 dispatcher) | **Dispatcher:** `lib/dispatchers/dots-dispatcher.zsh`
 >
 > **Backend:** [chezmoi](https://www.chezmoi.io/) for dotfile sync.
 
@@ -99,5 +99,5 @@ dots apply
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27

--- a/docs/reference/REFCARD-DOTFILE-DISPATCHER.md
+++ b/docs/reference/REFCARD-DOTFILE-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `dots` subcommands at a glance.
 >
-> **Version:** v7.7.1 (v3.0.0 dispatcher) | **Dispatcher:** `lib/dispatchers/dots-dispatcher.zsh`
+> **Version:** v7.8.0 (v3.0.0 dispatcher) | **Dispatcher:** `lib/dispatchers/dots-dispatcher.zsh`
 >
 > **Backend:** [chezmoi](https://www.chezmoi.io/) for dotfile sync.
 
@@ -99,5 +99,5 @@ dots apply
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27

--- a/docs/reference/REFCARD-GIT-DISPATCHER.md
+++ b/docs/reference/REFCARD-GIT-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `g` subcommands at a glance — the most-used flow-cli dispatcher.
 >
-> **Version:** v7.7.1 | **Dispatcher:** `lib/dispatchers/g-dispatcher.zsh`
+> **Version:** v7.8.0 | **Dispatcher:** `lib/dispatchers/g-dispatcher.zsh`
 >
 > Unknown commands pass through to `git` (e.g., `g remote -v` → `git remote -v`).
 
@@ -129,5 +129,5 @@ g pop                   # Restore stashed changes
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27

--- a/docs/reference/REFCARD-GIT-DISPATCHER.md
+++ b/docs/reference/REFCARD-GIT-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `g` subcommands at a glance — the most-used flow-cli dispatcher.
 >
-> **Version:** v7.8.0 | **Dispatcher:** `lib/dispatchers/g-dispatcher.zsh`
+> **Version:** v7.8.1 | **Dispatcher:** `lib/dispatchers/g-dispatcher.zsh`
 >
 > Unknown commands pass through to `git` (e.g., `g remote -v` → `git remote -v`).
 
@@ -129,5 +129,5 @@ g pop                   # Restore stashed changes
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27

--- a/docs/reference/REFCARD-SCHOLAR-FLAGS.md
+++ b/docs/reference/REFCARD-SCHOLAR-FLAGS.md
@@ -2,7 +2,7 @@
 
 > All flags available for `teach` Scholar wrapper commands (lecture, slides, exam, quiz, assignment, syllabus, rubric, feedback, demo).
 >
-> **Version:** v7.7.1 | **Source:** `lib/dispatchers/teach-dispatcher.zsh`
+> **Version:** v7.8.0 | **Source:** `lib/dispatchers/teach-dispatcher.zsh`
 
 ## Selection Flags (Universal)
 
@@ -746,6 +746,6 @@ teach lecture "ANOVA" --week 8 --dry-run
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-02
 **Status:** Complete Scholar flag documentation

--- a/docs/reference/REFCARD-SCHOLAR-FLAGS.md
+++ b/docs/reference/REFCARD-SCHOLAR-FLAGS.md
@@ -2,7 +2,7 @@
 
 > All flags available for `teach` Scholar wrapper commands (lecture, slides, exam, quiz, assignment, syllabus, rubric, feedback, demo).
 >
-> **Version:** v7.8.0 | **Source:** `lib/dispatchers/teach-dispatcher.zsh`
+> **Version:** v7.8.1 | **Source:** `lib/dispatchers/teach-dispatcher.zsh`
 
 ## Selection Flags (Universal)
 
@@ -746,6 +746,6 @@ teach lecture "ANOVA" --week 8 --dry-run
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-02
 **Status:** Complete Scholar flag documentation

--- a/docs/reference/REFCARD-SCHOLAR-WRAPPERS.md
+++ b/docs/reference/REFCARD-SCHOLAR-WRAPPERS.md
@@ -8,7 +8,7 @@ tags:
 # Quick Reference: Scholar Wrapper Commands
 
 **Purpose:** Reference card for Scholar-powered `teach` subcommands
-**Version:** v7.8.0+
+**Version:** v7.8.1+
 **Last Updated:** 2026-02-27
 
 ---

--- a/docs/reference/REFCARD-SCHOLAR-WRAPPERS.md
+++ b/docs/reference/REFCARD-SCHOLAR-WRAPPERS.md
@@ -8,7 +8,7 @@ tags:
 # Quick Reference: Scholar Wrapper Commands
 
 **Purpose:** Reference card for Scholar-powered `teach` subcommands
-**Version:** v7.7.1+
+**Version:** v7.8.0+
 **Last Updated:** 2026-02-27
 
 ---

--- a/docs/reference/REFCARD-SECRET-DISPATCHER.md
+++ b/docs/reference/REFCARD-SECRET-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `sec` subcommands at a glance.
 >
-> **Version:** v7.8.0 (v3.0.0 dispatcher) | **Dispatcher:** `lib/dispatchers/sec-dispatcher.zsh`
+> **Version:** v7.8.1 (v3.0.0 dispatcher) | **Dispatcher:** `lib/dispatchers/sec-dispatcher.zsh`
 >
 > **Backends:** macOS Keychain (primary), Bitwarden (optional secondary).
 
@@ -105,5 +105,5 @@ sec dashboard                # Overview of all secrets
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27

--- a/docs/reference/REFCARD-SECRET-DISPATCHER.md
+++ b/docs/reference/REFCARD-SECRET-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `sec` subcommands at a glance.
 >
-> **Version:** v7.7.1 (v3.0.0 dispatcher) | **Dispatcher:** `lib/dispatchers/sec-dispatcher.zsh`
+> **Version:** v7.8.0 (v3.0.0 dispatcher) | **Dispatcher:** `lib/dispatchers/sec-dispatcher.zsh`
 >
 > **Backends:** macOS Keychain (primary), Bitwarden (optional secondary).
 
@@ -105,5 +105,5 @@ sec dashboard                # Overview of all secrets
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27

--- a/docs/reference/REFCARD-TEACH-DISPATCHER.md
+++ b/docs/reference/REFCARD-TEACH-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All 34 `teach` subcommands at a glance. For detailed guides, see linked documentation.
 >
-> **Version:** v7.8.0 | **Dispatcher:** `lib/dispatchers/teach-dispatcher.zsh`
+> **Version:** v7.8.1 | **Dispatcher:** `lib/dispatchers/teach-dispatcher.zsh`
 
 ## Command Taxonomy
 
@@ -485,6 +485,6 @@ teach status --performance        # Review metrics
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 **Commands:** 34 total (12 Scholar wrappers + 5 course mgmt + 6 content mgmt + 9 infrastructure + 1 discovery + config subcommands)

--- a/docs/reference/REFCARD-TEACH-DISPATCHER.md
+++ b/docs/reference/REFCARD-TEACH-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All 34 `teach` subcommands at a glance. For detailed guides, see linked documentation.
 >
-> **Version:** v7.7.1 | **Dispatcher:** `lib/dispatchers/teach-dispatcher.zsh`
+> **Version:** v7.8.0 | **Dispatcher:** `lib/dispatchers/teach-dispatcher.zsh`
 
 ## Command Taxonomy
 
@@ -485,6 +485,6 @@ teach status --performance        # Review metrics
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 **Commands:** 34 total (12 Scholar wrappers + 5 course mgmt + 6 content mgmt + 9 infrastructure + 1 discovery + config subcommands)

--- a/docs/reference/REFCARD-TEACH-PLAN.md
+++ b/docs/reference/REFCARD-TEACH-PLAN.md
@@ -157,5 +157,5 @@ teach slides --week N         # Step 5: Generate content
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-01-29

--- a/docs/reference/REFCARD-TEACH-PLAN.md
+++ b/docs/reference/REFCARD-TEACH-PLAN.md
@@ -157,5 +157,5 @@ teach slides --week N         # Step 5: Generate content
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-01-29

--- a/docs/reference/REFCARD-WORKTREE-DISPATCHER.md
+++ b/docs/reference/REFCARD-WORKTREE-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `wt` subcommands at a glance.
 >
-> **Version:** v7.8.0 | **Dispatcher:** `lib/dispatchers/wt-dispatcher.zsh`
+> **Version:** v7.8.1 | **Dispatcher:** `lib/dispatchers/wt-dispatcher.zsh`
 
 ## Commands
 
@@ -105,5 +105,5 @@ cd ~/projects/my-project        # Back to feature A (untouched)
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27

--- a/docs/reference/REFCARD-WORKTREE-DISPATCHER.md
+++ b/docs/reference/REFCARD-WORKTREE-DISPATCHER.md
@@ -2,7 +2,7 @@
 
 > All `wt` subcommands at a glance.
 >
-> **Version:** v7.7.1 | **Dispatcher:** `lib/dispatchers/wt-dispatcher.zsh`
+> **Version:** v7.8.0 | **Dispatcher:** `lib/dispatchers/wt-dispatcher.zsh`
 
 ## Commands
 
@@ -105,5 +105,5 @@ cd ~/projects/my-project        # Back to feature A (untouched)
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27

--- a/docs/reference/TEACH-CONFIG-SCHEMA.md
+++ b/docs/reference/TEACH-CONFIG-SCHEMA.md
@@ -2,7 +2,7 @@
 
 > Complete field reference for teaching project configuration.
 >
-> **Version:** v7.7.1 | **Location:** `.flow/teach-config.yml`
+> **Version:** v7.8.0 | **Location:** `.flow/teach-config.yml`
 
 ## Overview
 
@@ -669,4 +669,4 @@ _teach_config_summary ".flow/teach-config.yml"
 ---
 
 **Last Updated:** 2026-02-02
-**Version:** v7.7.1
+**Version:** v7.8.0

--- a/docs/reference/TEACH-CONFIG-SCHEMA.md
+++ b/docs/reference/TEACH-CONFIG-SCHEMA.md
@@ -2,7 +2,7 @@
 
 > Complete field reference for teaching project configuration.
 >
-> **Version:** v7.8.0 | **Location:** `.flow/teach-config.yml`
+> **Version:** v7.8.1 | **Location:** `.flow/teach-config.yml`
 
 ## Overview
 
@@ -669,4 +669,4 @@ _teach_config_summary ".flow/teach-config.yml"
 ---
 
 **Last Updated:** 2026-02-02
-**Version:** v7.8.0
+**Version:** v7.8.1

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -93,4 +93,4 @@ tags:
 
 ---
 
-**v7.7.1** | [Home](../index.md)
+**v7.8.0** | [Home](../index.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -93,4 +93,4 @@ tags:
 
 ---
 
-**v7.8.0** | [Home](../index.md)
+**v7.8.1** | [Home](../index.md)

--- a/docs/specs/SPEC-manpage-refresh-2026-06-04.md
+++ b/docs/specs/SPEC-manpage-refresh-2026-06-04.md
@@ -1,0 +1,140 @@
+# SPEC: Man-Page Full Refresh + Anti-Drift Guard (Hybrid)
+
+**Status:** draft
+**Created:** 2026-06-04
+**Type:** docs/tooling (man pages)
+**Trigger:** man pages frozen at v3.0.0 (2025-12-26); `flow.1` lists only 5 of 15 dispatchers; no `tok.1` (so v7.8.0 `tok sync` commands are absent). Found during a post-v7.8.0 help-coverage audit.
+
+---
+
+## Overview
+
+The `man/man1/` set is ~5 releases stale and partial. `flow.1` is labelled
+`flow-cli 3.0.0` and its SMART DISPATCHERS section lists only `g`, `r`,
+`qu`, `mcp`, `obs`. Ten dispatchers have no man page (`cc`, `tm`, `wt`,
+`dots`, `sec`, `tok`, `teach`, `prompt`, `v`, `em`), and the `at` bridge.
+
+**Hybrid approach (chosen):** hand-write/update every man page to v7.8.0
+now (highest quality, ships immediately) AND add a CI **staleness guard**
+so a man page whose `.TH` version diverges from `FLOW_VERSION` fails CI —
+preventing the silent re-freeze that caused this.
+
+The maintained surfaces (in-shell `<disp> help`, docs site, QUICK-REFERENCE,
+refcards, dispatcher guide, completions) are already complete for v7.8.0;
+this spec only closes the man-page gap.
+
+---
+
+## Primary User Story
+
+**As a** CLI user who runs `man flow` / `man tok`,
+**I want** man pages that match the installed v7.8.0 (all dispatchers,
+incl. `tok sync`),
+**so that** the offline reference is trustworthy — and a CI guard keeps it
+that way release-over-release.
+
+### Acceptance Criteria
+
+- [ ] `flow.1`: `.TH` → `flow-cli 7.8.0`, dated; SMART DISPATCHERS lists
+      **all 15** dispatchers + `at`; SEE ALSO references them.
+- [ ] Existing pages updated to v7.8.0: `g.1`, `r.1`, `qu.1`, `mcp.1`,
+      `obs.1` (`.TH` version + any drifted command lists).
+- [ ] New pages created (troff, matching the existing NAME/SYNOPSIS/
+      DESCRIPTION/COMMANDS/EXAMPLES/SEE ALSO/AUTHOR structure):
+      `cc.1`, `tm.1`, `wt.1`, `dots.1`, `sec.1`, `tok.1`, `teach.1`,
+      `prompt.1`, `v.1`, `em.1`, `at.1`.
+- [ ] **`tok.1` includes** `tok sync push <name>`, `tok sync repos <name>`,
+      `tok sync gh`, the `--no-sync` flag, and `FLOW_TOK_AUTOSYNC`.
+- [ ] **CI staleness guard**: a check (test + workflow step) that fails if
+      any `man/man1/*.1` `.TH` version string ≠ `FLOW_VERSION` in
+      `flow.plugin.zsh`.
+- [ ] Install path covers the new pages (README / `setup/` / Brewfile
+      reference `man/man1/`).
+- [ ] `man -l man/man1/tok.1` renders without troff errors (spot-check a few).
+
+---
+
+## Secondary User Stories
+
+- **As a** maintainer, **I want** the staleness guard to point at the exact
+  fix (bump `.TH` to `FLOW_VERSION`), so release prep is mechanical.
+- **As a** future contributor adding a dispatcher, **I want** CI to remind
+  me to add its man page (stretch: guard also flags a dispatcher with no
+  `*.1`).
+
+## Architecture / Approach
+
+```mermaid
+flowchart TD
+    A[release.sh bumps FLOW_VERSION] --> B{man .TH == FLOW_VERSION?}
+    B -- no --> C[CI staleness guard FAILS\n→ bump .TH lines]
+    B -- yes --> D[CI green]
+    E[new dispatcher added] -.stretch.-> F[guard flags missing *.1]
+```
+
+- Man pages stay **hand-written troff** (quality); the **guard** is the
+  durable anti-drift mechanism (cheap, deterministic — a grep/awk over
+  `.TH` lines vs `FLOW_VERSION`).
+- Guard lives in `tests/` (e.g. `tests/test-manpage-version-sync.zsh`,
+  source-scan style like `test-terminal-hygiene-regression.zsh`) AND is
+  wired into `run-all.sh` + the CI workflow.
+
+## Dependencies
+
+- No new runtime deps. troff/`man` for local spot-checks. Pure-ZSH guard
+  test using the shared `tests/` conventions.
+
+## Data Models
+
+N/A — static troff files + one grep-based guard.
+
+## UI/UX Specifications
+
+- Each man page mirrors the existing structure (see `g.1`): `.TH`, NAME,
+  SYNOPSIS, DESCRIPTION, COMMANDS (`.TP`/`.B`), EXAMPLES, SEE ALSO, AUTHOR.
+- COMMANDS content sourced from each dispatcher's `_<x>_help` (deduped of
+  ANSI/emoji/box-drawing — the help output is NOT copy-pasteable).
+- Consistent `.TH <NAME> 1 "Month Year" "flow-cli 7.8.0" "User Commands"`.
+
+## Security Constraints
+
+| Constraint | Enforcement |
+|---|---|
+| No secret values in examples | tok.1/sec.1 examples use placeholders only |
+| Guard is read-only | grep/awk over `.TH` lines; never writes |
+
+## Open Questions
+
+1. Include the `at` bridge as `at.1`? *Recommendation: yes — it's a
+   user-facing dispatcher even if optional.*
+2. Stretch "missing-page" guard (dispatcher without `*.1`) in this pass or
+   a follow-up? *Recommendation: version-sync guard now; missing-page guard
+   as a noted follow-up to keep scope bounded.*
+3. Auto-bump `.TH` in `release.sh`? *Recommendation: yes — add a sed step so
+   the guard rarely fires (guard = backstop, not the primary path).*
+
+## Review Checklist
+
+- [ ] All 16 pages at v7.8.0; tok.1 covers sync push/repos + --no-sync.
+- [ ] Guard fails on a deliberately-mismatched `.TH`, passes when synced.
+- [ ] Guard wired into `run-all.sh` + CI; dogfood-clean.
+- [ ] `release.sh` bumps `.TH` (Open Q3).
+- [ ] New pages installed (README/setup/Brewfile).
+- [ ] Spot-checked render (`man -l`).
+
+## Implementation Notes
+
+- New code/files → worktree `feature/manpage-refresh` off `dev`. This spec
+  lands on `dev`. New `*.1` files are blocked on `dev` by branch guard —
+  another reason this needs the worktree.
+- ~11 new troff files + 6 updates + 1 guard test + release.sh + install
+  refs. Sizeable but mechanical; good fit for subagent-driven work
+  (one agent per cluster of pages).
+- Wire the guard like `test-terminal-hygiene-regression.zsh` (source-scan,
+  standalone harness, distinct function names to satisfy dogfood scanner).
+
+## History
+
+| Date | Event |
+|---|---|
+| 2026-06-04 | Draft from post-v7.8.0 help-coverage audit. Hybrid chosen: hand-write all pages now + CI staleness guard to prevent re-freeze. |

--- a/docs/teaching/index.md
+++ b/docs/teaching/index.md
@@ -232,4 +232,4 @@ teach plan help
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.7.1
+**Version:** v7.8.0

--- a/docs/teaching/index.md
+++ b/docs/teaching/index.md
@@ -232,4 +232,4 @@ teach plan help
 ---
 
 **Last Updated:** 2026-02-27
-**Version:** v7.8.0
+**Version:** v7.8.1

--- a/docs/tutorials/14-teach-dispatcher.md
+++ b/docs/tutorials/14-teach-dispatcher.md
@@ -10,7 +10,7 @@ tags:
 > **What you'll learn:** Manage course websites with fast deployment, config validation, and AI-assisted content creation
 >
 > **Time:** ~20 minutes | **Level:** Beginner
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 
 ---
 

--- a/docs/tutorials/14-teach-dispatcher.md
+++ b/docs/tutorials/14-teach-dispatcher.md
@@ -10,7 +10,7 @@ tags:
 > **What you'll learn:** Manage course websites with fast deployment, config validation, and AI-assisted content creation
 >
 > **Time:** ~20 minutes | **Level:** Beginner
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 
 ---
 

--- a/docs/tutorials/20-teaching-dates-automation.md
+++ b/docs/tutorials/20-teaching-dates-automation.md
@@ -657,4 +657,4 @@ yq eval .flow/teach-config.yml
 **Questions or issues?** Open an issue on [GitHub](https://github.com/Data-Wise/flow-cli/issues)
 
 **Last Updated:** 2026-02-27
-**Version:** v7.7.1
+**Version:** v7.8.0

--- a/docs/tutorials/20-teaching-dates-automation.md
+++ b/docs/tutorials/20-teaching-dates-automation.md
@@ -657,4 +657,4 @@ yq eval .flow/teach-config.yml
 **Questions or issues?** Open an issue on [GitHub](https://github.com/Data-Wise/flow-cli/issues)
 
 **Last Updated:** 2026-02-27
-**Version:** v7.8.0
+**Version:** v7.8.1

--- a/docs/tutorials/21-teach-analyze.md
+++ b/docs/tutorials/21-teach-analyze.md
@@ -9,7 +9,7 @@ tags:
 > **What you'll learn:** Validate lecture prerequisites, detect concept gaps, and generate optimized slides using `teach analyze`
 >
 > **Time:** ~15 minutes | **Level:** Beginner → Intermediate
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 
 ---
 

--- a/docs/tutorials/21-teach-analyze.md
+++ b/docs/tutorials/21-teach-analyze.md
@@ -9,7 +9,7 @@ tags:
 > **What you'll learn:** Validate lecture prerequisites, detect concept gaps, and generate optimized slides using `teach analyze`
 >
 > **Time:** ~15 minutes | **Level:** Beginner → Intermediate
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 
 ---
 

--- a/docs/tutorials/23-token-automation.md
+++ b/docs/tutorials/23-token-automation.md
@@ -9,7 +9,7 @@ tags:
 
 > **Smart token management with caching and isolated checks**
 >
-> **Time:** ~15 minutes | **Level:** Intermediate | **v7.7.1**
+> **Time:** ~15 minutes | **Level:** Intermediate | **v7.8.0**
 
 ---
 

--- a/docs/tutorials/23-token-automation.md
+++ b/docs/tutorials/23-token-automation.md
@@ -9,7 +9,7 @@ tags:
 
 > **Smart token management with caching and isolated checks**
 >
-> **Time:** ~15 minutes | **Level:** Intermediate | **v7.8.0**
+> **Time:** ~15 minutes | **Level:** Intermediate | **v7.8.1**
 
 ---
 

--- a/docs/tutorials/24-template-management.md
+++ b/docs/tutorials/24-template-management.md
@@ -9,7 +9,7 @@ tags:
 > **What you'll learn:** Create and manage teaching content templates with `teach templates`
 >
 > **Time:** ~15 minutes | **Level:** Beginner → Intermediate
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 
 ---
 
@@ -433,5 +433,5 @@ teach templates sync --force
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-01-28

--- a/docs/tutorials/24-template-management.md
+++ b/docs/tutorials/24-template-management.md
@@ -9,7 +9,7 @@ tags:
 > **What you'll learn:** Create and manage teaching content templates with `teach templates`
 >
 > **Time:** ~15 minutes | **Level:** Beginner → Intermediate
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 
 ---
 
@@ -433,5 +433,5 @@ teach templates sync --force
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-01-28

--- a/docs/tutorials/25-lesson-plan-migration.md
+++ b/docs/tutorials/25-lesson-plan-migration.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Extract lesson plans with `teach migrate-config` and manage them with `teach plan`
 >
 > **Time:** ~15 minutes | **Level:** Beginner
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 
 ---
 
@@ -417,5 +417,5 @@ teach lecture --week 5
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-01-28

--- a/docs/tutorials/25-lesson-plan-migration.md
+++ b/docs/tutorials/25-lesson-plan-migration.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Extract lesson plans with `teach migrate-config` and manage them with `teach plan`
 >
 > **Time:** ~15 minutes | **Level:** Beginner
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 
 ---
 
@@ -417,5 +417,5 @@ teach lecture --week 5
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-01-28

--- a/docs/tutorials/26-latex-macros.md
+++ b/docs/tutorials/26-latex-macros.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Configure LaTeX macros for consistent AI-generated notation with `teach macros`
 >
 > **Time:** ~15 minutes | **Level:** Beginner → Intermediate
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 
 ---
 

--- a/docs/tutorials/26-latex-macros.md
+++ b/docs/tutorials/26-latex-macros.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Configure LaTeX macros for consistent AI-generated notation with `teach macros`
 >
 > **Time:** ~15 minutes | **Level:** Beginner → Intermediate
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 
 ---
 

--- a/docs/tutorials/27-lesson-plan-management.md
+++ b/docs/tutorials/27-lesson-plan-management.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Create, manage, and use lesson plans with `teach plan` to drive AI content generation
 >
 > **Time:** ~15 minutes | **Level:** Beginner
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 
 ---
 
@@ -339,5 +339,5 @@ teach slides --week 5  # Generate slides
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-01-29

--- a/docs/tutorials/27-lesson-plan-management.md
+++ b/docs/tutorials/27-lesson-plan-management.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Create, manage, and use lesson plans with `teach plan` to drive AI content generation
 >
 > **Time:** ~15 minutes | **Level:** Beginner
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 
 ---
 
@@ -339,5 +339,5 @@ teach slides --week 5  # Generate slides
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-01-29

--- a/docs/tutorials/29-first-exam-walkthrough.md
+++ b/docs/tutorials/29-first-exam-walkthrough.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Generate exams and quizzes using Scholar AI wrappers with flow-cli
 >
 > **Time:** ~20 minutes | **Level:** Beginner → Intermediate
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 
 ---
 
@@ -846,6 +846,6 @@ teach exam "Topic" --week 5
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-27
 **Tutorial Series:** Part 29 of Teaching Workflow Tutorials

--- a/docs/tutorials/29-first-exam-walkthrough.md
+++ b/docs/tutorials/29-first-exam-walkthrough.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Generate exams and quizzes using Scholar AI wrappers with flow-cli
 >
 > **Time:** ~20 minutes | **Level:** Beginner → Intermediate
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 
 ---
 
@@ -846,6 +846,6 @@ teach exam "Topic" --week 5
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-27
 **Tutorial Series:** Part 29 of Teaching Workflow Tutorials

--- a/docs/tutorials/30-new-instructor-complete-workflow.md
+++ b/docs/tutorials/30-new-instructor-complete-workflow.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Go from an empty directory to a deployed course website with AI-powered content
 >
 > **Time:** ~30 minutes | **Level:** Beginner
-> **Version:** v7.7.1
+> **Version:** v7.8.0
 
 ---
 

--- a/docs/tutorials/30-new-instructor-complete-workflow.md
+++ b/docs/tutorials/30-new-instructor-complete-workflow.md
@@ -3,7 +3,7 @@
 > **What you'll learn:** Go from an empty directory to a deployed course website with AI-powered content
 >
 > **Time:** ~30 minutes | **Level:** Beginner
-> **Version:** v7.8.0
+> **Version:** v7.8.1
 
 ---
 

--- a/docs/tutorials/32-teach-doctor.md
+++ b/docs/tutorials/32-teach-doctor.md
@@ -390,5 +390,5 @@ Only runs when `scholar.latex_macros.enabled: true` in teach-config.yml:
 
 ---
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Last Updated:** 2026-02-08

--- a/docs/tutorials/32-teach-doctor.md
+++ b/docs/tutorials/32-teach-doctor.md
@@ -390,5 +390,5 @@ Only runs when `scholar.latex_macros.enabled: true` in teach-config.yml:
 
 ---
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Last Updated:** 2026-02-08

--- a/docs/tutorials/47-tok-auto-sync.md
+++ b/docs/tutorials/47-tok-auto-sync.md
@@ -9,7 +9,7 @@ tags:
 
 > **Fan out one token to GitHub Actions secrets across every repo that needs it**
 >
-> **Time:** ~15 minutes | **Level:** Intermediate | **v7.7.1**
+> **Time:** ~15 minutes | **Level:** Intermediate | **v7.8.0**
 
 ---
 

--- a/docs/tutorials/47-tok-auto-sync.md
+++ b/docs/tutorials/47-tok-auto-sync.md
@@ -9,7 +9,7 @@ tags:
 
 > **Fan out one token to GitHub Actions secrets across every repo that needs it**
 >
-> **Time:** ~15 minutes | **Level:** Intermediate | **v7.8.0**
+> **Time:** ~15 minutes | **Level:** Intermediate | **v7.8.1**
 
 ---
 

--- a/docs/tutorials/scholar-enhancement/index.md
+++ b/docs/tutorials/scholar-enhancement/index.md
@@ -1,6 +1,6 @@
 # Scholar Enhancement Tutorials
 
-**Version:** v7.8.0
+**Version:** v7.8.1
 **Total Duration:** ~65 minutes
 **Skill Levels:** 3 (Beginner → Advanced)
 

--- a/docs/tutorials/scholar-enhancement/index.md
+++ b/docs/tutorials/scholar-enhancement/index.md
@@ -1,6 +1,6 @@
 # Scholar Enhancement Tutorials
 
-**Version:** v7.7.1
+**Version:** v7.8.0
 **Total Duration:** ~65 minutes
 **Skill Levels:** 3 (Beginner → Advanced)
 

--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -142,7 +142,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="7.8.0"
+export FLOW_VERSION="7.8.1"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup

--- a/man/man1/at.1
+++ b/man/man1/at.1
@@ -1,0 +1,178 @@
+.\" Man page for at dispatcher (Atlas bridge)
+.\" Generated: June 2026
+.TH AT 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+at \- Atlas project intelligence bridge (optional integration)
+.SH SYNOPSIS
+.B at
+[\fIcommand\fR] [\fIarguments\fR]
+.SH DESCRIPTION
+.B at
+is an optional bridge to the
+.B Atlas
+project intelligence CLI.
+When Atlas is installed, all commands are forwarded to
+.BR atlas (1)
+directly, with the exception of
+.B at help
+(which always shows the flow-cli styled help page).
+.PP
+When Atlas is not installed, four commands work using ZSH-native fallbacks:
+.BR catch ,
+.BR inbox ,
+.BR where ,
+and
+.BR crumb .
+All other commands print an install message.
+.PP
+Atlas availability is controlled by the
+.B FLOW_ATLAS_ENABLED
+environment variable. Availability is cached at session start for performance.
+.PP
+Install Atlas:
+.RS
+.nf
+npm i -g @data-wise/atlas
+brew install data-wise/tap/atlas
+.fi
+.RE
+.SH COMMANDS
+.SS Always Available
+.TP
+.B help\fR, \fB--help\fR, \fB-h
+Show flow-cli styled help page (never shows Atlas native help).
+.SS Available Without Atlas (ZSH Fallbacks)
+.TP
+.B catch\fR, \fBc \fItext\fR
+Quick capture a thought, idea, or task into flow's quick-capture inbox.
+Works with or without Atlas installed.
+.TP
+.B inbox\fR, \fBi
+Show captured items from the quick-capture inbox.
+Works with or without Atlas installed.
+.TP
+.B where\fR, \fBw \fR[\fIproject\fR]
+Show context from the last work session: where you were, what you were
+doing, recent breadcrumbs. Works with or without Atlas installed.
+.TP
+.B crumb\fR, \fBb \fItext\fR
+Leave a breadcrumb note at the current point in your workflow to aid
+context recovery later. Works with or without Atlas installed.
+.SS Require Atlas
+The following commands require Atlas to be installed and will print install
+instructions if it is absent.
+.SS Session
+.TP
+.B session start \fIproject\fR
+Start a tracked work session for the given project.
+.TP
+.B session end \fR[\fInote\fR]
+End the current work session with an optional summary note.
+.SS Capture & Triage
+.TP
+.B triage
+Process inbox items interactively (prioritize, assign, or discard).
+.SS Context
+.TP
+.B trail
+Show the full breadcrumb trail for the current or specified project.
+.TP
+.B focus \fR[\fIproject\fR]
+Set or show the current focus project.
+.SS Project Management
+.TP
+.B stats
+Show project statistics overview (velocity, completion, trends).
+.TP
+.B plan
+Show planning view: priorities, deadlines, upcoming milestones.
+.TP
+.B park \fR[\fIproject\fR]
+Park (pause) a project, saving its context for later resumption.
+.TP
+.B unpark \fR[\fIproject\fR]
+Resume a previously parked project.
+.TP
+.B parked
+List all currently parked projects.
+.TP
+.B dash\fR, \fBdashboard
+Show a dashboard of all projects at a glance.
+.SH ENVIRONMENT
+.TP
+.B FLOW_ATLAS_ENABLED
+Controls Atlas integration:
+.RS
+.TP
+.B auto
+(default) Use Atlas if installed; gracefully degrade if not.
+.TP
+.B yes
+Require Atlas; do not use fallbacks.
+.TP
+.B no
+Disable Atlas entirely even if installed; always use fallbacks.
+.RE
+.SH EXAMPLES
+Quick capture (works without Atlas):
+.RS
+.nf
+at catch "Fix login bug before release"
+at catch "Research alternative caching strategy"
+.fi
+.RE
+.PP
+Show context from last session (works without Atlas):
+.RS
+.nf
+at where
+at where my-project
+.fi
+.RE
+.PP
+Leave a breadcrumb (works without Atlas):
+.RS
+.nf
+at crumb "Debugging auth flow in middleware"
+.fi
+.RE
+.PP
+Project overview (requires Atlas):
+.RS
+.nf
+at stats
+at plan
+at dash
+.fi
+.RE
+.PP
+Session management (requires Atlas):
+.RS
+.nf
+at session start flow-cli
+at session end "Finished man page refresh"
+.fi
+.RE
+.PP
+Park and switch projects (requires Atlas):
+.RS
+.nf
+at park
+at unpark flow-cli
+at parked
+.fi
+.RE
+.PP
+Disable Atlas for a session:
+.RS
+.nf
+FLOW_ATLAS_ENABLED=no at catch "note stored locally"
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR teach (1),
+.BR em (1),
+.BR g (1)
+.SH AUTHOR
+DT

--- a/man/man1/at.1
+++ b/man/man1/at.1
@@ -1,6 +1,6 @@
 .\" Man page for at dispatcher (Atlas bridge)
 .\" Generated: June 2026
-.TH AT 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH AT 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 at \- Atlas project intelligence bridge (optional integration)
 .SH SYNOPSIS

--- a/man/man1/cc.1
+++ b/man/man1/cc.1
@@ -1,0 +1,183 @@
+.\" Man page for cc dispatcher (Claude Code launcher)
+.\" Generated: June 2026
+.TH CC 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+cc \- Claude Code launcher and dispatcher
+.SH SYNOPSIS
+.B cc
+[\fImode\fR] [\fItarget\fR] [\fIarguments\fR]
+.SH DESCRIPTION
+.B cc
+is a smart dispatcher for launching Claude Code.
+It provides flexible project navigation, mode selection, and worktree integration
+with an ADHD-friendly design.
+.PP
+When called without arguments,
+.B cc
+launches Claude Code in the current directory with
+.I acceptEdits
+permission mode.
+.PP
+Both mode-first and target-first argument ordering are accepted:
+.I cc yolo pick
+and
+.I cc pick yolo
+are equivalent.
+.SH COMMANDS
+.SS Launch Targets
+.TP
+.B (none)
+Launch Claude Code in the current directory (acceptEdits mode).
+.TP
+.B .\fR, \fBhere
+Explicitly launch in the current directory (acceptEdits mode).
+.TP
+.B pick
+Open the project picker (fzf), then launch Claude Code in the selected project.
+.TP
+.B \fIproject\fR
+Jump directly to a named project and launch Claude Code there.
+.TP
+.B resume\fR, \fBr
+Resume a previous session (claude -r); opens session picker.
+.TP
+.B continue\fR, \fBc
+Continue the most recent session (claude -c).
+.SS Permission Modes
+Modes can be specified before or after the target.
+.TP
+.B yolo\fR, \fBy
+Launch with
+.I --dangerously-skip-permissions
+(skip all permission checks).
+.TP
+.B plan\fR, \fBp
+Launch in plan mode (--permission-mode plan).
+.TP
+.B opus\fR, \fBo
+Launch with the Opus model (--model opus --permission-mode acceptEdits).
+.TP
+.B haiku\fR, \fBh
+Launch with the Haiku model (--model haiku --permission-mode acceptEdits).
+.SS Quick Actions
+.TP
+.B ask \fIquestion\fR, \fBa \fIquestion\fR
+Ask Claude a quick question in non-interactive print mode (claude -p).
+.TP
+.B file \fIfile\fR [\fIprompt\fR], \fBf \fIfile\fR [\fIprompt\fR]
+Analyze a file. Pipes the file into Claude with an optional prompt
+(default: "Explain this code in detail").
+.TP
+.B diff\fR [\fIprompt\fR], \fBd\fR [\fIprompt\fR]
+Review uncommitted git changes. Pipes
+.I git diff
+into Claude with an optional prompt.
+.TP
+.B print \fIprompt\fR, \fBpr \fIprompt\fR
+Non-interactive print mode (claude -p) with an arbitrary prompt.
+.TP
+.B rpkg \fIprompt\fR
+R package context helper. Reads
+.I DESCRIPTION
+and prepends package context to the prompt.
+Requires running inside an R package directory.
+.SS Worktree Integration
+.TP
+.B wt \fIbranch\fR, \fBworktree \fIbranch\fR, \fBw \fIbranch\fR
+Launch Claude Code in the worktree for
+.IR branch .
+Creates the worktree if it does not yet exist.
+.TP
+.B wt
+(no branch) List all current worktrees.
+.TP
+.B wt pick
+Open an fzf picker for existing worktrees, then launch Claude Code.
+.TP
+.B wt status\fR, \fBwt st
+Show all worktrees with Claude session indicators (green = recent < 24h,
+yellow = old session, white circle = no session).
+.SS Help
+.TP
+.B help\fR, \fB--help\fR, \fB-h
+Show built-in help.
+.SH MODE AND TARGET COMBINATIONS
+Modes and targets compose freely in either order:
+.RS
+.nf
+cc yolo pick       Pick project, then launch YOLO mode
+cc opus wt pick    Pick worktree, then launch with Opus
+cc plan wt feature/auth  Plan mode in a specific worktree
+.fi
+.RE
+.PP
+Deprecated (still works but shows a warning): \fBcc wt yolo \fIbranch\fR.
+Preferred form: \fBcc yolo wt \fIbranch\fR.
+.SH ALIASES
+.TP
+.B ccw
+Alias for
+.IR "cc wt" .
+.TP
+.B ccwp
+Alias for
+.IR "cc wt pick" .
+.TP
+.B ccy
+Alias for
+.IR "cc yolo" .
+.SH ENVIRONMENT
+.TP
+.B FLOW_PROJECTS_ROOT
+Root directory scanned for projects (used by the
+.I pick
+target).
+.SH EXAMPLES
+Launch Claude in current directory:
+.RS
+.nf
+cc
+.fi
+.RE
+.PP
+Pick a project and launch with Opus model:
+.RS
+.nf
+cc opus pick
+.fi
+.RE
+.PP
+Launch in a worktree (creates if needed):
+.RS
+.nf
+cc wt feature/auth
+.fi
+.RE
+.PP
+Ask a quick question without opening an interactive session:
+.RS
+.nf
+cc ask "how do I handle missing data in R?"
+.fi
+.RE
+.PP
+Review uncommitted changes:
+.RS
+.nf
+cc diff
+.fi
+.RE
+.PP
+Analyze a file:
+.RS
+.nf
+cc file src/main.zsh "what does this function do?"
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR wt (1),
+.BR tm (1),
+.BR g (1)
+.SH AUTHOR
+DT

--- a/man/man1/cc.1
+++ b/man/man1/cc.1
@@ -1,6 +1,6 @@
 .\" Man page for cc dispatcher (Claude Code launcher)
 .\" Generated: June 2026
-.TH CC 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH CC 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 cc \- Claude Code launcher and dispatcher
 .SH SYNOPSIS

--- a/man/man1/dots.1
+++ b/man/man1/dots.1
@@ -1,0 +1,273 @@
+.\" Man page for dots dispatcher (Dotfile Management)
+.\" Generated: June 2026
+.TH DOTS 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+dots \- Dotfile management dispatcher (chezmoi wrapper)
+.SH SYNOPSIS
+.B dots
+[\fIcommand\fR] [\fIarguments\fR]
+.SH DESCRIPTION
+.B dots
+is a smart dispatcher for managing dotfiles via
+.BR chezmoi (1).
+It provides a consistent, ADHD-friendly interface for the most common
+dotfile operations: tracking files, editing them, syncing with a remote
+repository, and inspecting repository health.
+.PP
+When called without arguments,
+.B dots
+shows the current sync status: chezmoi state, last sync time, tracked
+file count, modified file count, and Bitwarden vault state (if
+.BR bw (1)
+is installed).
+.PP
+Unknown commands are passed through to
+.B chezmoi
+directly, so
+.B dots managed
+is equivalent to
+.BR "chezmoi managed" .
+This passthrough only fires when
+.B chezmoi
+is installed; otherwise an error is printed.
+.PP
+.B chezmoi
+must be installed for most operations.  Install via
+.BR "brew install chezmoi" ,
+then initialise with
+.BR "chezmoi init" .
+.SH COMMANDS
+.SS Status & Info
+.TP
+.B (none)
+Show dotfiles status: sync state, last sync, tracked/modified counts,
+and vault state.
+.TP
+.B status\fR, \fBs
+Alias for the default status view.
+.TP
+.B size
+Analyse chezmoi repository size.  Lists total size, top 10 largest
+files, and warns about nested
+.I .git
+directories and files larger than 100 KB.
+.TP
+.B version\fR, \fB\-\-version\fR, \fB\-v
+Show the
+.B dots
+dispatcher version and the installed versions of
+.BR chezmoi ,
+.BR bw ,
+and
+.BR mise .
+.SS File Management
+.TP
+.B add \fIfile\fR
+Add a file to chezmoi tracking.  Expands
+.I ~
+prefixes and checks whether the file is already managed.  Prints the
+resulting source path and a tip to edit the file immediately.
+.TP
+.B edit \fIfile\fR\fR, \fBe \fIfile\fR
+Edit a dotfile in
+.B $EDITOR
+(defaults to
+.BR vim ).
+Supports fuzzy file name matching against managed files.  If the file
+is not tracked, offers to add it to chezmoi.  If the file does not
+exist, offers to create it.  After editing, shows a diff and prompts
+whether to apply immediately.
+.PP
+.RS
+If the source file is a chezmoi template
+.RI ( .tmpl )
+that references Bitwarden secrets
+.RB ( "{{ bitwarden ... }}" ),
+.B dots edit
+offers to unlock the vault before showing the diff so that secret
+values are expanded in the preview.
+.RE
+.TP
+.B diff \fR[\fIfile\fR]\fR, \fBd \fR[\fIfile\fR]
+Show pending changes.  Without a file argument, shows all diffs via
+.BR "chezmoi diff" .
+With a file argument, resolves the path and shows just that file's diff.
+.TP
+.B apply \fR[\fIfile\fR] [\fB\-n\fR | \fB\-\-dry\-run\fR]\fR, \fBa \fR[\fIfile\fR]
+Apply pending chezmoi changes to the home directory.  Without a file
+argument, applies all pending changes (with a confirmation prompt).
+With
+.B \-n
+/
+.BR \-\-dry\-run ,
+shows what would change without writing anything.
+.TP
+.B undo
+Rollback the last apply.  (Implementation pending \(em for now use
+.B "chezmoi diff && chezmoi apply \-\-dry\-run"
+to review before applying.)
+.SS Ignore Patterns
+.TP
+.B ignore add \fIpattern\fR
+Add a glob pattern to
+.IR .chezmoiignore .
+Creates the file if it does not exist.  Skips duplicates silently.
+.TP
+.B ignore list\fR, \fBignore ls
+List all patterns in
+.IR .chezmoiignore ,
+numbered for readability.  This is the default when no
+.B ignore
+subcommand is given.
+.TP
+.B ignore remove \fIpattern\fR\fR, \fBignore rm \fIpattern\fR
+Remove a specific pattern from
+.IR .chezmoiignore .
+.TP
+.B ignore edit
+Open
+.I .chezmoiignore
+directly in
+.BR $EDITOR .
+.SS Remote Sync
+.TP
+.B sync\fR, \fBpull
+Pull updates from the remote chezmoi git repository.  Fetches, checks
+if the local copy is behind, shows pending commits, and runs
+.B chezmoi update
+to apply remote changes.  Prompts before pulling if local modifications
+exist.
+.TP
+.B push\fR, \fBp
+Push local changes to the remote chezmoi git repository.  If there are
+uncommitted changes in the chezmoi directory, prompts for a commit
+message, commits all changes, and pushes.  If the branch is already
+ahead of remote with no uncommitted changes, pushes directly.
+.SS Environment Integration
+.TP
+.B env init
+Generate a
+.I .envrc
+file for
+.BR direnv (1)
+that loads selected Bitwarden-managed secrets as environment variables
+when entering the directory.  Requires
+.B direnv
+and an unlocked Bitwarden vault.  Adds
+.I .envrc
+to
+.I .gitignore
+automatically.
+.SS Diagnostics
+.TP
+.B doctor\fR, \fBdr
+Run dotfile management diagnostics.  (Full implementation pending;
+available checks include chezmoi install, repository state, remote
+configuration,
+.I .chezmoiignore
+presence, managed file count, repository size, large files, nested git
+directories, and sync status.)  See also
+.BR "flow doctor \-\-dot" .
+.TP
+.B init
+Initialize chezmoi.  (Implementation pending \(em use
+.B chezmoi init
+directly.)
+.SS Help
+.TP
+.B help\fR, \fB\-\-help\fR, \fB\-h
+Show the help screen.
+.SH PASSTHROUGH
+Unknown commands are passed through to
+.BR chezmoi (1)
+when it is installed:
+.RS
+.nf
+dots managed        -> chezmoi managed
+dots source-path ~  -> chezmoi source-path ~
+.fi
+.RE
+.SH EXAMPLES
+Show dotfiles status:
+.RS
+.nf
+dots
+.fi
+.RE
+.PP
+Add a file to chezmoi tracking:
+.RS
+.nf
+dots add ~/.zshrc
+.fi
+.RE
+.PP
+Edit a dotfile (fuzzy match accepted):
+.RS
+.nf
+dots edit .zshrc
+.fi
+.RE
+.PP
+Preview pending changes without applying:
+.RS
+.nf
+dots apply -n
+.fi
+.RE
+.PP
+Apply all pending changes:
+.RS
+.nf
+dots apply
+.fi
+.RE
+.PP
+Pull latest dotfiles from remote:
+.RS
+.nf
+dots sync
+.fi
+.RE
+.PP
+Push local changes to remote:
+.RS
+.nf
+dots push
+.fi
+.RE
+.PP
+Add an ignore pattern for nested git repos:
+.RS
+.nf
+dots ignore add '**/.git'
+.fi
+.RE
+.PP
+List all ignore patterns:
+.RS
+.nf
+dots ignore list
+.fi
+.RE
+.PP
+Analyse repository size:
+.RS
+.nf
+dots size
+.fi
+.RE
+.PP
+Generate a direnv .envrc from Bitwarden secrets:
+.RS
+.nf
+dots env init
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR sec (1),
+.BR tok (1),
+.BR chezmoi (1)
+.SH AUTHOR
+DT

--- a/man/man1/dots.1
+++ b/man/man1/dots.1
@@ -1,6 +1,6 @@
 .\" Man page for dots dispatcher (Dotfile Management)
 .\" Generated: June 2026
-.TH DOTS 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH DOTS 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 dots \- Dotfile management dispatcher (chezmoi wrapper)
 .SH SYNOPSIS

--- a/man/man1/em.1
+++ b/man/man1/em.1
@@ -1,0 +1,381 @@
+.\" Man page for em dispatcher (Email / himalaya)
+.\" Generated: June 2026
+.TH EM 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+em \- Email dispatcher (himalaya wrapper)
+.SH SYNOPSIS
+.B em
+[\fIcommand\fR] [\fIarguments\fR]
+.br
+.B em
+.I ID
+.br
+.B em
+.B -n
+.I N
+.SH DESCRIPTION
+.B em
+is a smart email dispatcher that wraps the
+.B himalaya
+CLI, providing ADHD-friendly email management with AI-powered composition,
+fzf-based browsing, and a two-phase safety gate for destructive operations.
+.PP
+When called without arguments it shows a quick dashboard (unread count + 10
+most recent emails).
+.PP
+A bare number argument reads that email directly (e.g.
+.B em 42
+is equivalent to
+.BR "em read 42" ).
+.PP
+.B em -n \fIN
+limits the inbox listing to N messages.
+.PP
+AI features use Claude by default; switch backend with
+.B em ai
+or set
+.BR FLOW_EMAIL_AI .
+All send/reply/forward operations show a preview and prompt
+.B [y/N/e]
+(yes / no / edit) before sending.
+.SH COMMANDS
+.SS Inbox & Reading
+.TP
+.B inbox\fR, \fBi \fR[\fIN\fR]
+List N recent emails (default: 25, set by FLOW_EMAIL_PAGE_SIZE).
+.TP
+.B read\fR, \fBr \fIID\fR [\fIoptions\fR]
+Read an email by ID. Options:
+.RS
+.TP
+.B --html
+Render HTML version in terminal (w3m/lynx).
+.TP
+.B --md
+Convert to clean Markdown via pandoc.
+.TP
+.B --raw
+Dump raw MIME source.
+.RE
+.TP
+.B unread\fR, \fBu
+Show unread email count.
+.TP
+.B html \fIID\fR
+Render HTML email in terminal (alias for
+.BR "read --html" ).
+.TP
+.B dash\fR, \fBd
+Quick dashboard: unread count + recent emails.
+.SS Compose & Reply
+.TP
+.B send\fR, \fBs \fR[\fIoptions\fR]
+Compose a new email. Opens \fB$EDITOR\fR with a preview before sending.
+.RS
+.TP
+.B --force
+Send without preview confirmation.
+.TP
+.B --prompt \fIinstructions\fR
+AI-compose from prompt instructions.
+.TP
+.B --backend \fIclaude\fR|\fIgemini\fR
+Override AI backend for this operation.
+.RE
+.TP
+.B reply\fR, \fBre \fIID\fR [\fIoptions\fR]
+Reply to an email with an AI-drafted reply opened in \fB$EDITOR\fR.
+.RS
+.TP
+.B --no-ai
+Skip AI draft; open empty template.
+.TP
+.B --all
+Reply-all.
+.TP
+.B --batch
+Non-interactive: preview + confirm without opening editor.
+.TP
+.B --force
+Send immediately without preview.
+.TP
+.B --prompt \fIinstructions\fR
+Custom instructions for AI draft.
+.TP
+.B --backend \fIclaude\fR|\fIgemini\fR
+Override AI backend for this operation.
+.RE
+.TP
+.B forward\fR, \fBfwd \fIID\fR [\fIto\fR] [\fIoptions\fR]
+Forward an email.
+.RS
+.TP
+.B --prompt \fItext\fR
+AI-compose a custom forwarding note.
+.TP
+.B --backend \fIclaude\fR|\fIgemini\fR
+Override AI backend.
+.TP
+.B --force
+Send without preview.
+.RE
+.SS Search & Browse
+.TP
+.B find\fR, \fBf \fIquery\fR
+Search emails by query string.
+.TP
+.B pick\fR, \fBp \fR[\fIFOLDER\fR]
+Open fzf-powered email browser with preview pane.
+Optional FOLDER argument restricts scope.
+.SS Manage
+.TP
+.B delete\fR, \fBdel\fR, \fBrm \fIID\fR [\fIoptions\fR]
+Move email to Trash.
+.RS
+.TP
+.B --pick
+Interactive multi-select delete via fzf.
+.TP
+.B --purge
+Permanent delete (requires typing "yes" to confirm).
+.RE
+.TP
+.B move\fR, \fBmv \fIID\fR [\fIFOLDER\fR]
+Move email to folder. Opens fzf folder picker if FOLDER is omitted.
+.TP
+.B restore \fIID\fR
+Restore email from Trash to INBOX.
+.TP
+.B flag\fR, \fBfl \fIID\fR
+Star email for follow-up.
+.TP
+.B unflag \fIID\fR
+Remove star from email.
+.SS Organize
+.TP
+.B star \fIID\fR
+Toggle starred (flagged) status.
+.TP
+.B starred
+List all starred emails.
+.TP
+.B thread\fR, \fBth \fIID\fR
+Show full conversation thread.
+.TP
+.B snooze\fR, \fBsnz \fIID\fR \fItime\fR
+Snooze email. Time formats: 2h, 1d, tomorrow, monday.
+.TP
+.B snoozed
+List all snoozed emails.
+.TP
+.B digest\fR, \fBdg \fR[\fIoptions\fR]
+Generate AI-grouped daily email summary.
+.RS
+.TP
+.B --week
+Show weekly digest instead of daily.
+.RE
+.SS Folders
+.TP
+.B create-folder\fR, \fBcf \fIname\fR
+Create a new mail folder.
+.TP
+.B delete-folder\fR, \fBdf \fIname\fR
+Delete a folder (type-to-confirm safety prompt).
+.TP
+.B folders
+List all mail folders.
+.SS Attachments
+.TP
+.B attach\fR, \fBa \fIID\fR
+Download all attachments from an email.
+.TP
+.B attach list \fIID\fR
+Show attachment list (name, MIME type, size).
+.TP
+.B attach get \fIID\fR \fIfile\fR
+Download a specific named attachment.
+.SS Calendar (v2.0)
+.TP
+.B calendar\fR, \fBcal \fIID\fR
+Parse ICS attachment from email and add the event to Apple Calendar.
+.SS Watch / IMAP IDLE (v2.0, experimental)
+.TP
+.B watch start
+Start IMAP IDLE notification watcher in background.
+.TP
+.B watch stop
+Stop the background watcher.
+.TP
+.B watch status
+Show current watcher status.
+.TP
+.B watch log
+Show recent notification log.
+.SS AI Features
+.TP
+.B respond\fR, \fBresp \fR[\fIoptions\fR]
+Batch AI draft generation for actionable emails.
+.RS
+.TP
+.B --review
+Review and send previously generated drafts.
+.RE
+.TP
+.B classify\fR, \fBcl \fIID\fR
+Classify an email using AI (priority, category).
+.TP
+.B summarize\fR, \fBsum \fIID\fR
+Generate a one-line AI summary of an email.
+.TP
+.B catch\fR, \fBc \fIID\fR
+Capture an email as a task in flow's quick-capture inbox.
+.TP
+.B todo\fR, \fBtd \fIID\fR
+Extract action items from an email and add them to flow + Reminders.app.
+.TP
+.B event\fR, \fBev \fIID\fR
+Extract calendar events from an email and add them to flow + Calendar.app.
+.SS AI Backend
+.TP
+.B ai
+Show current AI backend setting.
+.TP
+.B ai claude
+Switch to Claude as the AI backend.
+.TP
+.B ai gemini
+Switch to Gemini as the AI backend.
+.TP
+.B ai none
+Disable AI features.
+.TP
+.B ai toggle
+Cycle through available AI backends.
+.TP
+.B ai auto
+Enable smart per-operation AI routing.
+.SS Utilities
+.TP
+.B html \fIID\fR
+Render HTML email in terminal browser (w3m/lynx).
+.TP
+.B cache stats
+Show AI draft cache statistics.
+.TP
+.B cache clear
+Clear the AI draft cache.
+.TP
+.B doctor\fR, \fBdr
+Check all email-related dependencies (himalaya, w3m/lynx, pandoc, AI CLIs).
+.TP
+.B help\fR, \fBh\fR, \fB--help\fR, \fB-h
+Show help page.
+.SH ENVIRONMENT
+.TP
+.B FLOW_EMAIL_AI
+AI backend: \fBclaude\fR (default) | \fBgemini\fR | \fBnone\fR.
+.TP
+.B FLOW_EMAIL_PAGE_SIZE
+Default inbox page size (default: 25).
+.TP
+.B FLOW_EMAIL_FOLDER
+Default folder (default: INBOX).
+.TP
+.B FLOW_EMAIL_TRASH_FOLDER
+Trash folder name (default: Trash; Exchange: "Deleted Items").
+.TP
+.B FLOW_EMAIL_AI_TIMEOUT
+AI draft timeout in seconds (default: 30).
+.TP
+.B EDITOR
+Editor used for composing and editing email drafts (nvim recommended).
+.SH FILES
+.TP
+.I .flow/email.conf
+Project-level email configuration (overrides global).
+.TP
+.I $FLOW_CONFIG_DIR/email.conf
+Global email configuration.
+.SH EXAMPLES
+Show email dashboard:
+.RS
+.nf
+em
+.fi
+.RE
+.PP
+Read an email:
+.RS
+.nf
+em read 42
+em 42
+em read --html 42
+em read --md 42
+.fi
+.RE
+.PP
+Reply with AI draft:
+.RS
+.nf
+em reply 42
+em re 42 --all
+em re 42 --prompt "be brief and professional"
+.fi
+.RE
+.PP
+Compose new email:
+.RS
+.nf
+em send
+em send --prompt "write a meeting request to the team"
+.fi
+.RE
+.PP
+Browse emails with fzf:
+.RS
+.nf
+em pick
+em pick INBOX
+.fi
+.RE
+.PP
+Search emails:
+.RS
+.nf
+em find "quarterly report"
+.fi
+.RE
+.PP
+Batch AI replies:
+.RS
+.nf
+em respond
+em respond --review
+.fi
+.RE
+.PP
+Manage folders:
+.RS
+.nf
+em folders
+em create-folder Archive
+em move 42 Archive
+.fi
+.RE
+.PP
+Switch AI backend:
+.RS
+.nf
+em ai gemini
+em ai claude
+em ai none
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR teach (1),
+.BR at (1),
+.BR tok (1)
+.SH AUTHOR
+DT

--- a/man/man1/em.1
+++ b/man/man1/em.1
@@ -1,6 +1,6 @@
 .\" Man page for em dispatcher (Email / himalaya)
 .\" Generated: June 2026
-.TH EM 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH EM 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 em \- Email dispatcher (himalaya wrapper)
 .SH SYNOPSIS

--- a/man/man1/flow.1
+++ b/man/man1/flow.1
@@ -1,6 +1,6 @@
 .\" Man page for flow command
 .\" Updated: June 2026
-.TH FLOW 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH FLOW 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 flow \- ADHD-friendly workflow CLI for developers
 .SH SYNOPSIS

--- a/man/man1/flow.1
+++ b/man/man1/flow.1
@@ -1,6 +1,6 @@
 .\" Man page for flow command
-.\" Generated: 2025-12-26
-.TH FLOW 1 "December 2025" "flow-cli 3.0.0" "User Commands"
+.\" Updated: June 2026
+.TH FLOW 1 "June 2026" "flow-cli 7.8.0" "User Commands"
 .SH NAME
 flow \- ADHD-friendly workflow CLI for developers
 .SH SYNOPSIS
@@ -164,7 +164,7 @@ Suppress welcome message. Set to 1 to enable.
 Enable debug output. Set to 1 to enable.
 .TP
 .B FLOW_VERSION
-Current version (read-only). Default: 3.0.0
+Current version (read-only). Current: 7.8.0
 .SH FILES
 .TP
 .I ~/.config/zsh/.worklog
@@ -236,30 +236,77 @@ dash         = flow dash
 .fi
 .RE
 .SH SMART DISPATCHERS
-In addition to flow commands, these dispatchers are available:
+In addition to flow commands, these 15 dispatchers plus the at bridge are available:
 .TP
 .B g \fIcmd\fR
-Git workflows (g status, g push, g commit)
-.TP
-.B r \fIcmd\fR
-R package development (r test, r doc, r check)
-.TP
-.B qu \fIcmd\fR
-Quarto publishing (qu preview, qu render)
+Git workflows: status, push, commit, branch, feature workflow, promote, release.
 .TP
 .B mcp \fIcmd\fR
-MCP server management (mcp status, mcp logs)
+MCP server management: list, cd, test, edit, pick, status, readme.
 .TP
 .B obs \fIcmd\fR
-Obsidian notes (obs daily, obs search)
+Obsidian vault management: stats, discover, vaults, analyze, ai subcommands.
+.TP
+.B qu \fIcmd\fR
+Quarto publishing: render, preview, check, clean, publish, format-specific renders, project creation.
+.TP
+.B r \fIcmd\fR
+R package development: load, test, doc, check, build, install, cycle, coverage, pkgdown.
+.TP
+.B cc \fIcmd\fR
+Claude Code launcher: open Claude with project context, worktree support.
+.TP
+.B tm \fIcmd\fR
+Terminal manager: tmux session and window management.
+.TP
+.B wt \fIcmd\fR
+Worktree management: create, list, pick, switch, and prune git worktrees.
+.TP
+.B dots \fIcmd\fR
+Dotfile management via chezmoi: sync, apply, edit, diff, and manage dotfiles.
+.TP
+.B sec \fIcmd\fR
+Secret management: store and retrieve secrets from macOS Keychain and Bitwarden.
+.TP
+.B tok \fIcmd\fR
+Token management: create, rotate, expire, and sync tokens to GitHub Actions secrets.
+.TP
+.B teach \fIcmd\fR
+Teaching workflow: Scholar integration, deploy, exam, macros, plans, prompts, doctor.
+.TP
+.B prompt \fIcmd\fR
+Prompt engine switcher: manage and switch between prompt profiles.
+.TP
+.B v \fIcmd\fR
+Vibe coding mode: AI-assisted pair programming workflows.
+.TP
+.B em \fIcmd\fR
+Email management via himalaya: read, compose, reply, search, attachments, IMAP watch.
+.TP
+.B at \fIcmd\fR
+Atlas bridge (optional): project intelligence and enhanced state management.
 .PP
-Use \fIdispatcher\fR help for details (e.g., r help, qu help).
+Use \fIdispatcher\fR\fB help\fR for details (e.g.,
+.BR "r help" ,
+.BR "qu help" ,
+.BR "teach help" ).
 .SH SEE ALSO
 .BR g (1),
 .BR r (1),
 .BR qu (1),
 .BR mcp (1),
-.BR obs (1)
+.BR obs (1),
+.BR cc (1),
+.BR tm (1),
+.BR wt (1),
+.BR dots (1),
+.BR sec (1),
+.BR tok (1),
+.BR teach (1),
+.BR prompt (1),
+.BR v (1),
+.BR em (1),
+.BR at (1)
 .PP
 Related documentation:
 .RS

--- a/man/man1/g.1
+++ b/man/man1/g.1
@@ -1,6 +1,6 @@
 .\" Man page for g dispatcher (Git workflows)
 .\" Updated: June 2026
-.TH G 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH G 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 g \- Git commands dispatcher
 .SH SYNOPSIS

--- a/man/man1/g.1
+++ b/man/man1/g.1
@@ -1,6 +1,6 @@
 .\" Man page for g dispatcher (Git workflows)
-.\" Generated: 2025-12-26
-.TH G 1 "December 2025" "flow-cli 3.0.0" "User Commands"
+.\" Updated: June 2026
+.TH G 1 "June 2026" "flow-cli 7.8.0" "User Commands"
 .SH NAME
 g \- Git commands dispatcher
 .SH SYNOPSIS
@@ -128,6 +128,31 @@ Abort rebase.
 .TP
 .B merge\fR, \fBmg
 Merge.
+.SS Feature Workflow
+.TP
+.B feature start \fIname\fR
+Create feature branch from dev.
+.TP
+.B feature sync
+Rebase feature branch onto dev.
+.TP
+.B feature list
+List feature, hotfix, and bugfix branches.
+.TP
+.B feature finish
+Push branch and create PR to dev.
+.TP
+.B feature status
+Show merged vs active feature branches.
+.TP
+.B feature prune \fR[\fB--all\fR] [\fB--dry-run\fR] [\fB--force\fR] [\fB--older-than \fIdur\fR]
+Delete merged feature/bugfix/hotfix branches.
+.TP
+.B promote
+Create PR from current feature/bugfix/hotfix branch to dev.
+.TP
+.B release
+Create PR from dev to main.
 .TP
 .B help\fR, \fBh
 Show help.
@@ -174,6 +199,7 @@ g cob feature/new-thing
 .BR qu (1),
 .BR mcp (1),
 .BR obs (1),
+.BR wt (1),
 .BR git (1)
 .SH AUTHOR
 DT

--- a/man/man1/mcp.1
+++ b/man/man1/mcp.1
@@ -1,6 +1,6 @@
 .\" Man page for mcp dispatcher (MCP server management)
-.\" Generated: 2025-12-26
-.TH MCP 1 "December 2025" "flow-cli 3.0.0" "User Commands"
+.\" Updated: June 2026
+.TH MCP 1 "June 2026" "flow-cli 7.8.0" "User Commands"
 .SH NAME
 mcp \- MCP server management dispatcher
 .SH SYNOPSIS

--- a/man/man1/mcp.1
+++ b/man/man1/mcp.1
@@ -1,6 +1,6 @@
 .\" Man page for mcp dispatcher (MCP server management)
 .\" Updated: June 2026
-.TH MCP 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH MCP 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 mcp \- MCP server management dispatcher
 .SH SYNOPSIS

--- a/man/man1/obs.1
+++ b/man/man1/obs.1
@@ -1,6 +1,6 @@
 .\" Man page for obs dispatcher (Obsidian CLI)
-.\" Generated: 2025-12-26
-.TH OBS 1 "December 2025" "flow-cli 3.0.0" "User Commands"
+.\" Updated: June 2026
+.TH OBS 1 "June 2026" "flow-cli 7.8.0" "User Commands"
 .SH NAME
 obs \- Obsidian CLI operations dispatcher
 .SH SYNOPSIS

--- a/man/man1/obs.1
+++ b/man/man1/obs.1
@@ -1,6 +1,6 @@
 .\" Man page for obs dispatcher (Obsidian CLI)
 .\" Updated: June 2026
-.TH OBS 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH OBS 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 obs \- Obsidian CLI operations dispatcher
 .SH SYNOPSIS

--- a/man/man1/prompt.1
+++ b/man/man1/prompt.1
@@ -1,6 +1,6 @@
 .\" Man page for prompt dispatcher (Prompt Engine Switcher)
 .\" Generated: June 2026
-.TH PROMPT 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH PROMPT 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 prompt \- Prompt engine switcher
 .SH SYNOPSIS

--- a/man/man1/prompt.1
+++ b/man/man1/prompt.1
@@ -1,0 +1,148 @@
+.\" Man page for prompt dispatcher (Prompt Engine Switcher)
+.\" Generated: June 2026
+.TH PROMPT 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+prompt \- Prompt engine switcher
+.SH SYNOPSIS
+.B prompt
+[\fB--dry-run\fR] \fIcommand\fR [\fIarguments\fR]
+.SH DESCRIPTION
+.B prompt
+is a dispatcher for managing the active ZSH prompt engine.
+It supports Powerlevel10k, Starship, and Oh My Posh.
+The active engine is tracked via the
+.B FLOW_PROMPT_ENGINE
+environment variable.
+.PP
+When called without arguments (or with an unknown command),
+.B prompt
+displays the built-in help.
+.PP
+The global flag
+.B --dry-run
+may be placed before any subcommand to preview what changes
+would be made without applying them.
+.SH COMMANDS
+.SS Status and Listing
+.TP
+.B status
+Show the currently active engine and list all available engines with
+description and config file path.
+Current engine is marked with a filled circle; others with an open circle.
+.TP
+.B list
+Tabular view of all engines: name, active marker, and config file path.
+.SS Switching
+.TP
+.B toggle
+Interactive engine selection menu (uses
+.I select
+). Presents all non-current engines; validates the chosen engine before switching.
+.TP
+.B starship
+Force-switch to Starship. Validates that
+.I starship
+is in
+.B PATH
+and that
+.I ~/.config/starship.toml
+exists.
+.TP
+.B p10k
+Force-switch to Powerlevel10k. Validates that the plugin is listed in
+.I ~/.config/zsh/.zsh_plugins.txt
+and that
+.I ~/.config/zsh/.p10k.zsh
+exists.
+.TP
+.B ohmyposh
+Force-switch to Oh My Posh. Validates that
+.I oh-my-posh
+is in
+.B PATH
+and that
+.I ~/.config/ohmyposh/config.json
+exists.
+.SS Setup
+.TP
+.B setup-ohmyposh
+Interactive wizard that creates a default Oh My Posh configuration at
+.IR ~/.config/ohmyposh/config.json .
+Asks for confirmation if the file already exists.
+.SS Help
+.TP
+.B help\fR, \fB--help\fR, \fB-h
+Show built-in help.
+.SH OPTIONS
+.TP
+.B --dry-run
+Preview the actions that any switch subcommand would perform, without
+applying them. Place before the subcommand:
+.RS
+.nf
+prompt --dry-run starship
+prompt --dry-run toggle
+.fi
+.RE
+.SH SUPPORTED ENGINES
+.TP
+.B powerlevel10k
+Feature-rich, highly customizable ZSH prompt.
+Config: \fI~/.config/zsh/.p10k.zsh\fR.
+.TP
+.B starship
+Minimal, fast Rust-based prompt.
+Config: \fI~/.config/starship.toml\fR.
+.TP
+.B ohmyposh
+Modular prompt with extensive themes.
+Config: \fI~/.config/ohmyposh/config.json\fR.
+.SH ENVIRONMENT
+.TP
+.B FLOW_PROMPT_ENGINE
+Name of the currently active prompt engine
+(\fIpowerlevel10k\fR, \fIstarship\fR, or \fIohmyposh\fR).
+Defaults to \fIpowerlevel10k\fR when unset or invalid.
+Switching engines exports this variable and reloads the shell
+(via \fIexec zsh -i\fR) in interactive sessions.
+.SH EXAMPLES
+Show the currently active engine:
+.RS
+.nf
+prompt status
+.fi
+.RE
+.PP
+Switch interactively:
+.RS
+.nf
+prompt toggle
+.fi
+.RE
+.PP
+Force-switch to Starship:
+.RS
+.nf
+prompt starship
+.fi
+.RE
+.PP
+Preview a switch without making changes:
+.RS
+.nf
+prompt --dry-run starship
+.fi
+.RE
+.PP
+Run the Oh My Posh setup wizard:
+.RS
+.nf
+prompt setup-ohmyposh
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR tm (1),
+.BR v (1)
+.SH AUTHOR
+DT

--- a/man/man1/qu.1
+++ b/man/man1/qu.1
@@ -1,6 +1,6 @@
 .\" Man page for qu dispatcher (Quarto publishing)
-.\" Generated: 2025-12-26
-.TH QU 1 "December 2025" "flow-cli 3.0.0" "User Commands"
+.\" Updated: June 2026
+.TH QU 1 "June 2026" "flow-cli 7.8.0" "User Commands"
 .SH NAME
 qu \- Quarto publishing dispatcher
 .SH SYNOPSIS

--- a/man/man1/qu.1
+++ b/man/man1/qu.1
@@ -1,6 +1,6 @@
 .\" Man page for qu dispatcher (Quarto publishing)
 .\" Updated: June 2026
-.TH QU 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH QU 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 qu \- Quarto publishing dispatcher
 .SH SYNOPSIS

--- a/man/man1/r.1
+++ b/man/man1/r.1
@@ -1,6 +1,6 @@
 .\" Man page for r dispatcher (R package development)
 .\" Updated: June 2026
-.TH R 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH R 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 r \- R package development dispatcher
 .SH SYNOPSIS

--- a/man/man1/r.1
+++ b/man/man1/r.1
@@ -1,6 +1,6 @@
 .\" Man page for r dispatcher (R package development)
-.\" Generated: 2025-12-26
-.TH R 1 "December 2025" "flow-cli 3.0.0" "User Commands"
+.\" Updated: June 2026
+.TH R 1 "June 2026" "flow-cli 7.8.0" "User Commands"
 .SH NAME
 r \- R package development dispatcher
 .SH SYNOPSIS

--- a/man/man1/sec.1
+++ b/man/man1/sec.1
@@ -1,6 +1,6 @@
 .\" Man page for sec dispatcher (Secret Management)
 .\" Generated: June 2026
-.TH SEC 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH SEC 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 sec \- Secret management dispatcher (Keychain and Bitwarden)
 .SH SYNOPSIS

--- a/man/man1/sec.1
+++ b/man/man1/sec.1
@@ -1,0 +1,245 @@
+.\" Man page for sec dispatcher (Secret Management)
+.\" Generated: June 2026
+.TH SEC 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+sec \- Secret management dispatcher (Keychain and Bitwarden)
+.SH SYNOPSIS
+.B sec
+[\fIcommand\fR] [\fIarguments\fR]
+.SH DESCRIPTION
+.B sec
+is a smart dispatcher for managing secrets stored in macOS Keychain and
+optionally Bitwarden.  It provides instant local access via Keychain
+(protected by Touch ID / system password) and cloud sync to Bitwarden
+for multi-machine setups.
+.PP
+The default backend is
+.B keychain
+(macOS Keychain only).  Set
+.B FLOW_SECRET_BACKEND=both
+to enable mirroring to Bitwarden, or
+.B FLOW_SECRET_BACKEND=bitwarden
+for the legacy Bitwarden-only mode.
+.PP
+When called without arguments,
+.B sec
+shows the help screen.
+.PP
+When called with an unrecognised first argument that does not match any
+subcommand,
+.B sec
+treats it as a secret name and retrieves the value from Keychain \(em
+equivalent to
+.BR "sec get \fIname\fR" .
+.SH ENVIRONMENT
+.TP
+.B FLOW_SECRET_BACKEND
+Selects the secret storage backend.  Values:
+.B keychain
+(default),
+.B bitwarden
+(legacy),
+.B both
+(Keychain primary + Bitwarden mirror for cloud sync).
+.TP
+.B BW_SESSION
+Bitwarden session token exported after a successful
+.BR "sec unlock" .
+Required for all Bitwarden operations.
+.SH COMMANDS
+.SS Keychain \(em Retrieve
+.TP
+.B \fIname\fR
+Retrieve a secret by name from Keychain (default action when no
+subcommand is recognised).  Equivalent to
+.BR "sec get \fIname\fR" .
+.TP
+.B get \fIname\fR
+Explicitly retrieve a named secret from Keychain.
+.TP
+.B list\fR, \fBls
+List all secrets stored in Keychain under the flow-cli service.
+.SS Keychain \(em Manage
+.TP
+.B add \fIname\fR
+Store a new secret in Keychain.  Prompts for the secret value
+(hidden input).  Alias:
+.BR new .
+.TP
+.B delete \fIname\fR
+Remove a named secret from Keychain.  Aliases:
+.BR rm ,
+.BR remove .
+.SS Bitwarden \(em Vault Access
+.TP
+.B unlock\fR, \fBu
+Unlock the Bitwarden vault.  Prompts for the master password,
+exports
+.B BW_SESSION
+to the current shell, and caches the session (15-minute idle
+timeout).  Required before any Bitwarden operations.
+.TP
+.B lock\fR, \fBl
+Lock the Bitwarden vault and clear the session cache.
+.TP
+.B bw \fIname\fR
+Retrieve a named secret directly from Bitwarden (bypasses Keychain).
+.TP
+.B bw list\fR | \fBbw ls
+List all items in the Bitwarden vault (requires unlock).
+.TP
+.B bw add \fIname\fR [\fB\-\-expires\fR \fIdays\fR] [\fB\-\-notes\fR \fItext\fR]
+Add a secret to Bitwarden with optional expiration tracking and notes.
+.TP
+.B bw check\fR | \fBbw expiring
+Check expiration status of Bitwarden secrets that have dot metadata.
+Warns about secrets expiring within 30 days and marks expired ones.
+.TP
+.B check
+Alias for
+.BR "sec bw check" .
+.SS Sync (Keychain \(lz\(ra Bitwarden)
+.TP
+.B sync
+Interactive sync wizard.  Shows the current state of both backends and
+prompts for direction (Keychain \(-> Bitwarden or Bitwarden \(-> Keychain).
+.TP
+.B sync \-\-status\fR | \fBsync status
+Show differences between Keychain and Bitwarden without writing anything.
+.TP
+.B sync \-\-to\-bw\fR | \fBsync push
+Push all Keychain secrets to Bitwarden.
+.TP
+.B sync \-\-from\-bw\fR | \fBsync pull
+Pull all Bitwarden secrets into Keychain.
+.SS Dashboard & Overview
+.TP
+.B status
+Show the current backend configuration (active backend, Keychain
+location, secret count, Bitwarden vault state, and the
+.B FLOW_SECRET_BACKEND
+value).
+.TP
+.B dashboard
+Full secrets overview with expiry status table for all
+dot-managed secrets in Bitwarden.
+.TP
+.B dashboard sync github
+Sync selected dot-managed secrets as GitHub Actions secrets for the
+current git repository.  Converts names to SCREAMING_SNAKE_CASE.
+Requires
+.B gh
+CLI and Bitwarden unlocked.
+.SS Diagnostics & Utilities
+.TP
+.B doctor\fR, \fBdr
+Secret-specific diagnostics.  Full implementation pending; see
+.B "flow doctor \-\-dot"
+for the current dotfile health check.
+.TP
+.B import
+Import secrets from a file into Keychain.
+.TP
+.B tutorial
+Run the interactive secret management tutorial.
+.SS Help
+.TP
+.B help\fR, \fB\-\-help\fR, \fB\-h
+Show the help screen.
+.SH EXAMPLES
+Get a secret value:
+.RS
+.nf
+sec MY_SECRET
+.fi
+.RE
+.PP
+Copy a secret to the clipboard:
+.RS
+.nf
+sec MY_SECRET | pbcopy
+.fi
+.RE
+.PP
+Use a secret in a command without exposing it in shell history:
+.RS
+.nf
+GITHUB_TOKEN=$(sec MY_TOKEN_NAME) gh pr list
+.fi
+.RE
+.PP
+Add a new secret:
+.RS
+.nf
+sec add DEPLOY_KEY
+.fi
+.RE
+.PP
+List all secrets:
+.RS
+.nf
+sec list
+.fi
+.RE
+.PP
+Delete a secret:
+.RS
+.nf
+sec delete OLD_SECRET
+.fi
+.RE
+.PP
+Unlock the Bitwarden vault:
+.RS
+.nf
+sec unlock
+.fi
+.RE
+.PP
+Lock the vault:
+.RS
+.nf
+sec lock
+.fi
+.RE
+.PP
+Retrieve a secret directly from Bitwarden:
+.RS
+.nf
+sec bw MY_SECRET
+.fi
+.RE
+.PP
+Check for expiring secrets in Bitwarden:
+.RS
+.nf
+sec check
+.fi
+.RE
+.PP
+Sync Keychain secrets to Bitwarden:
+.RS
+.nf
+sec sync --to-bw
+.fi
+.RE
+.PP
+Show backend configuration:
+.RS
+.nf
+sec status
+.fi
+.RE
+.PP
+View the secrets dashboard:
+.RS
+.nf
+sec dashboard
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR tok (1),
+.BR dots (1)
+.SH AUTHOR
+DT

--- a/man/man1/teach.1
+++ b/man/man1/teach.1
@@ -1,6 +1,6 @@
 .\" Man page for teach dispatcher (Teaching Workflow)
 .\" Generated: June 2026
-.TH TEACH 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH TEACH 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 teach \- Teaching workflow dispatcher (Scholar integration)
 .SH SYNOPSIS

--- a/man/man1/teach.1
+++ b/man/man1/teach.1
@@ -1,0 +1,432 @@
+.\" Man page for teach dispatcher (Teaching Workflow)
+.\" Generated: June 2026
+.TH TEACH 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+teach \- Teaching workflow dispatcher (Scholar integration)
+.SH SYNOPSIS
+.B teach
+[\fIcommand\fR] [\fIoptions\fR] [\fIarguments\fR]
+.SH DESCRIPTION
+.B teach
+is a comprehensive teaching workflow dispatcher that wraps the Scholar
+Claude Code plugin for AI-powered course content generation.
+It provides commands for creating lectures, slides, exams, quizzes,
+assignments, syllabi, rubrics, and more.
+.PP
+When called without arguments (or with
+.B help
+), it shows the help page along with a health indicator dot reflecting
+the last
+.B teach doctor
+run result.
+.PP
+Commands are grouped into two categories: Scholar wrappers (which
+invoke Claude + Scholar for AI-generated content) and local commands
+(which run entirely without Claude).
+.PP
+All content generation commands accept universal content flags
+(\fB--explanation\fR, \fB--math\fR, \fB--examples\fR, \fB--code\fR, \fB--diagrams\fR,
+\fB--practice-problems\fR, \fB--references\fR, \fB--proof\fR, \fB--definitions\fR)
+and selection flags (\fB--topic\fR/\fB-t\fR, \fB--week\fR/\fB-w\fR, \fB--style\fR, \fB--interactive\fR/\fB-i\fR).
+.SH COMMANDS
+.SS Content Generation (Scholar Wrappers)
+.TP
+.B lecture\fR, \fBlec \fR[\fIflags\fR]
+Generate a lecture document. Accepts content flags and style presets
+(conceptual, computational, rigorous, applied).
+.TP
+.B slides\fR, \fBsl \fR[\fIflags\fR]
+Generate presentation slides. Flags: \fB--theme\fR (default|academic|minimal),
+\fB--from-lecture\fR, \fB--format\fR (quarto|markdown).
+.TP
+.B exam\fR, \fBe \fR[\fIflags\fR]
+Generate an exam. Flags: \fB--questions\fR, \fB--duration\fR, \fB--types\fR,
+\fB--format\fR (quarto|qti|markdown).
+.TP
+.B quiz\fR, \fBq \fR[\fIflags\fR]
+Generate a quiz. Flags: \fB--questions\fR, \fB--time-limit\fR,
+\fB--format\fR (quarto|qti|markdown).
+.TP
+.B assignment\fR, \fBhw \fR[\fIflags\fR]
+Generate a homework assignment. Flags: \fB--due-date\fR, \fB--points\fR,
+\fB--format\fR (quarto|markdown).
+.TP
+.B syllabus\fR, \fBsyl \fR[\fIflags\fR]
+Generate a course syllabus. Flags: \fB--format\fR (quarto|markdown|pdf).
+.TP
+.B rubric\fR, \fBrb \fR[\fIflags\fR]
+Generate a grading rubric. Flags: \fB--criteria\fR, \fB--format\fR (quarto|markdown).
+.TP
+.B feedback\fR, \fBfb \fR[\fIflags\fR]
+Generate student feedback.
+.TP
+.B demo \fR[\fIflags\fR]
+Generate a live demo script or notebook.
+.TP
+.B solution\fR, \fBsol \fR[\fIflags\fR]
+Generate a solution document for an assignment or exam.
+.TP
+.B sync \fR[\fIflags\fR]
+Sync content with Scholar (merges production into draft branch).
+.TP
+.B validate-r\fR, \fBvr \fR[\fIflags\fR]
+Validate R code blocks in course documents via Scholar.
+.SS Setup & Initialization
+.TP
+.B init\fR, \fBi
+Initialize a new course project. Creates \fB.flow/teach-config.yml\fR
+and directory structure.
+.TP
+.B migrate-config\fR, \fBmigrate
+Migrate embedded weeks from \fBteach-config.yml\fR into a standalone
+\fB.flow/lesson-plans.yml\fR file.
+.SS Deployment
+.TP
+.B deploy\fR, \fBd \fR[\fIoptions\fR]
+Deploy the course website. Options:
+.RS
+.TP
+.B --direct
+Fast direct merge deploy (8\(en15s, bypasses PR).
+.TP
+.B --dry-run
+Simulate deployment without publishing.
+.TP
+.B --history \fR[\fIN\fR]
+Show last N deployments (default: 10).
+.TP
+.B --rollback \fR[\fIN\fR]
+Roll back to Nth previous deployment.
+.TP
+.B --sync
+Merge production into draft (ff-only first, then regular merge).
+.TP
+.B --ci
+CI-mode output (no color, exits non-zero on failure).
+.RE
+.TP
+.B archive\fR, \fBa
+Archive current course materials using the backup system.
+.TP
+.B backup\fR, \fBbk
+Manage course backups.
+.SS Health Check
+.TP
+.B doctor\fR, \fBdoc \fR[\fIoptions\fR]
+Run health check. Two modes:
+.RS
+.TP
+.B (default)
+Quick mode: checks CLI deps, R + renv, config, git, Scholar config (< 3s).
+.TP
+.B --full
+Full mode: adds per-package R checks, Quarto ext, Scholar, hooks, cache,
+macros, and style (11 categories total).
+.TP
+.B --brief
+One-line summary output.
+.TP
+.B --fix
+Interactive repair: offers renv vs system install for missing R packages.
+.TP
+.B --json
+Machine-readable JSON output.
+.TP
+.B --ci
+CI mode: exits non-zero on failure, no color.
+.TP
+.B --verbose
+Verbose output.
+.RE
+.SS Validation
+.TP
+.B validate\fR, \fBval
+Validate course content (links, math blocks, YAML front matter, R code).
+Requires Quarto and project configuration.
+.TP
+.B analyze\fR, \fBconcept\fR, \fBconcepts
+Analyze course documents for concept coverage, concept graphs, and
+prerequisite chains.
+.SS Lesson Plans
+.TP
+.B plan\fR, \fBpl \fR[\fIsubcmd\fR]
+Manage lesson plans. Subcommands:
+.RS
+.TP
+.B create \fIweek\fR
+Create a lesson plan for the given week.
+.TP
+.B list
+List all lesson plans.
+.TP
+.B show \fIweek\fR
+Show the lesson plan for a specific week.
+.TP
+.B edit \fIweek\fR
+Edit the lesson plan for a specific week.
+.TP
+.B delete \fIweek\fR
+Delete the lesson plan for a specific week.
+.RE
+.SS Content Organization
+.TP
+.B templates\fR, \fBtmpl\fR, \fBtpl \fR[\fIsubcmd\fR]
+Manage content templates stored in \fB.flow/templates/\fR.
+Subcommands: list, create, edit, delete.
+.TP
+.B macros\fR, \fBmacro\fR, \fBm \fR[\fIsubcmd\fR]
+Manage LaTeX macros for consistent mathematical notation.
+Subcommands:
+.RS
+.TP
+.B list
+List all macros.
+.TP
+.B sync
+Synchronize macros across documents.
+.TP
+.B export
+Export macros to a file.
+.RE
+.TP
+.B prompt\fR, \fBpr \fR[\fIsubcmd\fR]
+Manage AI prompt templates (3-tier resolution: local, course, global).
+Subcommands: list, show, edit, validate, export.
+.SS Style & Profiles
+.TP
+.B style\fR, \fBst \fR[\fIsubcmd\fR]
+Manage teaching styles. Available presets:
+.RS
+.TP
+.B conceptual
+Explanation + definitions + examples (intuition-focused).
+.TP
+.B computational
+Explanation + examples + code + practice (hands-on, lab-style).
+.TP
+.B rigorous
+Definitions + explanation + math + proof (graduate-level).
+.TP
+.B applied
+Explanation + examples + code + practice (real-world applications).
+.RE
+.TP
+.B profiles\fR, \fBprofile\fR, \fBprof \fR[\fIsubcmd\fR]
+Manage course profiles (saved configuration sets). Subcommands:
+list, create, switch, delete.
+.SS Status & Info
+.TP
+.B status\fR, \fBs
+Show current course project status dashboard.
+.TP
+.B week\fR, \fBw \fIweek\fR
+Show status and materials for a specific week.
+.TP
+.B map
+Show the ecosystem map of course tools and integrations (v6.6.0+).
+.TP
+.B dates
+Manage course date schedules (semester start, holidays, deadlines).
+.SS Configuration
+.TP
+.B config\fR, \fBc \fR[\fIsubcmd\fR]
+Manage course configuration (\fB.flow/teach-config.yml\fR). Subcommands:
+.RS
+.TP
+.B check
+Validate configuration against JSON schema (strict mode).
+.TP
+.B diff
+Show diff between current and reference configuration.
+.TP
+.B show
+Display current configuration.
+.TP
+.B scaffold
+Generate a scaffold configuration file.
+.TP
+.B --view
+View configuration in pager.
+.TP
+.B --cat
+Print raw configuration to stdout.
+.RE
+.SS Git Hooks
+.TP
+.B hooks\fR, \fBhook \fR[\fIsubcmd\fR]
+Manage git hooks for teaching workflow (pre-commit math validation, etc.).
+Subcommands:
+.RS
+.TP
+.B install\fR, \fBi
+Install git hooks.
+.TP
+.B upgrade\fR, \fBup
+Upgrade hooks to latest version.
+.TP
+.B uninstall\fR, \fBremove\fR, \fBrm
+Remove git hooks.
+.TP
+.B status\fR, \fBcheck\fR, \fBs
+Check current hook status.
+.RE
+.SS Cache & Cleanup
+.TP
+.B cache\fR [\fIsubcmd\fR]
+Manage AI result caches and build caches.
+Subcommands: stats, clear, warm.
+.TP
+.B clean\fR, \fBcl
+Delete \fB_freeze/\fR and \fB_site/\fR build artifacts.
+.SH CONTENT FLAGS
+Universal content flags accepted by all Scholar-wrapper commands:
+.TP
+.B --explanation\fR, \fB-e
+Include conceptual explanations.
+.TP
+.B --math\fR, \fB-m
+Use formal mathematical notation.
+.TP
+.B --examples\fR, \fB-x
+Include worked numerical examples.
+.TP
+.B --code\fR, \fB-c
+Include code demonstrations (R/Python).
+.TP
+.B --diagrams\fR, \fB-d
+Include visual diagrams and plots.
+.TP
+.B --practice-problems\fR, \fB-p
+Include practice exercises.
+.TP
+.B --references\fR, \fB-r
+Include citations and references.
+.TP
+.B --proof
+Include mathematical proofs.
+.TP
+.B --definitions
+Include formal definitions.
+.PP
+Prefix any flag with
+.B --no-
+to explicitly exclude that element (e.g., \fB--no-examples\fR).
+.SH SELECTION FLAGS
+.TP
+.B --topic \fItopic\fR\fR, \fB-t \fItopic\fR
+Specify a topic string directly.
+.TP
+.B --week \fIN\fR\fR, \fB-w \fIN\fR
+Use week N from the lesson plan schedule.
+.TP
+.B --style \fIpreset\fR
+Apply a content style preset (conceptual, computational, rigorous, applied).
+.TP
+.B --interactive\fR, \fB-i
+Launch interactive wizard for topic and style selection.
+.SH EXAMPLES
+Initialize a new course:
+.RS
+.nf
+teach init
+.fi
+.RE
+.PP
+Generate lecture for week 3:
+.RS
+.nf
+teach lecture --week 3
+teach lecture -w 3 --style computational
+.fi
+.RE
+.PP
+Generate an exam with 10 questions:
+.RS
+.nf
+teach exam --topic "Regression" --questions 10
+teach exam -t "Regression" --format qti
+.fi
+.RE
+.PP
+Generate slides with custom content flags:
+.RS
+.nf
+teach slides -w 5 --math --examples --no-code
+.fi
+.RE
+.PP
+Interactive content generation:
+.RS
+.nf
+teach lecture --interactive
+.fi
+.RE
+.PP
+Deploy with PR workflow:
+.RS
+.nf
+teach deploy
+teach deploy --direct   # fast merge, skip PR
+.fi
+.RE
+.PP
+Run health check:
+.RS
+.nf
+teach doctor
+teach doctor --full
+teach doctor --fix
+.fi
+.RE
+.PP
+Manage lesson plans:
+.RS
+.nf
+teach plan create 8
+teach plan list
+teach plan show 8
+.fi
+.RE
+.PP
+Manage macros:
+.RS
+.nf
+teach macros list
+teach macros sync
+.fi
+.RE
+.PP
+Validate configuration:
+.RS
+.nf
+teach config check
+teach config show
+teach config scaffold
+.fi
+.RE
+.SH FILES
+.TP
+.I .flow/teach-config.yml
+Course configuration file (JSON Schema validated).
+.TP
+.I .flow/lesson-plans.yml
+Lesson plan schedule (week topics, styles, objectives).
+.TP
+.I .flow/templates/
+Content templates (prompts, metadata, checklists).
+.TP
+.I .flow/doctor-status.json
+Cached health status used by the health indicator dot.
+.SH ENVIRONMENT
+.TP
+.B FLOW_PROJECTS_ROOT
+Root directory for project scanning.
+.SH SEE ALSO
+.BR flow (1),
+.BR em (1),
+.BR at (1),
+.BR g (1),
+.BR qu (1),
+.BR r (1)
+.SH AUTHOR
+DT

--- a/man/man1/tm.1
+++ b/man/man1/tm.1
@@ -1,0 +1,176 @@
+.\" Man page for tm dispatcher (Terminal Manager)
+.\" Generated: June 2026
+.TH TM 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+tm \- Terminal manager dispatcher
+.SH SYNOPSIS
+.B tm
+[\fIcommand\fR] [\fIarguments\fR]
+.SH DESCRIPTION
+.B tm
+is a dispatcher for terminal management.
+It provides instant shell-native commands (no Python required) for common
+terminal operations and delegates richer features to the
+.B aiterm
+Python CLI (invoked as
+.BR ait ).
+.PP
+When called without arguments,
+.B tm
+shows the built-in help.
+.PP
+If
+.B aiterm
+is not installed, all subcommands except shell-native ones print an
+installation hint. Unknown subcommands are passed through to
+.B ait
+directly.
+.SH COMMANDS
+.SS Shell-Native Commands (instant, no Python)
+.TP
+.B title \fItext\fR, \fBt \fItext\fR
+Set the terminal tab/window title using the universal OSC 2 escape sequence.
+Works in any terminal that supports OSC 2.
+.TP
+.B profile \fIname\fR, \fBp \fIname\fR
+Switch the iTerm2 profile to
+.IR name .
+Has no effect (and prints an error) when run outside iTerm2.
+.TP
+.B var \fIkey\fR \fIvalue\fR, \fBv \fIkey\fR \fIvalue\fR
+Set an iTerm2 user variable for use in the iTerm2 status bar.
+Requires iTerm2; not supported in other terminals.
+.TP
+.B which\fR, \fBw
+Detect and print the name of the current terminal emulator
+(iterm2, ghostty, wezterm, kitty, alacritty, vscode, terminal, or unknown).
+.SS Aiterm Delegation Commands
+These subcommands require
+.B aiterm
+(install: \fIbrew install data-wise/tap/aiterm\fR).
+.TP
+.B ghost\fR [\fIsubcmd\fR], \fBg\fR [\fIsubcmd\fR], \fBghostty\fR [\fIsubcmd\fR]
+Ghostty-specific controls. Notable sub-subcommands:
+.RS
+.TP
+.B theme \fIname\fR
+Set the Ghostty theme.
+.TP
+.B font\fR [\fIname\fR]
+Get or set the Ghostty font.
+.RE
+Requires aiterm >= 0.3.9.
+.TP
+.B switch\fR, \fBs
+Apply terminal context for the current project (delegates to
+.IR "ait switch" ).
+.TP
+.B detect\fR, \fBd
+Detect the current project context (delegates to
+.IR "ait detect" ).
+.TP
+.B doctor
+Check terminal health. Uses
+.I ait terminals doctor
+(aiterm >= 0.3.9) or falls back to
+.IR "ait doctor" .
+.TP
+.B status
+Display detected terminal information (delegates to
+.IR "ait terminals detect" ).
+.TP
+.B compare
+Compare terminal feature sets (requires aiterm >= 0.3.9).
+.TP
+.B features \fR[\fIargs\fR]
+Show terminal feature details (delegates to
+.IR "ait terminals features" ).
+.SS Help
+.TP
+.B help\fR, \fB--help\fR, \fB-h
+Show built-in help.
+.SH ALIASES
+.TP
+.B tmt
+Alias for
+.IR "tm title" .
+.TP
+.B tmp
+Alias for
+.IR "tm profile" .
+.TP
+.B tmv
+Alias for
+.IR "tm var" .
+.TP
+.B tmw
+Alias for
+.IR "tm which" .
+.TP
+.B tmg
+Alias for
+.IR "tm ghost" .
+.TP
+.B tms
+Alias for
+.IR "tm switch" .
+.TP
+.B tmd
+Alias for
+.IR "tm detect" .
+.SH ENVIRONMENT
+.TP
+.B TERM_PROGRAM
+Used to detect the running terminal emulator.
+.TP
+.B KITTY_WINDOW_ID
+Set by Kitty; used in terminal detection.
+.TP
+.B ALACRITTY_WINDOW_ID
+Set by Alacritty; used in terminal detection.
+.TP
+.B TM_AUTO_SWITCH
+When set, enables automatic
+.I tm switch
+on directory change (chpwd hook).
+.SH EXAMPLES
+Set the window title:
+.RS
+.nf
+tm title "Feature XYZ"
+.fi
+.RE
+.PP
+Switch to a named iTerm2 profile:
+.RS
+.nf
+tm profile dev
+.fi
+.RE
+.PP
+Identify the active terminal:
+.RS
+.nf
+tm which
+.fi
+.RE
+.PP
+Set a Ghostty theme:
+.RS
+.nf
+tm ghost theme catppuccin
+.fi
+.RE
+.PP
+Check terminal health:
+.RS
+.nf
+tm doctor
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR cc (1),
+.BR wt (1)
+.SH AUTHOR
+DT

--- a/man/man1/tm.1
+++ b/man/man1/tm.1
@@ -1,6 +1,6 @@
 .\" Man page for tm dispatcher (Terminal Manager)
 .\" Generated: June 2026
-.TH TM 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH TM 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 tm \- Terminal manager dispatcher
 .SH SYNOPSIS

--- a/man/man1/tok.1
+++ b/man/man1/tok.1
@@ -1,6 +1,6 @@
 .\" Man page for tok dispatcher (Token Management)
 .\" Generated: June 2026
-.TH TOK 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH TOK 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 tok \- Token lifecycle management dispatcher
 .SH SYNOPSIS

--- a/man/man1/tok.1
+++ b/man/man1/tok.1
@@ -1,0 +1,243 @@
+.\" Man page for tok dispatcher (Token Management)
+.\" Generated: June 2026
+.TH TOK 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+tok \- Token lifecycle management dispatcher
+.SH SYNOPSIS
+.B tok
+[\fIcommand\fR] [\fIarguments\fR] [\fB\-\-no\-sync\fR]
+.SH DESCRIPTION
+.B tok
+is a smart dispatcher for API token lifecycle management. It provides
+interactive creation wizards, expiration tracking, rotation workflows, and
+automatic fan-out to GitHub Actions secrets.
+.PP
+Tokens are stored in macOS Keychain (default) and optionally mirrored to
+Bitwarden for cloud backup. Each token is stored with JSON metadata
+(version, type, creation date, expiration) to enable fast expiration
+checks without decrypting the token value.
+.PP
+When called without arguments,
+.B tok
+shows the help screen.
+.PP
+The flag
+.B \-\-no\-sync
+may be passed anywhere on the command line to suppress the automatic
+post-store/post-rotate GitHub Actions secret fan-out for that invocation.
+The environment variable
+.B FLOW_TOK_AUTOSYNC
+provides a persistent override (set to
+.B 0
+to disable auto-sync globally).
+.PP
+The flag
+.B \-\-refresh
+(or
+.BR \-r )
+may be placed anywhere on the command line to trigger rotation of an
+existing named token.  For example:
+.B tok my-token \-\-refresh
+.SH ENVIRONMENT
+.TP
+.B FLOW_TOK_AUTOSYNC
+Controls automatic fan-out of newly stored or rotated tokens to
+configured GitHub Actions secrets.  Set to
+.B 0
+to disable globally.  Default: enabled (equivalent to
+.BR 1 ).
+Per-invocation override: pass
+.B \-\-no\-sync
+on the command line.
+.TP
+.B FLOW_SECRET_BACKEND
+Selects the secret storage backend.  Values:
+.B keychain
+(default \- macOS Keychain only),
+.B bitwarden
+(Bitwarden only, legacy),
+.B both
+(Keychain primary + Bitwarden mirror).
+.SH COMMANDS
+.SS Token Wizards
+Interactive guided flows that open the provider's website, validate the
+token, store it with expiry metadata, and auto-sync to GitHub Actions.
+.TP
+.B github\fR, \fBgh
+GitHub Personal Access Token wizard.  Prompts for PAT type (classic
+.I ghp_*
+or fine-grained
+.I github_pat_*
+), opens GitHub in the browser, validates the token against
+.I api.github.com
+, and stores it in Keychain/Bitwarden with expiry metadata.
+.TP
+.B npm
+NPM access token wizard.  Prompts for token type (automation,
+read-only, or granular access), opens npmjs.com, validates format
+.RI ( npm_*
+prefix), and stores the token.
+.TP
+.B pypi\fR, \fBpip
+PyPI API token wizard.  Prompts for scope (account-wide or
+project-scoped), opens pypi.org, validates format
+.RI ( pypi-
+prefix), and stores the token.  Note: for CI/CD, consider PyPI
+Trusted Publishing (GitHub OIDC) instead.
+.SS Expiration & Rotation
+.TP
+.B expiring
+Check expiration status of stored tokens.  Queries the GitHub API to
+detect expired or nearly-expired tokens (< 7 days remaining on a
+90-day window).  Offers to launch
+.B tok rotate
+interactively.
+.TP
+.B rotate \fR[\fIname\fR]
+Rotate an existing token.  Backs up the current token, launches the
+provider wizard to create a new one, validates it, optionally prompts
+for old-token revocation, then auto-syncs the new value to
+configured GitHub Actions secrets.  Defaults to
+.IR github-token .
+.TP
+.IB name " \-\-refresh"
+Rotate a specific named token without going through
+.BR tok rotate .
+Looks up the token in the vault, determines its provider type (github,
+npm, or pypi) from stored metadata, opens the provider's token page,
+and updates the vault entry with a new value.
+.SS Sync
+.TP
+.B sync gh\fR | \fBsync github
+Re-authenticate the
+.B gh
+CLI using the stored
+.I github-token
+from Keychain.  Reads the token via
+.B sec
+and pipes it to
+.BR "gh auth login \-\-with\-token" .
+.TP
+.B sync push \fIname\fR
+Fan out a named token to all configured GitHub Actions secret targets.
+Reads the token value from the vault and calls
+.B gh secret set
+for each configured repository/secret mapping.  This is the same
+fan-out triggered automatically after
+.B tok github
+(or any wizard) unless suppressed with
+.B \-\-no\-sync
+/
+.BR FLOW_TOK_AUTOSYNC=0 .
+.TP
+.B sync repos \fIname\fR
+Dry run: list the configured GitHub Actions secret targets for a named
+token without writing anything.  Shows
+.I repo\fB:\fIsecret
+pairs for push targets and a Trusted Publishing note for OIDC targets.
+.SS Diagnostics
+.TP
+.B doctor\fR, \fBdr
+Token health check.  Currently surfaces quick diagnostics; for a
+comprehensive check use
+.B tok expiring
+and
+.BR "tok sync gh" .
+See also
+.BR "flow doctor \-\-dot" .
+.SS Help
+.TP
+.B help\fR, \fB\-\-help\fR, \fB\-h
+Show the help screen.
+.SH EXAMPLES
+Create a new GitHub PAT:
+.RS
+.nf
+tok github
+.fi
+.RE
+.PP
+Create a new NPM token:
+.RS
+.nf
+tok npm
+.fi
+.RE
+.PP
+Create a new PyPI token:
+.RS
+.nf
+tok pypi
+.fi
+.RE
+.PP
+Check which tokens are expiring:
+.RS
+.nf
+tok expiring
+.fi
+.RE
+.PP
+Rotate the default github-token:
+.RS
+.nf
+tok rotate
+.fi
+.RE
+.PP
+Rotate a specific named token interactively:
+.RS
+.nf
+tok MY_TOKEN_NAME \-\-refresh
+.fi
+.RE
+.PP
+Authenticate gh CLI with the stored GitHub token:
+.RS
+.nf
+tok sync gh
+.fi
+.RE
+.PP
+Fan out a token to all configured GitHub Actions secrets:
+.RS
+.nf
+tok sync push MY_TOKEN_NAME
+.fi
+.RE
+.PP
+Preview what
+.B sync push
+would write (dry run):
+.RS
+.nf
+tok sync repos MY_TOKEN_NAME
+.fi
+.RE
+.PP
+Store a new GitHub token without triggering auto-sync:
+.RS
+.nf
+tok github \-\-no\-sync
+.fi
+.RE
+.PP
+Disable auto-sync persistently, then rotate:
+.RS
+.nf
+FLOW_TOK_AUTOSYNC=0 tok rotate
+.fi
+.RE
+.PP
+Run the token health check:
+.RS
+.nf
+tok doctor
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR sec (1),
+.BR dots (1)
+.SH AUTHOR
+DT

--- a/man/man1/v.1
+++ b/man/man1/v.1
@@ -1,6 +1,6 @@
 .\" Man page for v dispatcher (Vibe / Workflow Automation)
 .\" Generated: June 2026
-.TH V 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH V 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 v \- Workflow automation dispatcher (vibe coding mode)
 .SH SYNOPSIS

--- a/man/man1/v.1
+++ b/man/man1/v.1
@@ -1,0 +1,167 @@
+.\" Man page for v dispatcher (Vibe / Workflow Automation)
+.\" Generated: June 2026
+.TH V 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+v \- Workflow automation dispatcher (vibe coding mode)
+.SH SYNOPSIS
+.B v
+[\fIcommand\fR] [\fIarguments\fR]
+.br
+.B vibe
+[\fIcommand\fR] [\fIarguments\fR]
+.SH DESCRIPTION
+.B v
+(also invokable as
+.BR vibe )
+is a workflow automation dispatcher covering testing, ecosystem coordination,
+sprint planning, activity logging, and session management.
+.PP
+When called without arguments,
+.B v
+prints a short usage hint.
+Unknown commands produce an error and suggest
+.IR "v help" .
+.SH COMMANDS
+.SS Testing
+.TP
+.B test\fR, \fBt
+Run tests in auto-detect mode (delegates to
+.IR pt ).
+.TP
+.B test watch\fR, \fBt w
+Run tests in watch mode.
+.TP
+.B test cov\fR, \fBtest coverage\fR, \fBt c
+Run tests with coverage report.
+.TP
+.B test scaffold\fR, \fBt s
+Generate a test template for the current project.
+.TP
+.B test file \fIpath\fR, \fBt f \fIpath\fR
+Run tests for a specific file.
+.TP
+.B test docs\fR, \fBt d
+Generate test documentation.
+.SS Coordination
+.TP
+.B coord\fR, \fBc
+Show ecosystem coordination overview.
+.TP
+.B coord sync
+Sync the ecosystem.
+.TP
+.B coord status
+Ecosystem dashboard.
+.TP
+.B coord deps
+Dependency graph.
+.TP
+.B coord release
+Coordinate a release across the ecosystem.
+.SS Planning
+.TP
+.B plan\fR, \fBp
+Show the current sprint.
+.TP
+.B plan sprint
+Sprint management.
+.TP
+.B plan roadmap
+View the roadmap.
+.TP
+.B plan add
+Add a task.
+.TP
+.B plan backlog
+View the backlog.
+.SS Activity Logging
+These subcommands delegate to the
+.B workflow
+command.
+.TP
+.B log\fR, \fBl
+Show recent activity log.
+.TP
+.B log today
+Show today's log.
+.TP
+.B log started
+Log session start.
+.SS Direct Command Aliases
+.TP
+.B dash\fR, \fBd
+Open the project dashboard (delegates to
+.IR dash ).
+.TP
+.B status\fR, \fBs
+Show project status (delegates to
+.IR status ).
+.TP
+.B health
+Run a combined system health check.
+.SS Session Management
+.TP
+.B start\fR, \fBbegin
+Start a new work session (delegates to
+.IR startsession ).
+.TP
+.B end\fR, \fBstop
+End the current work session (delegates to
+.IR endsession ).
+.TP
+.B morning\fR, \fBgm
+Run the morning routine (delegates to
+.IR pmorning ).
+.TP
+.B night\fR, \fBgn
+Run the night routine (delegates to
+.IR pnight ).
+.TP
+.B progress\fR, \fBprog
+Check progress (delegates to
+.IR progress_check ).
+.SS Help
+.TP
+.B help\fR, \fBh\fR, \fB--help\fR, \fB-h
+Show built-in help.
+.SH EXAMPLES
+Run tests (auto-detect framework):
+.RS
+.nf
+v test
+.fi
+.RE
+.PP
+Run tests in watch mode:
+.RS
+.nf
+v test watch
+.fi
+.RE
+.PP
+Show the project dashboard:
+.RS
+.nf
+v dash
+.fi
+.RE
+.PP
+View the current sprint:
+.RS
+.nf
+v plan
+.fi
+.RE
+.PP
+Sync the ecosystem using the full command name:
+.RS
+.nf
+vibe coord sync
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR cc (1),
+.BR prompt (1)
+.SH AUTHOR
+DT

--- a/man/man1/wt.1
+++ b/man/man1/wt.1
@@ -1,0 +1,157 @@
+.\" Man page for wt dispatcher (Git Worktree Management)
+.\" Generated: June 2026
+.TH WT 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.SH NAME
+wt \- Git worktree management dispatcher
+.SH SYNOPSIS
+.B wt
+[\fIcommand\fR] [\fIarguments\fR]
+.SH DESCRIPTION
+.B wt
+is a smart dispatcher for managing Git worktrees.
+It provides creation, listing, cleanup, and status inspection of worktrees
+stored under a configurable base directory (default:
+.IR ~/.git-worktrees/ ).
+.PP
+When called without arguments,
+.B wt
+shows a formatted overview of all worktrees with branch name, status,
+Claude session indicator, and path.
+When called with an unknown argument that is not a recognized subcommand,
+.B wt
+treats it as a project-name filter and displays only matching worktrees.
+Unrecognized subcommands also pass through to
+.B git worktree
+directly.
+.SH COMMANDS
+.SS Overview and Listing
+.TP
+.B (none)
+Display a formatted table of all worktrees showing branch, status
+(active, merged, stale, main), Claude session indicator, and path.
+.TP
+.B \fIfilter\fR
+Display only worktrees whose project name matches
+.IR filter .
+.TP
+.B list\fR, \fBls\fR, \fBl
+Raw
+.I git worktree list
+output.
+.TP
+.B status\fR, \fBst
+Detailed view showing disk size, merge status, and per-worktree health.
+.SS Create and Move
+.TP
+.B create \fIbranch\fR, \fBadd \fIbranch\fR, \fBc \fIbranch\fR
+Create a new worktree at
+.I $FLOW_WORKTREE_DIR/<project>/<branch>
+for
+.IR branch .
+If the branch does not yet exist locally,
+.B git worktree add -b
+is used to create it.
+.TP
+.B move\fR, \fBmv
+Move the current branch into a worktree.
+Equivalent to running
+.I wt create
+for the current branch.
+Protected branches (main, master, dev) cannot be moved.
+.SS Cleanup
+.TP
+.B clean
+Run
+.I git worktree prune
+to remove stale worktree references.
+.TP
+.B prune\fR [\fIoptions\fR]
+Comprehensive cleanup: prunes stale references, then finds and optionally
+removes worktrees for merged feature/bugfix/hotfix branches.
+Options:
+.RS
+.TP
+.B --dry-run\fR, \fB-n
+Show what would be removed without making changes.
+.TP
+.B --force\fR, \fB-f
+Skip confirmation prompts.
+.TP
+.B --branches\fR, \fB-b
+Also delete the merged branches after removing their worktrees.
+.RE
+.SS Remove
+.TP
+.B remove \fIpath\fR, \fBrm \fIpath\fR
+Remove the worktree at
+.IR path .
+.SS Help
+.TP
+.B help\fR, \fBh\fR, \fB--help\fR, \fB-h
+Show built-in help.
+.SH PASSTHROUGH
+Any subcommand not listed above is passed directly to
+.BR "git worktree" :
+.RS
+.nf
+wt lock <path>    -> git worktree lock <path>
+wt unlock <path>  -> git worktree unlock <path>
+wt repair         -> git worktree repair
+.fi
+.RE
+.SH ENVIRONMENT
+.TP
+.B FLOW_WORKTREE_DIR
+Base directory for worktrees. Default:
+.IR ~/.git-worktrees .
+New worktrees are created at
+.IR $FLOW_WORKTREE_DIR/<project>/<branch> .
+.SH EXAMPLES
+Show all worktrees:
+.RS
+.nf
+wt
+.fi
+.RE
+.PP
+Filter to show only flow-cli worktrees:
+.RS
+.nf
+wt flow
+.fi
+.RE
+.PP
+Create a worktree for a feature branch:
+.RS
+.nf
+wt create feature/auth
+.fi
+.RE
+.PP
+Prune merged worktrees (dry run first):
+.RS
+.nf
+wt prune --dry-run
+wt prune --branches
+.fi
+.RE
+.PP
+Remove a specific worktree:
+.RS
+.nf
+wt remove ~/.git-worktrees/myproject/feature-auth
+.fi
+.RE
+.PP
+Move current branch to a worktree:
+.RS
+.nf
+wt move
+.fi
+.RE
+.SH SEE ALSO
+.BR flow (1),
+.BR cc (1),
+.BR g (1)
+.SH AUTHOR
+DT

--- a/man/man1/wt.1
+++ b/man/man1/wt.1
@@ -1,6 +1,6 @@
 .\" Man page for wt dispatcher (Git Worktree Management)
 .\" Generated: June 2026
-.TH WT 1 "June 2026" "flow-cli 7.8.0" "User Commands"
+.TH WT 1 "June 2026" "flow-cli 7.8.1" "User Commands"
 .SH NAME
 wt \- Git worktree management dispatcher
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,6 +39,14 @@ sed -i '' "s/v[0-9]*\.[0-9]*\.[0-9]*/v$VERSION/g" CLAUDE.md
 echo "🔌 Updating flow.plugin.zsh..."
 sed -i '' "s/FLOW_VERSION=\"[^\"]*\"/FLOW_VERSION=\"$VERSION\"/" flow.plugin.zsh
 
+# 4b. Update man-page .TH version lines (anti-drift backstop for the CI guard)
+echo "📚 Updating man pages (man/man1/*.1)..."
+for _man in man/man1/*.1; do
+    [[ -f "$_man" ]] || continue
+    # Only rewrite flow-cli pages; leave vendored pages (e.g. scribe.1) alone.
+    sed -i '' "s/\"flow-cli [0-9]*\.[0-9]*\.[0-9]*\"/\"flow-cli $VERSION\"/" "$_man"
+done
+
 # 5. Update CC-DISPATCHER-REFERENCE.md (archived)
 echo "📖 Updating CC-DISPATCHER-REFERENCE.md..."
 if [[ -f "docs/reference/.archive/CC-DISPATCHER-REFERENCE.md" ]]; then

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -111,6 +111,7 @@ echo "Regression tests:"
 run_test ./tests/test-local-path-regression.zsh
 run_test ./tests/test-readonly-scope-regression.zsh
 run_test ./tests/test-terminal-hygiene-regression.zsh
+run_test ./tests/test-manpage-version-sync.zsh
 
 echo ""
 echo "Dogfooding tests:"

--- a/tests/test-manpage-version-sync.zsh
+++ b/tests/test-manpage-version-sync.zsh
@@ -1,0 +1,241 @@
+#!/usr/bin/env zsh
+# test-manpage-version-sync.zsh - Anti-drift guard for man pages
+#
+# Problem this guards: the man/man1/ set silently froze at flow-cli 3.0.0
+# (2025-12-26) while FLOW_VERSION marched to 7.8.0 — `man flow` became a lie.
+# This guard fails CI whenever any flow-cli man page's .TH version string
+# diverges from FLOW_VERSION in flow.plugin.zsh, so the freeze can't recur.
+#
+# .TH line format (the 2nd quoted field is "<product> <version>"):
+#     .TH G 1 "December 2025" "flow-cli 7.8.0" "User Commands"
+#                              ^^^^^^^^ ^^^^^
+#                              product  version
+#
+# Scope: ONLY pages whose product token == "flow-cli". A vendored page like
+# scribe.1 ("scribe 1.1.0") tracks its own version and must NOT be flagged.
+#
+# This file also guards man-page COVERAGE: every dispatcher (a public top-level
+# command function in lib/dispatchers/*.zsh or lib/atlas-bridge.zsh, aliases
+# excluded) must have a man/man1/<cmd>.1, and no flow-cli page may be an orphan
+# (a page with no matching dispatcher). So adding a dispatcher without its page —
+# or deleting a dispatcher but leaving its page — fails CI.
+#
+# Standalone harness (no test-framework.zsh), consistent with the sibling
+# source-scan guards (test-terminal-hygiene-regression.zsh etc.): these assert
+# static invariants with awk over .TH lines, not runtime behavior. run_check is
+# intentionally distinct from pass/fail/log_test/run_test to avoid
+# dogfood-test-quality.zsh's inline-framework check.
+#
+# Usage: zsh tests/test-manpage-version-sync.zsh
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'
+CYAN='\033[0;36m'; DIM='\033[2m'; RESET='\033[0m'
+
+CHECKS_RUN=0; CHECKS_PASSED=0; CHECKS_FAILED=0
+
+run_check() {
+    local check_name="$1" check_func="$2"
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    echo -n "${CYAN}[$CHECKS_RUN] $check_name...${RESET} "
+    local output
+    if output=$(eval "$check_func" 2>&1); then
+        echo "${GREEN}✓${RESET}"; CHECKS_PASSED=$((CHECKS_PASSED + 1))
+    else
+        echo "${RED}✗${RESET}"; [[ -n "$output" ]] && echo "    ${DIM}$output${RESET}"
+        CHECKS_FAILED=$((CHECKS_FAILED + 1))
+    fi
+}
+
+PLUGIN="$PROJECT_ROOT/flow.plugin.zsh"
+MAN_DIR="$PROJECT_ROOT/man/man1"
+DISP_DIR="$PROJECT_ROOT/lib/dispatchers"
+ATLAS="$PROJECT_ROOT/lib/atlas-bridge.zsh"
+
+# ── .TH parsing primitives (the core logic) ─────────────────────────────────
+
+# 2nd quoted field of the first .TH line, e.g. `flow-cli 7.8.0`.
+_th_source_field() { awk -F'"' '/^\.TH/ {print $4; exit}' "$1"; }
+# Product token (everything before the last space), e.g. `flow-cli`.
+_th_product() { local f; f=$(_th_source_field "$1"); print -r -- "${f% *}"; }
+# Version token (everything after the last space), e.g. `7.8.0`.
+_th_version() { local f; f=$(_th_source_field "$1"); print -r -- "${f##* }"; }
+
+_flow_version() {
+    grep -oE 'FLOW_VERSION="?[0-9]+\.[0-9]+\.[0-9]+' "$PLUGIN" \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
+}
+
+# ── dispatcher-command extraction (for the coverage / missing-page guard) ────
+# A "dispatcher" is a public top-level command function (e.g. `tok() { ... }`)
+# defined in a dispatcher source file. We derive the set from the functions the
+# shell actually exposes — NOT from filenames (irregular: obs.zsh,
+# email-dispatcher.zsh -> em, at lives in atlas-bridge.zsh) and NOT from a
+# `_<cmd>_help` convention (teach has none). Pure aliases whose entire body is a
+# lone `<cmd> "$@"` delegation (e.g. vibe -> v) are excluded.
+#
+# Body of a top-level `name() {` ... up to the first `}` at column 0.
+_msync_func_body() {
+    local file="$1" fn="$2"
+    awk -v fn="$fn" '
+        $0 ~ "^" fn "\\(\\) *\\{" {f=1; next}
+        f && /^\}/ {exit}
+        f {print}
+    ' "$file"
+}
+
+# Print dispatcher command names found across the given source files, one per
+# line, sorted/unique, aliases removed.
+_msync_dispatcher_cmds() {
+    local file name body sig
+    for file in "$@"; do
+        [[ -f "$file" ]] || continue
+        for name in ${(f)"$(grep -oE '^[a-z][a-z0-9]*\(\) \{' "$file" | sed 's/() {//')"}; do
+            body=$(_msync_func_body "$file" "$name")
+            sig=$(echo "$body" | grep -vE '^[[:space:]]*(#|$)')   # drop comments + blanks
+            # pure-alias delegation: exactly one statement, `<word> "$@"`
+            if [[ $(echo "$sig" | grep -c .) -eq 1 ]] \
+               && echo "$sig" | grep -qE '^[[:space:]]*[a-z][a-z0-9]*[[:space:]]+"\$@"[[:space:]]*$'; then
+                continue
+            fi
+            echo "$name"
+        done
+    done | sort -u
+}
+
+# ── logic self-tests (prove the parser, independent of real page state) ──────
+# These pass immediately and stay green; they prove the guard CATCHES a
+# mismatch and PASSES a synced page (Review Checklist: "Guard fails on a
+# deliberately-mismatched .TH, passes when synced.").
+
+run_check "FLOW_VERSION is extractable from flow.plugin.zsh" '
+    v=$(_flow_version)
+    [[ "$v" =~ "^[0-9]+\.[0-9]+\.[0-9]+$" ]] || { echo "got: [$v]"; exit 1; }
+'
+
+run_check "parser reads version + product from a synced .TH fixture" '
+    tmp=$(mktemp -d); trap "rm -rf $tmp" EXIT
+    print -r -- ".TH FOO 1 \"June 2026\" \"flow-cli 7.8.0\" \"User Commands\"" > "$tmp/foo.1"
+    [[ "$(_th_product "$tmp/foo.1")" == "flow-cli" ]] || { echo "product wrong: $(_th_product "$tmp/foo.1")"; exit 1; }
+    [[ "$(_th_version "$tmp/foo.1")" == "7.8.0" ]]    || { echo "version wrong: $(_th_version "$tmp/foo.1")"; exit 1; }
+'
+
+run_check "parser flags a deliberately-mismatched .TH version" '
+    tmp=$(mktemp -d); trap "rm -rf $tmp" EXIT
+    print -r -- ".TH BAR 1 \"June 2026\" \"flow-cli 1.2.3\" \"User Commands\"" > "$tmp/bar.1"
+    [[ "$(_th_version "$tmp/bar.1")" != "7.8.0" ]] || { echo "should differ from 7.8.0"; exit 1; }
+'
+
+run_check "parser identifies non-flow-cli (vendored) pages by product" '
+    tmp=$(mktemp -d); trap "rm -rf $tmp" EXIT
+    print -r -- ".TH SCRIBE 1 \"June 2026\" \"scribe 1.1.0\" \"User Commands\"" > "$tmp/scribe.1"
+    [[ "$(_th_product "$tmp/scribe.1")" == "scribe" ]] || { echo "product: $(_th_product "$tmp/scribe.1")"; exit 1; }
+'
+
+# ── the real assertion: every flow-cli man page matches FLOW_VERSION ─────────
+# RED until Wave 2 bumps the .TH lines from 3.0.0 -> FLOW_VERSION.
+
+run_check "at least one flow-cli man page is present" '
+    found=0
+    for p in "$MAN_DIR"/*.1(N); do
+        [[ "$(_th_product "$p")" == "flow-cli" ]] && found=$((found+1))
+    done
+    (( found > 0 )) || { echo "no flow-cli .TH pages under $MAN_DIR"; exit 1; }
+'
+
+run_check "every flow-cli man page .TH version == FLOW_VERSION" '
+    want=$(_flow_version)
+    checked=0; stale=""
+    for p in "$MAN_DIR"/*.1(N); do
+        [[ "$(_th_product "$p")" == "flow-cli" ]] || continue   # skip vendored pages
+        checked=$((checked+1))
+        v=$(_th_version "$p")
+        [[ "$v" == "$want" ]] || stale+="${p:t}=$v "
+    done
+    (( checked > 0 )) || { echo "no flow-cli pages checked"; exit 1; }
+    if [[ -n "$stale" ]]; then
+        echo "stale pages (expected flow-cli $want): $stale"
+        echo "    fix: bump the .TH 2nd field to \"flow-cli $want\" on each"
+        exit 1
+    fi
+'
+
+# ── coverage / missing-page logic self-tests (fixtures) ─────────────────────
+# Prove the detector flags a dispatcher with no page, and ignores aliases and
+# non-dispatcher helper files — independent of the real tree.
+
+run_check "coverage detector finds a real dispatcher function" '
+    tmp=$(mktemp -d); trap "rm -rf $tmp" EXIT
+    printf "foo() {\n  case \"\$1\" in\n    *) _foo_help ;;\n  esac\n}\n" > "$tmp/foo-dispatcher.zsh"
+    cmds=$(_msync_dispatcher_cmds "$tmp/foo-dispatcher.zsh")
+    [[ "$cmds" == "foo" ]] || { echo "got: [$cmds]"; exit 1; }
+'
+
+run_check "coverage detector flags a dispatcher missing its man page" '
+    tmp=$(mktemp -d); trap "rm -rf $tmp" EXIT
+    mkdir -p "$tmp/man"
+    printf "foo() {\n  case \"\$1\" in\n    *) _foo_help ;;\n  esac\n}\n" > "$tmp/foo-dispatcher.zsh"
+    missing=""
+    for c in ${(f)"$(_msync_dispatcher_cmds "$tmp/foo-dispatcher.zsh")"}; do
+        [[ -f "$tmp/man/$c.1" ]] || missing+="$c "
+    done
+    [[ "$missing" == "foo " ]] || { echo "expected foo flagged missing, got: [$missing]"; exit 1; }
+'
+
+run_check "coverage detector ignores pure-alias public functions (vibe-style)" '
+    tmp=$(mktemp -d); trap "rm -rf $tmp" EXIT
+    printf "baz() {\n    qux \"\$@\"\n}\n" > "$tmp/baz-dispatcher.zsh"
+    cmds=$(_msync_dispatcher_cmds "$tmp/baz-dispatcher.zsh")
+    [[ -z "$cmds" ]] || { echo "alias baz should be skipped, got: [$cmds]"; exit 1; }
+'
+
+run_check "coverage detector ignores helper files with no public function" '
+    tmp=$(mktemp -d); trap "rm -rf $tmp" EXIT
+    printf "_helper_only() { echo x; }\n" > "$tmp/teach-dates.zsh"
+    cmds=$(_msync_dispatcher_cmds "$tmp/teach-dates.zsh")
+    [[ -z "$cmds" ]] || { echo "helper should yield no cmds, got: [$cmds]"; exit 1; }
+'
+
+# ── the real assertions: dispatcher <-> man-page coverage ───────────────────
+
+run_check "every dispatcher command has a man page" '
+    cmds=$(_msync_dispatcher_cmds "$DISP_DIR"/*.zsh(N) "$ATLAS")
+    [[ -n "$cmds" ]] || { echo "no dispatcher commands detected"; exit 1; }
+    missing=""
+    for c in ${(f)cmds}; do
+        [[ -f "$MAN_DIR/$c.1" ]] || missing+="$c "
+    done
+    if [[ -n "$missing" ]]; then
+        echo "dispatchers with no man/man1/<cmd>.1: $missing"
+        echo "    fix: add a page for each (model: man/man1/g.1)"
+        exit 1
+    fi
+'
+
+run_check "no orphan flow-cli dispatcher page (page without a dispatcher)" '
+    cmds=$(_msync_dispatcher_cmds "$DISP_DIR"/*.zsh(N) "$ATLAS")
+    orphan=""
+    for p in "$MAN_DIR"/*.1(N); do
+        [[ "$(_th_product "$p")" == "flow-cli" ]] || continue   # skip vendored
+        base="${p:t:r}"
+        [[ "$base" == "flow" ]] && continue                     # flow is the index, not a dispatcher
+        print -r -- "$cmds" | grep -qx "$base" || orphan+="$base "
+    done
+    if [[ -n "$orphan" ]]; then
+        echo "man pages with no matching dispatcher: $orphan"
+        echo "    fix: remove the stale page, or it names a real command not detected"
+        exit 1
+    fi
+'
+
+echo ""
+echo "${CYAN}──────────────────────────────────────────────────────────────${RESET}"
+if [[ $CHECKS_FAILED -eq 0 ]]; then
+    echo "${GREEN}All $CHECKS_PASSED/$CHECKS_RUN man-page guard checks passed${RESET}"; exit 0
+else
+    echo "${RED}$CHECKS_FAILED/$CHECKS_RUN checks failed${RESET}"
+    echo "${YELLOW}Man-page version drift or coverage gap — see SPEC-manpage-refresh-2026-06-04.${RESET}"
+    exit 1
+fi


### PR DESCRIPTION
## v7.8.1 — full man-page set + version-sync guard

### Added
- **Full man-page set for all 15 dispatchers + the `at` bridge** — `man/man1/` brought from a partial set frozen at flow-cli 3.0.0 up to v7.8.1. New pages: `cc`, `wt`, `tm`, `v`, `prompt`, `tok`, `sec`, `dots`, `teach`, `em`, `at`. `flow.1` SMART DISPATCHERS rebuilt; `g`/`r`/`qu`/`mcp`/`obs` refreshed. `tok.1` documents `tok sync push/repos/gh`, `--no-sync`, `FLOW_TOK_AUTOSYNC`.
- **Man-page version-sync CI guard** (`tests/test-manpage-version-sync.zsh`) — fails if any flow-cli man page `.TH` version diverges from `FLOW_VERSION`, and enforces coverage (every dispatcher has a page, no orphans). `release.sh` auto-bumps `.TH`.

### Test plan
- [x] `test-manpage-version-sync.zsh` 12/12 (after release.sh bumped .TH to 7.8.1)
- [x] version consistency: flow.plugin.zsh / package.json / CLAUDE.md = 7.8.1
- [x] CHANGELOGs mirror; doc footers swept to v7.8.1; strict build clean

Patch release (docs + tooling, no `feat:`).