### PR TITLE
test(dogfood): match condensed CLAUDE.md format in scholar-config check

### DIFF
--- a/tests/dogfood-scholar-config-sync.zsh
+++ b/tests/dogfood-scholar-config-sync.zsh
@@ -198,10 +198,15 @@ echo "${CYAN}── Documentation ──${RESET}"
 # DOCUMENTATION CHECKS
 # ============================================================================
 
+# Accept either the per-command form (`teach solution`) or the condensed
+# subcommand-list form (`..., solution, sync, validate-r, ...`). CLAUDE.md was
+# optimized to the condensed list in a03916ba ("move teach/dispatcher detail to
+# pointers"); the subcommands are still documented, just not as two-word literals.
+# Boundaries ([(,] before, [,)] after) avoid matching the `--sync` deploy flag.
 run_test "CLAUDE.md lists new subcommands" '
-    grep -q "teach solution" "$PROJECT_ROOT/CLAUDE.md" &&
-    grep -q "teach sync" "$PROJECT_ROOT/CLAUDE.md" &&
-    grep -q "teach validate-r" "$PROJECT_ROOT/CLAUDE.md"
+    grep -Eq "teach solution|[(,] ?solution[,)]" "$PROJECT_ROOT/CLAUDE.md" &&
+    grep -Eq "teach sync|[(,] ?sync[,)]" "$PROJECT_ROOT/CLAUDE.md" &&
+    grep -Eq "teach validate-r|[(,] ?validate-r[,)]" "$PROJECT_ROOT/CLAUDE.md"
 '
 
 run_test "QUICK-REFERENCE includes config commands" '


### PR DESCRIPTION
Fixes the long-standing 1/41 failure in `dogfood-scholar-config-sync` (present on `dev`, unrelated to any feature work).

## Root cause
Check [34] grepped for the literal strings `teach solution`, `teach sync`, `teach validate-r`, but commit `a03916ba` ("docs(claude): optimize — move teach/dispatcher detail to pointers") condensed CLAUDE.md's teach docs into a single subcommand list (`..., solution, sync, validate-r, ...`). The subcommands are still documented — the assertion went stale.

## Fix
Accept either form via alternation: `teach <sub>` OR `[(,] ?<sub>[,)]`. The character-class boundaries keep it non-vacuous and stop it matching the `--sync` deploy flag on the same line.

Fixes the test, not the doc — re-adding per-command lines would undo the deliberate CLAUDE.md optimization.

## Verification
- Check [34] passes; full suite **59 passed, 0 failed, 1 expected timeout** (restores the true clean baseline).
- Non-vacuous: removing `solution` from the list fails the check; removing the `sync` subcommand while keeping `--sync` also fails (no false match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)