### PR TITLE
Release v7.11.0 — at completions + atlas doctor fixes

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -5,9 +5,17 @@
 ## Type: zsh-plugin
 ## Status: active
 ## Focus: --help
-## Phase: Released (v7.9.0)
+## Phase: Released (v7.10.2)
 ## Priority: 2
 ## Progress: 100
+
+## Current Session (2026-06-18) — v7.10.2 SHIPPED (docs polish + dep maintenance) [main + Homebrew]
+
+**Session activity:**
+- **Scheduling docs overhaul:** new top-level **Planning & Scheduling** mkdocs tab (gathered tutorial 48 + AGENDA-SCHEDULE-GUIDE + capture/routine, removed dup guide entry + empty Learn ADHD subsection); planning arc cross-linked (44→48→43, 02→48) + added missing `T48` node to the learning-path map; clarified flow-cli ↔ Atlas in 43/44/48 (value-line + guide link, was 0 links); tutorials index count fix (47) + completed All Tutorials table.
+- **Agenda tutorial (48) + guide made friendlier with REAL output:** captured live agenda renders via sandbox + `_flow_has_atlas` override (memory: [[capture-real-agenda-output-for-docs]]); added empty/populated/overdue screens + 3 real-world recipes; guide gained real today/week renders.
+- **Dependabot cleared:** merged #469 prettier 3.8.4 + #462 checkout v6 (update-branch → CI green → merge, not --admin); dev synced with main each time.
+- **Released v7.10.2** (`release.sh 7.10.2`): version files + man `.TH` + 47 doc footers + CHANGELOG ×2 + index What's New → PR #470 → CI green (64/0/1) → merged main (`50bae7f0`) → main CI green + docs deployed → GitHub release → Homebrew tap auto-updated (v7.10.2.tar.gz) → dev/main synced. All docs + dev/CI deps, no runtime changes.
 
 ## Current Session (2026-06-14) — v7.10.1 SHIPPED (main + Homebrew + agenda tutorial #48); v7.10.0 + CI gate prior [dev]
 
@@ -389,8 +397,8 @@
 
 ---
 
-**Last Updated:** 2026-06-14
-**Status:** v7.10.1 SHIPPED (main + Homebrew tap) | full suite REQUIRED on main (PRs #465/#466) — 64 passed / 0 failed / 1 skipped (tool-absent rc 77) | 14 dispatchers + at bridge | 216 test files | 12000+ test functions | 0 lint errors | 0 broken links
-## wins: Fixed the regression bug (2026-06-13), --category fix squashed the bug (2026-06-13), fixed the bug (2026-06-13), Fixed the regression bug (2026-06-13), Fixed the regression bug (2026-06-13)
+**Last Updated:** 2026-06-18
+**Status:** v7.10.2 SHIPPED (main + Homebrew tap) — docs polish + dep maintenance | full suite REQUIRED on main — 64 passed / 0 failed / 1 skipped | 14 dispatchers + at bridge | 216 test files | 12000+ test functions | 0 lint errors | 0 broken links
+## wins: Fixed the regression bug (2026-06-17), --category fix squashed the bug (2026-06-17), fixed the bug (2026-06-17), Fixed the regression bug (2026-06-13), --category fix squashed the bug (2026-06-13)
 ## streak: 1
-## last_active: 2026-06-13 22:10
+## last_active: 2026-06-17 22:43

--- a/.STATUS
+++ b/.STATUS
@@ -416,6 +416,6 @@
 
 **Last Updated:** 2026-06-18
 **Status:** v7.10.2 SHIPPED (main + Homebrew tap) — docs polish + dep maintenance | full suite REQUIRED on main — 64 passed / 0 failed / 1 skipped | 14 dispatchers + at bridge | 216 test files | 12000+ test functions | 0 lint errors | 0 broken links
-## wins: Fixed the regression bug (2026-06-17), --category fix squashed the bug (2026-06-17), fixed the bug (2026-06-17), Fixed the regression bug (2026-06-13), --category fix squashed the bug (2026-06-13)
+## wins: Fixed the regression bug (2026-06-19), Fixed the regression bug (2026-06-19), --category fix squashed the bug (2026-06-19), fixed the bug (2026-06-19), Fixed the regression bug (2026-06-17)
 ## streak: 1
-## last_active: 2026-06-17 22:43
+## last_active: 2026-06-19 07:30

--- a/.STATUS
+++ b/.STATUS
@@ -9,6 +9,23 @@
 ## Priority: 2
 ## Progress: 100
 
+## Current Session (2026-06-19) — flow claude subcommand spec [dev]
+
+**Session activity:**
+- **Brainstormed + grilled** (max depth, interactive) expanding flow-cli to manage Claude Code environment health: settings parity, hook health, memory index drift, CLAUDE.md length rule, shell env parity for Claude Work/Chat
+- **5-question grilled design decisions:** `flow claude` as new top-level subcommand (not `doctor --claude`); all 4 checks in scope; settings.json canonical (fix direction: zshrc → match settings.json); Work/Chat in scope as best-effort shell-env check; craft rules stay out of scope
+- **Spec written:** `docs/specs/SPEC-flow-claude-subcommand.md` — 5 checks (C1–C5), `--fix` updates zshrc export only, jq for JSON parsing, shellcheck optional dependency, exit codes 0/1/2
+
+## Previous Session (2026-06-19) — atlas-surface-standard items 4-6 [feature/at-dispatcher-surface]
+
+**Session activity:**
+- **Worktree created:** `~/.git-worktrees/flow-cli/at-dispatcher-surface` on `feature/at-dispatcher-surface` (from dev)
+- **Item 4 — _at_help() in lib/atlas-bridge.zsh:** added 5 flag entries: `session status --format json`, `inbox --count`, `trail --limit N`, `project list --count`, `project list --suggest`
+- **Item 5 — man/man1/at.1:** added .TP docs for `--format json`, `--count`, `--limit N`, `--suggest` in appropriate sections; added 4 flag examples to EXAMPLES section
+- **Item 6 — completions/_at:** new file, auto-discovered via existing fpath (flow.plugin.zsh:138); covers all subcommands + flags
+- **Tests:** 63 pass / 0 fail / 1 timeout / 1 skip (man-page version-sync: 12/12); .TH line unchanged
+- **PR #471** (draft): https://github.com/Data-Wise/flow-cli/pull/471
+
 ## Current Session (2026-06-18) — v7.10.2 SHIPPED (docs polish + dep maintenance) [main + Homebrew]
 
 **Session activity:**

--- a/.flow/teach-config.yml
+++ b/.flow/teach-config.yml
@@ -9,10 +9,6 @@ git:
   auto_pr: true
   require_clean: true
 
-branches:
-  draft: draft
-  production: main
-
 workflow:
   teaching_mode: false
   auto_commit: false

--- a/.flow/teach-config.yml
+++ b/.flow/teach-config.yml
@@ -9,6 +9,10 @@ git:
   auto_pr: true
   require_clean: true
 
+branches:
+  draft: draft
+  production: main
+
 workflow:
   teaching_mode: false
   auto_commit: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.11.0] — 2026-06-19 — at-dispatcher completions + atlas doctor fixes
