### PR TITLE
chore(ci): drop deprecated Node 20 apt-cache action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: zsh
-          version: 1.0
+      - name: Ensure zsh is installed
+        run: |
+          # zsh is preinstalled on ubuntu-latest; install only as a fallback.
+          # Replaces awalsh128/cache-apt-pkgs-action (pulled in deprecated
+          # Node.js 20 actions/cache/restore@v4) for a tiny preinstalled package.
+          if ! command -v zsh >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y zsh
+          fi
 
       - name: Record start time
         id: start


### PR DESCRIPTION
## Summary

Removes the Node.js 20 deprecation warning from CI at its root.

`awalsh128/cache-apt-pkgs-action@latest` transitively pulled in `actions/cache/restore@v4`, which runs on Node.js 20 — deprecated by GitHub and removed from runners **Sept 16, 2026**. The action was only caching the `zsh` package, which is **preinstalled on `ubuntu-latest`**, making the caching step redundant.

## Change

Replaced the third-party caching action in `test.yml` with a fallback install guard:

```yaml
- name: Ensure zsh is installed
  run: |
    if ! command -v zsh >/dev/null 2>&1; then
      sudo apt-get update && sudo apt-get install -y zsh
    fi
```

## Why this approach

- **Fixes root cause** vs. masking with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`
- **Drops a third-party action** from the CI supply chain
- **Works regardless** of whether zsh is preinstalled (defensive guard)

## Verification

Validated green on `dev` (run 26968072991): `✓ Ensure zsh is installed`, all steps pass, **no Node 20 warning** in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)