### PR TITLE
feat(at): completions + help/man for atlas v0.9.3 flags (items 4-6)

### DIFF
--- a/completions/_at
+++ b/completions/_at
@@ -1,0 +1,40 @@
+#compdef at
+
+_at() {
+  local -a subcommands
+  subcommands=(
+    'session:Session management (start, end, status)'
+    'catch:Quick capture a thought or task'
+    'c:Quick capture (alias)'
+    'inbox:Show captured items'
+    'i:Inbox alias'
+    'triage:Process inbox interactively'
+    'where:Where was I? (context recovery)'
+    'w:Where alias'
+    'crumb:Leave a breadcrumb'
+    'b:Breadcrumb alias'
+    'trail:Show breadcrumb trail'
+    'focus:Set focus project'
+    'stats:Project statistics'
+    'plan:Planning view'
+    'park:Park a project'
+    'unpark:Resume a parked project'
+    'parked:List parked projects'
+    'dash:Project dashboard'
+    'project:Project management'
+    'help:Show help'
+  )
+  _arguments -s \
+    '-h[Show help]' '--help[Show help]' \
+    '--format[Output format]:format:(table json names text)' \
+    '--count[Output bare integer count]' \
+    '--suggest[Suggest one active project name]' \
+    '--limit[Limit results]:n:' \
+    '--days[Days of history]:n:' \
+    '--project[Project filter]:project:' \
+    '1:subcommand:->subcommands' && return 0
+  case "$state" in
+    subcommands) _describe -t subcommands 'subcommand' subcommands ;;
+  esac
+}
+_at "$@"

--- a/lib/atlas-bridge.zsh
+++ b/lib/atlas-bridge.zsh
@@ -960,11 +960,13 @@ _at_help() {
   echo "${_C_BLUE}📋 SESSION${_C_NC}"
   echo "  ${_C_CYAN}at session start${_C_NC} ${_C_DIM}<project>${_C_NC}  ${_C_DIM}Start work session${_C_NC}"
   echo "  ${_C_CYAN}at session end${_C_NC} ${_C_DIM}[note]${_C_NC}      ${_C_DIM}End session with optional note${_C_NC}"
+  echo "  ${_C_CYAN}at session status --format json${_C_NC}  ${_C_DIM}Machine-readable session state${_C_NC}"
   echo ""
 
   echo "${_C_BLUE}📥 CAPTURE${_C_NC}"
   echo "  ${_C_CYAN}at catch${_C_NC} ${_C_DIM}<text>${_C_NC}             ${_C_DIM}Quick capture (works without Atlas)${_C_NC}"
   echo "  ${_C_CYAN}at inbox${_C_NC}                    ${_C_DIM}Show captured items${_C_NC}"
+  echo "  ${_C_CYAN}at inbox --count${_C_NC}            ${_C_DIM}Bare integer count for scripting${_C_NC}"
   echo "  ${_C_CYAN}at triage${_C_NC}                   ${_C_DIM}Process inbox items${_C_NC}"
   echo ""
 
@@ -972,6 +974,7 @@ _at_help() {
   echo "  ${_C_CYAN}at where${_C_NC} ${_C_DIM}[project]${_C_NC}         ${_C_DIM}Where was I? (works without Atlas)${_C_NC}"
   echo "  ${_C_CYAN}at crumb${_C_NC} ${_C_DIM}<text>${_C_NC}            ${_C_DIM}Leave breadcrumb (works without Atlas)${_C_NC}"
   echo "  ${_C_CYAN}at trail${_C_NC}                    ${_C_DIM}Show breadcrumb trail${_C_NC}"
+  echo "  ${_C_CYAN}at trail --limit N${_C_NC}          ${_C_DIM}Newest-N breadcrumbs${_C_NC}"
   echo "  ${_C_CYAN}at focus${_C_NC} ${_C_DIM}[project]${_C_NC}         ${_C_DIM}Set focus project${_C_NC}"
   echo ""
 
@@ -982,6 +985,8 @@ _at_help() {
   echo "  ${_C_CYAN}at unpark${_C_NC} ${_C_DIM}[project]${_C_NC}        ${_C_DIM}Resume a parked project${_C_NC}"
   echo "  ${_C_CYAN}at parked${_C_NC}                   ${_C_DIM}List parked projects${_C_NC}"
   echo "  ${_C_CYAN}at dash${_C_NC}                     ${_C_DIM}Project dashboard${_C_NC}"
+  echo "  ${_C_CYAN}at project list --count${_C_NC}     ${_C_DIM}Bare integer project count${_C_NC}"
+  echo "  ${_C_CYAN}at project list --suggest${_C_NC}   ${_C_DIM}One active project name suggestion${_C_NC}"
   echo ""
 
   if ! _flow_has_atlas; then

--- a/man/man1/at.1
+++ b/man/man1/at.1
@@ -68,14 +68,31 @@ Start a tracked work session for the given project.
 .TP
 .B session end \fR[\fInote\fR]
 End the current work session with an optional summary note.
+.TP
+.B session status
+Show current session state.
+.TP
+.B \-\-format \fIjson\fR
+Output session status as machine-readable JSON (use with
+.BR "session status" ).
 .SS Capture & Triage
 .TP
 .B triage
 Process inbox items interactively (prioritize, assign, or discard).
+.TP
+.B \-\-count
+Output a bare integer count instead of formatted output (use with
+.BR inbox ).
 .SS Context
 .TP
 .B trail
 Show the full breadcrumb trail for the current or specified project.
+.TP
+.B \-\-limit \fIN\fR
+Limit trail output to the newest
+.I N
+breadcrumbs (use with
+.BR trail ).
 .TP
 .B focus \fR[\fIproject\fR]
 Set or show the current focus project.
@@ -98,6 +115,14 @@ List all currently parked projects.
 .TP
 .B dash\fR, \fBdashboard
 Show a dashboard of all projects at a glance.
+.TP
+.B \-\-count
+Output a bare integer project count instead of formatted output (use with
+.BR "project list" ).
+.TP
+.B \-\-suggest
+Output one active project name suggestion (use with
+.BR "project list" ).
 .SH ENVIRONMENT
 .TP
 .B FLOW_ATLAS_ENABLED
@@ -167,6 +192,35 @@ Disable Atlas for a session:
 .RS
 .nf
 FLOW_ATLAS_ENABLED=no at catch "note stored locally"
+.fi
+.RE
+.PP
+Check session state in scripts (machine-readable JSON):
+.RS
+.nf
+.B at session status --format json
+.fi
+.RE
+.PP
+Get a bare integer count of pending captures:
+.RS
+.nf
+.B at inbox --count
+.fi
+.RE
+.PP
+Show only the 5 most recent breadcrumbs:
+.RS
+.nf
+.B at trail --limit 5
+.fi
+.RE
+.PP
+Get a bare project count or a suggestion for scripting:
+.RS
+.nf
+.B at project list --count
+.B at project list --suggest
 .fi
 .RE
 .SH SEE ALSO


### PR DESCRIPTION
Implements atlas-surface-standard items 4-6 (independent of PR #468 items 1-3).

- Item 4: _at_help() — 5 new flag entries (--format json, --count, --suggest, --limit N)
- Item 5: man/man1/at.1 — .TP flag docs + 2 flag examples
- Item 6: completions/_at (new file, auto-discovered via existing fpath)

Acceptance criteria: help shows all flags, man page documents flags, tab-completion works (verify manually in interactive ZSH).