+
+### Added
+
+- **`at` dispatcher tab completions** (`completions/_at`): new completions file, auto-discovered via the existing fpath entry in `flow.plugin.zsh`. Covers all subcommands (`session`, `inbox`, `trail`, `project`, `catch`, `crumb`, `stats`, `plan`, `park`, `unpark`, `focus`, `triage`, `dash`) plus flags (`--format`, `--count`, `--limit`, `--suggest`, `--json`).
+- **`_at_help()` flag entries**: five new entries for atlas v0.9.3 flags — `session status --format json`, `inbox --count`, `trail --limit N`, `project list --count`, `project list --suggest`.
+- **`at` man page flag docs** (`man/man1/at.1`): `.TP` entries for all four new flags with examples in the EXAMPLES section.
+
+### Fixed
+
+- **`flow doctor` reported "atlas connected" on a broken install** (`commands/doctor.zsh`): the check previously passed as soon as `command -v atlas` succeeded, even if the atlas binary had a broken shebang or failed interpreter. Now gated on `atlas config show` returning a non-empty response.
+- **`flow doctor` called nonexistent `atlas config get backend`**: replaced with `atlas config show` + `.storage` parse (jq when available, anchored sed fallback).
+- **`flow doctor` called nonexistent `atlas mcp status`**: `atlas-mcp` is a separate binary. Replaced with `command -v atlas-mcp`.
+- **`_flow_validate_teaching_config` rejected valid `git.*` branch schema** (`lib/project-detector.zsh`): validator now accepts `git.draft_branch` / `git.production_branch` alongside `branches.draft` / `branches.production`.
+
+### Documentation
+
+- **Atlas CLI API Contract v1.1.0** (`docs/ATLAS-CONTRACT.md`): per-command `--format` matrix, `atlas config show` contract, v0.9.3 flag contracts (`--count`, `--suggest`, `--limit`, `--format=json`), and static regression guard `tests/test-doctor-atlas-calls.zsh`.
+- `TEACH-CONFIG-SCHEMA.md` and `TEACHING-WORKFLOW.md` updated to document both accepted branch schema forms.
+
 ## [7.10.2] — 2026-06-18 — Documentation polish + dependency maintenance
 
 ### Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management. Zero dependencies. Standalone (works without Oh-My-Zsh or any plugin manager).
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Current Version:** v7.10.2
+- **Current Version:** v7.11.0
 - **Install:** Homebrew (recommended), or any plugin manager
 - **Source:** `source /opt/homebrew/opt/flow-cli/flow.plugin.zsh` (via Homebrew)
 - **Optional:** Atlas integration for enhanced state management
@@ -215,8 +215,8 @@ export FLOW_FORCE_DISPATCHER_OBS=1           # Force-keep one dispatcher (FLOW_F
 
 ## Current Status
 
-**Version:** v7.10.2 | **Tests:** 12000+ (64/64 suite, 1 interactive timeout) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.11.0 | **Tests:** 12000+ (64/64 suite, 1 interactive timeout) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 
-**Last Updated:** 2026-06-13 (v7.10.2)
+**Last Updated:** 2026-06-13 (v7.11.0)

--- a/commands/doctor.zsh
+++ b/commands/doctor.zsh
@@ -360,30 +360,47 @@ doctor() {
       atlas_version="${atlas_version:-unknown}"
       _doctor_log_quiet "  ${FLOW_COLORS[success]}✓${FLOW_COLORS[reset]} atlas installed (v${atlas_version})"
 
-      # Check connection / backend
+      # Check connection / backend. Gate "connected" on atlas actually
+      # RESPONDING — `command -v atlas` (above) only proves the binary is on
+      # PATH, so a broken/half-installed atlas (e.g. a bad interpreter shebang)
+      # would otherwise be reported as "connected". `atlas config show` emits the
+      # full config as pretty JSON (atlas bin/atlas.js); `.storage` is the
+      # backend (`filesystem` | `sqlite`). Run it once and reuse the output.
       if _flow_has_atlas 2>/dev/null; then
-        local atlas_backend
-        atlas_backend="$(atlas config get backend 2>/dev/null || echo "unknown")"
-        atlas_backend="${atlas_backend:-filesystem}"
-        _doctor_log_quiet "  ${FLOW_COLORS[success]}✓${FLOW_COLORS[reset]} atlas connected (${atlas_backend} backend)"
+        local atlas_cfg atlas_backend
+        atlas_cfg="$(atlas config show 2>/dev/null)"
+        if [[ -n "$atlas_cfg" ]]; then
+          if command -v jq >/dev/null 2>&1; then
+            atlas_backend="$(print -r -- "$atlas_cfg" | jq -r '.storage // "filesystem"' 2>/dev/null)"
+          else
+            # Anchor the match on the "storage" key so the value is taken from
+            # THAT field — a bare `.*: *"..."` greedily grabs the last quoted
+            # value on the line, which is wrong for single-line/compact JSON.
+            atlas_backend="$(print -r -- "$atlas_cfg" | grep '"storage"' | sed 's/.*"storage"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+          fi
+          atlas_backend="${atlas_backend:-filesystem}"
+          _doctor_log_quiet "  ${FLOW_COLORS[success]}✓${FLOW_COLORS[reset]} atlas connected (${atlas_backend} backend)"
 
-        # Show project count
-        local atlas_project_count
-        atlas_project_count="$(atlas project list --format=names 2>/dev/null | wc -l | tr -d ' ')"
-        if [[ -n "$atlas_project_count" && "$atlas_project_count" -gt 0 ]] 2>/dev/null; then
-          _doctor_log_quiet "  ${FLOW_COLORS[success]}✓${FLOW_COLORS[reset]} project list works (${atlas_project_count} projects)"
+          # Show project count
+          local atlas_project_count
+          atlas_project_count="$(atlas project list --format=names 2>/dev/null | wc -l | tr -d ' ')"
+          if [[ -n "$atlas_project_count" && "$atlas_project_count" -gt 0 ]] 2>/dev/null; then
+            _doctor_log_quiet "  ${FLOW_COLORS[success]}✓${FLOW_COLORS[reset]} project list works (${atlas_project_count} projects)"
+          else
+            _doctor_log_quiet "  ${FLOW_COLORS[muted]}○${FLOW_COLORS[reset]} project list empty or unavailable"
+          fi
         else
-          _doctor_log_quiet "  ${FLOW_COLORS[muted]}○${FLOW_COLORS[reset]} project list empty or unavailable"
+          _doctor_log_quiet "  ${FLOW_COLORS[warning]}⚠${FLOW_COLORS[reset]}  atlas installed but not responding (config show failed)"
         fi
       else
         _doctor_log_quiet "  ${FLOW_COLORS[warning]}⚠${FLOW_COLORS[reset]}  atlas installed but not connected"
       fi
 
-      # Check MCP server (optional)
-      if atlas mcp status &>/dev/null 2>&1; then
-        _doctor_log_quiet "  ${FLOW_COLORS[success]}✓${FLOW_COLORS[reset]} atlas MCP server running"
+      # Check MCP server binary (atlas-mcp is a separate binary, not an atlas subcommand)
+      if command -v atlas-mcp &>/dev/null; then
+        _doctor_log_quiet "  ${FLOW_COLORS[success]}✓${FLOW_COLORS[reset]} atlas-mcp binary available"
       else
-        _doctor_log_quiet "  ${FLOW_COLORS[muted]}○${FLOW_COLORS[reset]} atlas MCP server ${FLOW_COLORS[muted]}(optional, not running)${FLOW_COLORS[reset]}"
+        _doctor_log_quiet "  ${FLOW_COLORS[muted]}○${FLOW_COLORS[reset]} atlas-mcp ${FLOW_COLORS[muted]}(optional MCP server, not installed)${FLOW_COLORS[reset]}"
       fi
     else
       _doctor_log_quiet "  ${FLOW_COLORS[muted]}○${FLOW_COLORS[reset]} atlas ${FLOW_COLORS[muted]}(optional, not installed)${FLOW_COLORS[reset]}"

--- a/completions/_at
+++ b/completions/_at
@@ -1,0 +1,40 @@
+#compdef at
+
+_at() {
+  local -a subcommands
+  subcommands=(
+    'session:Session management (start, end, status)'
+    'catch:Quick capture a thought or task'
+    'c:Quick capture (alias)'
+    'inbox:Show captured items'
+    'i:Inbox alias'
+    'triage:Process inbox interactively'
+    'where:Where was I? (context recovery)'
+    'w:Where alias'
+    'crumb:Leave a breadcrumb'
+    'b:Breadcrumb alias'
+    'trail:Show breadcrumb trail'
+    'focus:Set focus project'
+    'stats:Project statistics'
+    'plan:Planning view'
+    'park:Park a project'
+    'unpark:Resume a parked project'
+    'parked:List parked projects'
+    'dash:Project dashboard'
+    'project:Project management'
+    'help:Show help'
+  )
+  _arguments -s \
+    '-h[Show help]' '--help[Show help]' \
+    '--format[Output format]:format:(table json names text)' \
+    '--count[Output bare integer count]' \
+    '--suggest[Suggest one active project name]' \
+    '--limit[Limit results]:n:' \
+    '--days[Days of history]:n:' \
+    '--project[Project filter]:project:' \
+    '1:subcommand:->subcommands' && return 0
+  case "$state" in
+    subcommands) _describe -t subcommands 'subcommand' subcommands ;;
+  esac
+}
+_at "$@"

--- a/docs/ATLAS-CONTRACT.md
+++ b/docs/ATLAS-CONTRACT.md
@@ -1,7 +1,7 @@
 # Atlas CLI API Contract
 
-**Version:** 1.0.0
-**Parties:** flow-cli (v7.4.x) <-> Atlas CLI `@data-wise/atlas` (v0.9.x)
+**Version:** 1.1.0
+**Parties:** flow-cli (v7.10.x) <-> Atlas CLI `@data-wise/atlas` (v0.9.3)
 **Status:** Active
 
 ---
@@ -10,7 +10,8 @@
 
 | flow-cli | Atlas CLI | Notes |
 |----------|-----------|-------|
-| v7.4.x   | v0.9.x    | Current contract version |
+| v7.10.x  | v0.9.3    | Contract v1.1 — 5 new integration flags (`session status --format`, `project list --count`, `project list --suggest`, `inbox --count`, `trail --limit`) |
+| v7.4.x   | v0.9.x    | Contract v1.0 — original contract |
 | v7.3.x   | v0.8.x    | Legacy — no `crumb` command |
 | v7.5.x   | v1.0.x    | Planned — stable API |
 
@@ -26,6 +27,7 @@ These 6 commands are bridged with ZSH-native fallbacks when Atlas is not install
 | `atlas session end [note]` | `_flow_session_end` | worklog file | exit 0 |
 | `atlas catch <text> [--project=X]` | `_flow_catch` | inbox.md | exit 0 |
 | `atlas inbox` | `_flow_inbox` | cat inbox.md | text |
+| `atlas inbox --count` | `_flow_inbox_count` | echo "0" | bare integer (pending inbox count) |
 | `atlas where [project]` | `_flow_where` | filesystem detection | text |
 | `atlas crumb <text> [--project=X]` | `_flow_crumb` | trail.log | exit 0 |
 
@@ -37,7 +39,9 @@ These commands require Atlas CLI. flow-cli shows an install message if Atlas is 
 
 | Command | Description | Output Format |
 |---------|-------------|---------------|
+| `atlas session status` | Current session state | `table` (default); `--format=json` → `{project,durationMinutes,state,task,startedAt}` or `null` when idle |
 | `atlas stats` | Project statistics | table |
+| `atlas config show` | Full configuration as pretty JSON | JSON — top-level `storage` key is the backend (`filesystem` \| `sqlite`) |
 | `atlas plan` | Planning view | table |
 | `atlas park [project]` | Park a project | text |
 | `atlas unpark [project]` | Unpark a project | text |
@@ -46,6 +50,7 @@ These commands require Atlas CLI. flow-cli shows an install message if Atlas is 
 | `atlas focus [project]` | Set focus project | text |
 | `atlas triage` | Triage inbox items | interactive |
 | `atlas trail` | Show breadcrumb trail | text |
+| `atlas trail --limit <n>` | Breadcrumb trail, capped at n entries (most recent first) | text |
 
 ---
 
@@ -98,7 +103,20 @@ ships with the silent no-op until it lands.
 
 ## Output Format Specifications
 
-Atlas CLI supports 4 output formats via the `--format` flag:
+Format support is **per-command**, not universal. The `--format` flag is only valid for the commands listed below.
+
+### Per-Command Format Support Matrix
+
+| Command | Supported `--format` values | Default | Notes |
+|---------|----------------------------|---------|-------|
+| `atlas project list` | `table`, `json`, `names` | `table` | `names` = one name per line, no headers |
+| `atlas project show` | `table`, `json`, `names`, `shell` | `table` | `shell` = key=value pairs |
+| `atlas session status` | `table`, `json` | `table` | `json` emits `{project,durationMinutes,state,task,startedAt}` or `null` when idle |
+| `atlas stats` | `table`, `json`, `text`, `md` | `table` | |
+| `atlas session export` | `ical`, `json` | `ical` | |
+| `atlas plan` | *(n/a)* | n/a | Use `--json` flag for machine-readable output |
+
+### Format Descriptions
 
 | Format | Description | Example |
 |--------|-------------|---------|
@@ -138,6 +156,76 @@ atlas project list --status=<filter> --format=names
 ```
 
 Valid `--status` values: `active`, `parked`, `archived`, `all`.
+
+**`--count` flag (v0.9.3+):**
+
+```
+atlas project list --count
+atlas project list --status=active --count
+```
+
+Prints a bare integer (count of matched projects). Combinable with `--status`. Exits 0.
+
+**`--suggest` flag (v0.9.3+):**
+
+```
+atlas project list --suggest
+```
+
+Prints ONE project name — the most-recently-touched active project. Prints nothing (empty output) if no active projects exist. Exits 0.
+
+## `atlas inbox --count` Contract (v0.9.3+)
+
+```
+atlas inbox --count
+```
+
+Prints a bare integer (count of pending inbox captures, i.e. `status=inbox`). Exits 0.
+
+## `atlas trail --limit` Contract (v0.9.3+)
+
+```
+atlas trail --limit <n>
+```
+
+Caps the breadcrumb entries shown to the `n` most recent. Exits 0. Output format is text (unchanged from `atlas trail`).
+
+## `atlas session status --format=json` Contract (v0.9.3+)
+
+```
+atlas session status --format=json
+```
+
+Emits a JSON object when a session is active:
+
+```json
+{
+  "project": "<project-name>",
+  "durationMinutes": 42,
+  "state": "active",
+  "task": "<task text or null>",
+  "startedAt": "2026-06-14T09:00:00.000Z"
+}
+```
+
+Emits `null` (the literal JSON value) when no session is active. Always exits 0.
+
+## `atlas config show` Contract (consumed by `flow doctor`)
+
+```
+atlas config show
+```
+
+Prints the **entire** atlas configuration as pretty-printed JSON
+(`JSON.stringify(config, null, 2)` — always JSON, there is no `--format` flag on
+this command). The top-level **`storage`** key is the active backend
+(`filesystem` | `sqlite`); other keys include scan paths and `preferences`. Exits 0.
+
+`flow doctor` consumes this for two things: (a) a **liveness check** — a non-empty
+result is the connectivity signal, because a binary on `PATH` alone does not prove
+atlas actually runs (e.g. a broken interpreter shebang); and (b) reading the
+storage backend. Note there is **no `atlas config get <key>` subcommand** — read a
+single value by parsing `config show`.
 
 ---
 

--- a/docs/ATLAS-CONTRACT.md
+++ b/docs/ATLAS-CONTRACT.md
@@ -19,7 +19,7 @@
 
 ## Required Commands (Hot Path)
 
-These 6 commands are bridged with ZSH-native fallbacks when Atlas is not installed. flow-cli calls these in performance-critical paths and MUST NOT block if Atlas is unavailable.
+These 7 commands are bridged with ZSH-native fallbacks when Atlas is not installed. flow-cli calls these in performance-critical paths and MUST NOT block if Atlas is unavailable.
 
 | Command | Usage in flow-cli | Fallback (no Atlas) | Output Format |
 |---------|-------------------|---------------------|---------------|
@@ -174,6 +174,8 @@ atlas project list --suggest
 
 Prints ONE project name — the most-recently-touched active project. Prints nothing (empty output) if no active projects exist. Exits 0.
 
+---
+
 ## `atlas inbox --count` Contract (v0.9.3+)
 
 ```
@@ -182,6 +184,8 @@ atlas inbox --count
 
 Prints a bare integer (count of pending inbox captures, i.e. `status=inbox`). Exits 0.
 
+---
+
 ## `atlas trail --limit` Contract (v0.9.3+)
 
 ```
@@ -189,6 +193,8 @@ atlas trail --limit <n>
 ```
 
 Caps the breadcrumb entries shown to the `n` most recent. Exits 0. Output format is text (unchanged from `atlas trail`).
+
+---
 
 ## `atlas session status --format=json` Contract (v0.9.3+)
 
@@ -209,6 +215,8 @@ Emits a JSON object when a session is active:
 ```
 
 Emits `null` (the literal JSON value) when no session is active. Always exits 0.
+
+---
 
 ## `atlas config show` Contract (consumed by `flow doctor`)
 
@@ -255,8 +263,7 @@ The flow-cli wrapper provides:
 
 ## Testing
 
-Contract compliance is verified by `tests/test-atlas-contract.zsh`.
+Contract compliance is verified by two test files:
 
-- Tests validate exit codes, output formats, and command availability
-- Tests skip gracefully when Atlas is not installed (`[SKIP] Atlas not installed`)
-- Hot path fallbacks are tested independently of Atlas availability
+- **`tests/test-atlas-contract.zsh`** — validates exit codes, output formats, and command availability; skips gracefully when Atlas is not installed (`[SKIP] Atlas not installed`); hot path fallbacks tested independently of Atlas availability
+- **`tests/test-doctor-atlas-calls.zsh`** — static regression guard (grep-based, no Atlas needed); enforces that `doctor.zsh` uses spec-compliant calls (`atlas config show`, `command -v atlas-mcp`) and does not regress to the out-of-spec calls removed in v1.1.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ## [Unreleased]
 
+## [7.11.0] — 2026-06-19 — at-dispatcher completions + atlas doctor fixes
+
+### Added
+
+- **`at` dispatcher tab completions** (`completions/_at`): new completions file, auto-discovered via the existing fpath entry in `flow.plugin.zsh`. Covers all subcommands (`session`, `inbox`, `trail`, `project`, `catch`, `crumb`, `stats`, `plan`, `park`, `unpark`, `focus`, `triage`, `dash`) plus flags (`--format`, `--count`, `--limit`, `--suggest`, `--json`).
+- **`_at_help()` flag entries**: five new entries for atlas v0.9.3 flags — `session status --format json`, `inbox --count`, `trail --limit N`, `project list --count`, `project list --suggest`.
+- **`at` man page flag docs** (`man/man1/at.1`): `.TP` entries for all four new flags with examples in the EXAMPLES section.
+
+### Fixed
+
+- **`flow doctor` reported "atlas connected" on a broken install** (`commands/doctor.zsh`): the check previously passed as soon as `command -v atlas` succeeded, even if the atlas binary had a broken shebang or failed interpreter. Now gated on `atlas config show` returning a non-empty response.
+- **`flow doctor` called nonexistent `atlas config get backend`**: replaced with `atlas config show` + `.storage` parse (jq when available, anchored sed fallback).
+- **`flow doctor` called nonexistent `atlas mcp status`**: `atlas-mcp` is a separate binary. Replaced with `command -v atlas-mcp`.
+- **`_flow_validate_teaching_config` rejected valid `git.*` branch schema** (`lib/project-detector.zsh`): validator now accepts `git.draft_branch` / `git.production_branch` alongside `branches.draft` / `branches.production`.
+
+### Documentation
+
+- **Atlas CLI API Contract v1.1.0** (`docs/ATLAS-CONTRACT.md`): per-command `--format` matrix, `atlas config show` contract, v0.9.3 flag contracts (`--count`, `--suggest`, `--limit`, `--format=json`), and static regression guard `tests/test-doctor-atlas-calls.zsh`.
+- `TEACH-CONFIG-SCHEMA.md` and `TEACHING-WORKFLOW.md` updated to document both accepted branch schema forms.
+
 ## [7.10.2] — 2026-06-18 — Documentation polish + dependency maintenance
 
 ### Documentation

--- a/docs/guides/TEACHING-WORKFLOW.md
+++ b/docs/guides/TEACHING-WORKFLOW.md
@@ -346,8 +346,8 @@ shortcuts:
 
 **Required Fields:**
 - `course.name` - Course display name
-- `branches.draft` - Draft branch name
-- `branches.production` - Production branch name
+- Draft branch — either `branches.draft` or `git.draft_branch`
+- Production branch — either `branches.production` or `git.production_branch`
 
 **Optional Fields:**
 - `course.full_name` - Full course title

--- a/docs/reference/TEACH-CONFIG-SCHEMA.md
+++ b/docs/reference/TEACH-CONFIG-SCHEMA.md
@@ -534,6 +534,12 @@ The `_teach_validate_config()` function enforces these rules:
 ### Required Fields
 
 - `course.name` - Must be non-empty
+- **Draft branch** (one of):
+  - `branches.draft` — preferred schema
+  - `git.draft_branch` — legacy schema (also accepted)
+- **Production branch** (one of):
+  - `branches.production` — preferred schema
+  - `git.production_branch` — legacy schema (also accepted)
 
 ### Enum Validation
 

--- a/docs/specs/SPEC-flow-claude-subcommand.md
+++ b/docs/specs/SPEC-flow-claude-subcommand.md
@@ -1,0 +1,108 @@
+# SPEC: `flow claude` Subcommand
+
+**Status:** Draft  
+**Created:** 2026-06-19  
+**Scope:** flow-cli — new `claude` top-level subcommand for Claude Code environment health
+
+---
+
+## Problem
+
+Claude Code settings live in two places that can silently diverge:
+
+- `~/.claude/settings.json` env block (canonical — CC reads this directly)
+- `~/.config/zsh/.zshrc` export (fallback for issue #63186 where settings.json env block is silently ignored)
+
+No tool currently checks parity, hook health, memory index drift, or CLAUDE.md length. These failures surface as confusing behavior (wrong compaction threshold, missing PostCompact context, stale memory index), not as errors.
+
+---
+
+## Command Surface
+
+New `flow claude` top-level subcommand.
+
+**Implementation files:**
+- `commands/claude.zsh` — new file
+- `flow.zsh` — add `claude` dispatch case
+
+### Subcommands
+
+```
+flow claude check      # run all checks (alias: flow claude doctor)
+flow claude check --fix  # run checks + auto-repair safe mismatches
+```
+
+---
+
+## Checks
+
+| ID | Name | Logic | Severity | Fix-able |
+|----|------|-------|----------|----------|
+| C1 | Settings parity | Parse `~/.claude/settings.json` `.env` block; compare each key against matching `export KEY=VAL` in zshrc. Flag when zshrc diverges from settings.json (settings.json is canonical). | WARN | Yes — `--fix` updates zshrc export to match |
+| C2 | Hook health | `~/.claude/hooks/post-compact-reinject.sh` exists, is executable, passes `shellcheck`. | ERROR | No — report path and symptom only |
+| C3 | Memory index drift | Count `.md` files in `~/.claude/projects/*/memory/` directories; compare vs entry count in each `MEMORY.md` index. | WARN | No — report mismatched dirs |
+| C4 | CLAUDE.md length | `wc -l ~/.claude/CLAUDE.md` — warn if > 100 lines (project rule: trim before adding). | WARN | No — report with rule reminder |
+| C5 | Shell env parity | Verify `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is exported in the current shell session (proxy for env reaching Claude Work/Chat Electron apps launched from this shell). | INFO | No — informational only |
+
+---
+
+## `--fix` Behavior
+
+Safe writes only. `--fix` never touches `settings.json`.
+
+**What it fixes:**
+- C1: String-replace the `export KEY=VAL` line in zshrc to match the value in settings.json. Uses exact line match, not regex glob.
+
+**What it never touches:**
+- `~/.claude/settings.json` (complex nested JSON — manual edit)
+- Hook scripts (logic changes, not data)
+- MEMORY.md (structural document)
+
+---
+
+## Source of Truth
+
+`settings.json` env block is canonical for all Claude Code env vars.  
+zshrc export is a fallback for session-level env visibility only.
+
+When they diverge, `--fix` brings zshrc into alignment with settings.json — not the reverse.
+
+---
+
+## Out of Scope
+
+- craft rules (branch-guard, pre-commit hooks) — stay in craft
+- Claude Work/Chat config APIs (none exist; C5 is the best-effort proxy)
+- settings.json structural validation (not env-var domain)
+- Plugin or MCP server health (separate concern)
+
+---
+
+## Implementation Notes
+
+- Parse settings.json with `jq` (already a flow-cli dependency)
+- zshrc path: `$FLOW_ZSH_ROOT/.zshrc` or detect from `$ZDOTDIR`
+- `shellcheck` optional dependency — degrade gracefully if absent (skip C2 shellcheck sub-check, report existence + executable only)
+- Exit codes: 0 = all pass, 1 = any ERROR, 2 = any WARN (no ERROR)
+
+---
+
+## Dispatch Addition (flow.zsh)
+
+```zsh
+claude) flow_claude "$@" ;;
+```
+
+---
+
+## Example Output
+
+```
+flow claude check
+
+✓ Settings parity         AUTOCOMPACT=65 matches in settings.json + zshrc
+✗ Hook health             post-compact-reinject.sh: shellcheck failed (line 12)
+⚠ Memory index drift      ~/.claude/projects/-Users-dt--config/memory/: 8 files, 6 MEMORY.md entries
+✓ CLAUDE.md length        148 lines — exceeds 100-line rule (trim before adding)
+ℹ Shell env parity        CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=65 exported in current session
+```

--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -186,7 +186,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="7.10.2"
+export FLOW_VERSION="7.11.0"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup

--- a/lib/atlas-bridge.zsh
+++ b/lib/atlas-bridge.zsh
@@ -960,11 +960,13 @@ _at_help() {
   echo "${_C_BLUE}📋 SESSION${_C_NC}"
   echo "  ${_C_CYAN}at session start${_C_NC} ${_C_DIM}<project>${_C_NC}  ${_C_DIM}Start work session${_C_NC}"
   echo "  ${_C_CYAN}at session end${_C_NC} ${_C_DIM}[note]${_C_NC}      ${_C_DIM}End session with optional note${_C_NC}"
+  echo "  ${_C_CYAN}at session status --format json${_C_NC}  ${_C_DIM}Machine-readable session state${_C_NC}"
   echo ""
 
   echo "${_C_BLUE}📥 CAPTURE${_C_NC}"
   echo "  ${_C_CYAN}at catch${_C_NC} ${_C_DIM}<text>${_C_NC}             ${_C_DIM}Quick capture (works without Atlas)${_C_NC}"
   echo "  ${_C_CYAN}at inbox${_C_NC}                    ${_C_DIM}Show captured items${_C_NC}"
+  echo "  ${_C_CYAN}at inbox --count${_C_NC}            ${_C_DIM}Bare integer count for scripting${_C_NC}"
   echo "  ${_C_CYAN}at triage${_C_NC}                   ${_C_DIM}Process inbox items${_C_NC}"
   echo ""
 
@@ -972,6 +974,7 @@ _at_help() {
   echo "  ${_C_CYAN}at where${_C_NC} ${_C_DIM}[project]${_C_NC}         ${_C_DIM}Where was I? (works without Atlas)${_C_NC}"
   echo "  ${_C_CYAN}at crumb${_C_NC} ${_C_DIM}<text>${_C_NC}            ${_C_DIM}Leave breadcrumb (works without Atlas)${_C_NC}"
   echo "  ${_C_CYAN}at trail${_C_NC}                    ${_C_DIM}Show breadcrumb trail${_C_NC}"
+  echo "  ${_C_CYAN}at trail --limit N${_C_NC}          ${_C_DIM}Newest-N breadcrumbs${_C_NC}"
   echo "  ${_C_CYAN}at focus${_C_NC} ${_C_DIM}[project]${_C_NC}         ${_C_DIM}Set focus project${_C_NC}"
   echo ""
 
@@ -982,6 +985,8 @@ _at_help() {
   echo "  ${_C_CYAN}at unpark${_C_NC} ${_C_DIM}[project]${_C_NC}        ${_C_DIM}Resume a parked project${_C_NC}"
   echo "  ${_C_CYAN}at parked${_C_NC}                   ${_C_DIM}List parked projects${_C_NC}"
   echo "  ${_C_CYAN}at dash${_C_NC}                     ${_C_DIM}Project dashboard${_C_NC}"
+  echo "  ${_C_CYAN}at project list --count${_C_NC}     ${_C_DIM}Bare integer project count${_C_NC}"
+  echo "  ${_C_CYAN}at project list --suggest${_C_NC}   ${_C_DIM}One active project name suggestion${_C_NC}"
   echo ""
 
   if ! _flow_has_atlas; then

--- a/lib/project-detector.zsh
+++ b/lib/project-detector.zsh
@@ -242,7 +242,7 @@ _flow_project_icon() {
 #
 # Notes:
 #   - Requires yq for YAML parsing (warns and returns 0 if not installed)
-#   - Required fields: course.name, branches.draft, branches.production
+#   - Required fields: course.name, branches.draft (or git.draft_branch), branches.production (or git.production_branch)
 #   - Called automatically by _flow_detect_project_type for teaching projects
 #   - Part of teaching workflow v2 validation layer
 # =============================================================================
@@ -261,13 +261,15 @@ _flow_validate_teaching_config() {
     return 1
   }
 
-  yq -e '.branches.draft' "$config" &>/dev/null || {
-    _flow_log_error "Missing required field: branches.draft"
+  yq -e '.branches.draft' "$config" &>/dev/null \
+    || yq -e '.git.draft_branch' "$config" &>/dev/null || {
+    _flow_log_error "Missing required field: branches.draft or git.draft_branch"
     return 1
   }
 
-  yq -e '.branches.production' "$config" &>/dev/null || {
-    _flow_log_error "Missing required field: branches.production"
+  yq -e '.branches.production' "$config" &>/dev/null \
+    || yq -e '.git.production_branch' "$config" &>/dev/null || {
+    _flow_log_error "Missing required field: branches.production or git.production_branch"
     return 1
   }
 

--- a/man/man1/agenda.1
+++ b/man/man1/agenda.1
@@ -1,6 +1,6 @@
 .\" Man page for the agenda command (forward-looking schedule view)
 .\" Updated: June 2026
-.TH AGENDA 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH AGENDA 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 agenda \- forward-looking schedule across all projects
 .SH SYNOPSIS

--- a/man/man1/at.1
+++ b/man/man1/at.1
@@ -1,6 +1,6 @@
 .\" Man page for at dispatcher (Atlas bridge)
 .\" Generated: June 2026
-.TH AT 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH AT 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 at \- Atlas project intelligence bridge (optional integration)
 .SH SYNOPSIS

--- a/man/man1/at.1
+++ b/man/man1/at.1
@@ -68,14 +68,31 @@ Start a tracked work session for the given project.
 .TP
 .B session end \fR[\fInote\fR]
 End the current work session with an optional summary note.
+.TP
+.B session status
+Show current session state.
+.TP
+.B \-\-format \fIjson\fR
+Output session status as machine-readable JSON (use with
+.BR "session status" ).
 .SS Capture & Triage
 .TP
 .B triage
 Process inbox items interactively (prioritize, assign, or discard).
+.TP
+.B \-\-count
+Output a bare integer count instead of formatted output (use with
+.BR inbox ).
 .SS Context
 .TP
 .B trail
 Show the full breadcrumb trail for the current or specified project.
+.TP
+.B \-\-limit \fIN\fR
+Limit trail output to the newest
+.I N
+breadcrumbs (use with
+.BR trail ).
 .TP
 .B focus \fR[\fIproject\fR]
 Set or show the current focus project.
@@ -98,6 +115,14 @@ List all currently parked projects.
 .TP
 .B dash\fR, \fBdashboard
 Show a dashboard of all projects at a glance.
+.TP
+.B \-\-count
+Output a bare integer project count instead of formatted output (use with
+.BR "project list" ).
+.TP
+.B \-\-suggest
+Output one active project name suggestion (use with
+.BR "project list" ).
 .SH ENVIRONMENT
 .TP
 .B FLOW_ATLAS_ENABLED
@@ -167,6 +192,35 @@ Disable Atlas for a session:
 .RS
 .nf
 FLOW_ATLAS_ENABLED=no at catch "note stored locally"
+.fi
+.RE
+.PP
+Check session state in scripts (machine-readable JSON):
+.RS
+.nf
+.B at session status --format json
+.fi
+.RE
+.PP
+Get a bare integer count of pending captures:
+.RS
+.nf
+.B at inbox --count
+.fi
+.RE
+.PP
+Show only the 5 most recent breadcrumbs:
+.RS
+.nf
+.B at trail --limit 5
+.fi
+.RE
+.PP
+Get a bare project count or a suggestion for scripting:
+.RS
+.nf
+.B at project list --count
+.B at project list --suggest
 .fi
 .RE
 .SH SEE ALSO

--- a/man/man1/cc.1
+++ b/man/man1/cc.1
@@ -1,6 +1,6 @@
 .\" Man page for cc dispatcher (Claude Code launcher)
 .\" Generated: June 2026
-.TH CC 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH CC 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 cc \- Claude Code launcher and dispatcher
 .SH SYNOPSIS

--- a/man/man1/dash.1
+++ b/man/man1/dash.1
@@ -1,6 +1,6 @@
 .\" Man page for the dash command (project dashboard)
 .\" Updated: June 2026
-.TH DASH 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH DASH 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 dash \- ADHD-friendly project dashboard
 .SH SYNOPSIS

--- a/man/man1/dots.1
+++ b/man/man1/dots.1
@@ -1,6 +1,6 @@
 .\" Man page for dots dispatcher (Dotfile Management)
 .\" Generated: June 2026
-.TH DOTS 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH DOTS 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 dots \- Dotfile management dispatcher (chezmoi wrapper)
 .SH SYNOPSIS

--- a/man/man1/em.1
+++ b/man/man1/em.1
@@ -1,6 +1,6 @@
 .\" Man page for em dispatcher (Email / himalaya)
 .\" Generated: June 2026
-.TH EM 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH EM 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 em \- Email dispatcher (himalaya wrapper)
 .SH SYNOPSIS

--- a/man/man1/flow.1
+++ b/man/man1/flow.1
@@ -1,6 +1,6 @@
 .\" Man page for flow command
 .\" Updated: June 2026
-.TH FLOW 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH FLOW 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 flow \- ADHD-friendly workflow CLI for developers
 .SH SYNOPSIS

--- a/man/man1/g.1
+++ b/man/man1/g.1
@@ -1,6 +1,6 @@
 .\" Man page for g dispatcher (Git workflows)
 .\" Updated: June 2026
-.TH G 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH G 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 g \- Git commands dispatcher
 .SH SYNOPSIS

--- a/man/man1/mcp.1
+++ b/man/man1/mcp.1
@@ -1,6 +1,6 @@
 .\" Man page for mcp dispatcher (MCP server management)
 .\" Updated: June 2026
-.TH MCP 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH MCP 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 mcp \- MCP server management dispatcher
 .SH SYNOPSIS

--- a/man/man1/morning.1
+++ b/man/man1/morning.1
@@ -1,6 +1,6 @@
 .\" Man page for the morning command (daily startup routine)
 .\" Updated: June 2026
-.TH MORNING 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH MORNING 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 morning \- ADHD-friendly daily startup routine
 .SH SYNOPSIS

--- a/man/man1/prompt.1
+++ b/man/man1/prompt.1
@@ -1,6 +1,6 @@
 .\" Man page for prompt dispatcher (Prompt Engine Switcher)
 .\" Generated: June 2026
-.TH PROMPT 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH PROMPT 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 prompt \- Prompt engine switcher
 .SH SYNOPSIS

--- a/man/man1/qu.1
+++ b/man/man1/qu.1
@@ -1,6 +1,6 @@
 .\" Man page for qu dispatcher (Quarto publishing)
 .\" Updated: June 2026
-.TH QU 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH QU 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 qu \- Quarto publishing dispatcher
 .SH SYNOPSIS

--- a/man/man1/r.1
+++ b/man/man1/r.1
@@ -1,6 +1,6 @@
 .\" Man page for r dispatcher (R package development)
 .\" Updated: June 2026
-.TH R 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH R 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 r \- R package development dispatcher
 .SH SYNOPSIS

--- a/man/man1/sec.1
+++ b/man/man1/sec.1
@@ -1,6 +1,6 @@
 .\" Man page for sec dispatcher (Secret Management)
 .\" Generated: June 2026
-.TH SEC 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH SEC 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 sec \- Secret management dispatcher (Keychain and Bitwarden)
 .SH SYNOPSIS

--- a/man/man1/teach.1
+++ b/man/man1/teach.1
@@ -1,6 +1,6 @@
 .\" Man page for teach dispatcher (Teaching Workflow)
 .\" Generated: June 2026
-.TH TEACH 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH TEACH 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 teach \- Teaching workflow dispatcher (Scholar integration)
 .SH SYNOPSIS

--- a/man/man1/tm.1
+++ b/man/man1/tm.1
@@ -1,6 +1,6 @@
 .\" Man page for tm dispatcher (Terminal Manager)
 .\" Generated: June 2026
-.TH TM 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH TM 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 tm \- Terminal manager dispatcher
 .SH SYNOPSIS

--- a/man/man1/today.1
+++ b/man/man1/today.1
@@ -1,6 +1,6 @@
 .\" Man page for the today command (quick daily status)
 .\" Updated: June 2026
-.TH TODAY 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH TODAY 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 today \- quick daily status
 .SH SYNOPSIS

--- a/man/man1/tok.1
+++ b/man/man1/tok.1
@@ -1,6 +1,6 @@
 .\" Man page for tok dispatcher (Token Management)
 .\" Generated: June 2026
-.TH TOK 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH TOK 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 tok \- Token lifecycle management dispatcher
 .SH SYNOPSIS

--- a/man/man1/v.1
+++ b/man/man1/v.1
@@ -1,6 +1,6 @@
 .\" Man page for v dispatcher (Vibe / Workflow Automation)
 .\" Generated: June 2026
-.TH V 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH V 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 v \- Workflow automation dispatcher (vibe coding mode)
 .SH SYNOPSIS

--- a/man/man1/week.1
+++ b/man/man1/week.1
@@ -1,6 +1,6 @@
 .\" Man page for the week command (weekly review helper)
 .\" Updated: June 2026
-.TH WEEK 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH WEEK 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 week \- weekly review helper
 .SH SYNOPSIS

--- a/man/man1/wt.1
+++ b/man/man1/wt.1
@@ -1,6 +1,6 @@
 .\" Man page for wt dispatcher (Git Worktree Management)
 .\" Generated: June 2026
-.TH WT 1 "June 2026" "flow-cli 7.10.2" "User Commands"
+.TH WT 1 "June 2026" "flow-cli 7.11.0" "User Commands"
 .SH NAME
 wt \- Git worktree management dispatcher
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "7.10.2",
+  "version": "7.11.0",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {

--- a/tests/fixtures/demo-course/.teach/concepts.json
+++ b/tests/fixtures/demo-course/.teach/concepts.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "schema_version": "concept-graph-v1",
   "metadata": {
-    "last_updated": "2026-05-04T18:35:50Z",
+    "last_updated": "2026-06-18T04:42:46Z",
     "course_hash": "f1d6eb285878575aa9936f3b487679c672f95ce1",
     "total_concepts": 12,
     "weeks": 5,

--- a/tests/fixtures/demo-course/.teach/concepts.json
+++ b/tests/fixtures/demo-course/.teach/concepts.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "schema_version": "concept-graph-v1",
   "metadata": {
-    "last_updated": "2026-06-18T04:42:46Z",
+    "last_updated": "2026-06-19T13:30:11Z",
     "course_hash": "f1d6eb285878575aa9936f3b487679c672f95ce1",
     "total_concepts": 12,
     "weeks": 5,

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -160,6 +160,7 @@ run_test ./tests/e2e-agenda.zsh
 echo ""
 echo "Atlas contract tests:"
 run_test ./tests/test-atlas-contract.zsh
+run_test ./tests/test-doctor-atlas-calls.zsh
 
 echo ""
 echo "Additional unit tests:"

--- a/tests/test-doctor-atlas-calls.zsh
+++ b/tests/test-doctor-atlas-calls.zsh
@@ -1,0 +1,68 @@
+#!/usr/bin/env zsh
+# ============================================================================
+# Static regression guard: flow doctor's atlas health checks must use
+# spec-compliant atlas calls (see docs/ATLAS-CONTRACT.md).
+#
+# Prevents re-introducing the out-of-spec calls fixed in atlas-contract-v1.1:
+#   OOS-1: `atlas config get backend`  → `atlas config show` (parse `.storage`)
+#   OOS-2: `atlas mcp status`          → `command -v atlas-mcp` (separate binary)
+# and the false-positive fix: "connected" is gated on a captured config-show
+# response, not merely on the atlas binary being on PATH.
+#
+# This is a STATIC test — it greps the source, so it needs neither a working
+# atlas nor jq and runs identically on every machine and CI runner.
+# ============================================================================
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh"
+
+DOCTOR_FILE="$PROJECT_ROOT/commands/doctor.zsh"
+
+test_doctor_file_exists() {
+    test_case "commands/doctor.zsh exists"
+    assert_file_exists "$DOCTOR_FILE" && test_pass
+}
+
+test_uses_config_show_not_get() {
+    test_case "uses 'atlas config show' and not the nonexistent 'atlas config get'"
+    local content="$(cat "$DOCTOR_FILE")"
+    assert_contains "$content" "atlas config show" && \
+        assert_not_contains "$content" "atlas config get" && test_pass
+}
+
+test_uses_atlas_mcp_binary_not_subcommand() {
+    test_case "checks 'command -v atlas-mcp', not the nonexistent 'atlas mcp status'"
+    local content="$(cat "$DOCTOR_FILE")"
+    assert_contains "$content" "command -v atlas-mcp" && \
+        assert_not_contains "$content" "atlas mcp status" && test_pass
+}
+
+test_connected_gated_on_response() {
+    test_case "'connected' is gated on a captured config-show response (not just command -v atlas)"
+    local content="$(cat "$DOCTOR_FILE")"
+    assert_contains "$content" 'atlas_cfg=' && \
+        assert_contains "$content" 'not responding' && test_pass
+}
+
+test_storage_parse_is_anchored() {
+    test_case "no-jq backend parse anchors on the \"storage\" key (no greedy last-quote match)"
+    local content="$(cat "$DOCTOR_FILE")"
+    # The hardened sed matches '"storage"...:..."<value>"'; assert the anchor is present.
+    assert_contains "$content" '"storage"' && test_pass
+}
+
+main() {
+    test_suite_start "Doctor Atlas Calls — spec-compliance guard"
+
+    test_doctor_file_exists
+    test_uses_config_show_not_get
+    test_uses_atlas_mcp_binary_not_subcommand
+    test_connected_gated_on_response
+    test_storage_parse_is_anchored
+
+    test_suite_end
+    exit $?
+}
+
+main "$@"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -214,6 +214,16 @@ command -v radian >/dev/null && alias R='radian'
 # Run 'cc help' to see all available commands:
 #   cc, cc yolo, cc plan, cc ask, cc file, cc diff, cc resume, etc.
 
+# Token optimization: compact at 55% context (default is ~83.5%)
+# Fallback for settings.json env block which may be silently ignored (issue #63186)
+export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=55
+
+# Model tiering: main loop = Opus/opusplan; subagents route per-task via their own
+# definitions (craft orchestrator-v2 already does haiku-for-reads / sonnet-for-writes).
+# NOT setting CLAUDE_CODE_SUBAGENT_MODEL: it has highest priority and would OVERRIDE
+# craft's finer per-task routing, forcing cheap haiku read/test agents up to sonnet (~5x).
+# For ad-hoc main-session agents, pass model: explicitly at spawn.
+
 # Backward compatibility alias for YOLO mode
 alias ccy='cc yolo'
 
@@ -1059,6 +1069,19 @@ fpath=(~/.zsh/completions $fpath)
 # Gated to real iTerm2 only (was loading under Ghostty and leaking OSC 1337 +
 # focus/DA query responses as literal text — garbled Claude Code's TUI).
 [[ "$TERM_PROGRAM" == "iTerm.app" ]] && test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
+
+# ============================================
+# DISABLE BUN KITTY PROBE - Added 2026-06-04
+# ============================================
+# Claude Code 2.1.x is a Bun-compiled binary; Bun's runtime fires a Kitty
+# keyboard-protocol PROBE at startup (an escape-sequence terminal query). On
+# Ghostty the probe + Ghostty's response renders as garbage in Claude's prompt
+# at startup — invariant across `ccy`/`cc`/plain `claude`. Disabling Bun's probe
+# fixes it at the source. CONFIRMED 2026-06-04 (BUN_DISABLE_KITTY_PROBE=1 claude
+# = clean). NOT a zsh-state issue: the earlier precmd CSI-u-reset hook was the
+# wrong layer (terminal read flags=0 before launch) and is removed.
+# Sibling of the iTerm2-integration gating above (same escape-leak-into-TUI class).
+export BUN_DISABLE_KITTY_PROBE=1
 
 # Nexus Desktop - Quick Launcher
 # REMOVED 2026-01-17: alias nexus='cd ~/projects/dev-tools/nexus/nexus-desktop && npm start'

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -214,10 +214,12 @@ command -v radian >/dev/null && alias R='radian'
 # Run 'cc help' to see all available commands:
 #   cc, cc yolo, cc plan, cc ask, cc file, cc diff, cc resume, etc.
 
-# Token optimization: compact at 55% context (default is ~83.5%)
+# Token optimization: compact at 65% context (default is ~83.5%)
 # Fallback for settings.json env block which may be silently ignored (issue #63186)
-export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=55
+export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=65
 
+# Default main-loop model: opusplan (Opus in plan mode, Sonnet for execution).
+# Set in ~/.claude/settings.json ("model": "opusplan"); kept here as documentation.
 # Model tiering: main loop = Opus/opusplan; subagents route per-task via their own
 # definitions (craft orchestrator-v2 already does haiku-for-reads / sonnet-for-writes).
 # NOT setting CLAUDE_CODE_SUBAGENT_MODEL: it has highest priority and would OVERRIDE

--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -566,3 +566,21 @@ winshistory() {
 # ══════════════════════════════════════════════════════════════════════════════
 # END WORKFLOW FUNCTIONS
 # ══════════════════════════════════════════════════════════════════════════════
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PROJECT DOCS — savant (private, local-only docs site; no public Pages)
+# ══════════════════════════════════════════════════════════════════════════════
+
+# savant-docs — serve savant's private docs site locally and auto-open the browser.
+# Runs in a subshell so your current directory is unchanged. Ctrl-C to stop.
+# Extra args pass through, e.g.:  savant-docs -a 127.0.0.1:8001
+savant-docs() {
+    ( cd ~/projects/dev-tools/savant && mkdocs serve -o "$@" )
+}
+
+# savant-docs-build — one-off static build into savant/site/ and open it.
+# Note: opens via file:// so Material search / instant-nav won't work — use
+# `savant-docs` (the server) for full functionality.
+savant-docs-build() {
+    ( cd ~/projects/dev-tools/savant && mkdocs build && open site/index.html )
+}


### PR DESCRIPTION
## Summary

- **New:** `at` dispatcher tab completions (`completions/_at`) + `_at_help()` flag entries + man page docs for atlas v0.9.3 flags
- **Fixed:** `flow doctor` atlas health checks — gated "connected" on `atlas config show` response; replaced nonexistent `atlas config get backend` and `atlas mcp status` calls
- **Fixed:** `_flow_validate_teaching_config` now accepts `git.draft_branch` / `git.production_branch` alongside `branches.*`
- **Docs:** Atlas CLI API Contract v1.1.0; teach-config schema reference updated

## Test plan

- [x] e2e: core-commands, atlas-bridge, dispatcher-split, plugin-system, agenda — all pass
- [x] dogfood: 4/4 anti-pattern checks pass
- [x] `test-doctor-atlas-calls.zsh` 5/5 (static regression guard)
- [x] `test-atlas-contract.zsh` 18/18
- [ ] CI full suite on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)