### PR TITLE
feat(claude): C7-C11 checks + watch daemon (v7.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.13.0] — TBD — flow claude: C7-C11 checks + watch daemon
+
+### Added
+
+- **C4 two-tier threshold** (`commands/claude.zsh`): >100 lines → WARN "approaching 180-line limit"; >180 lines → ERROR "exceeds 180-line hard limit" (was a single >100 check)
+- **C7 per-project CLAUDE.md audit**: scans `$FLOW_CLAUDE_PROJECTS_ROOT` (default: `~/projects`) up to depth 4; warns on files >180 lines or version refs that don't match `git describe --tags`; injectable via `FLOW_CLAUDE_PROJECTS_ROOT`
+- **C8 orphaned memory dirs**: decodes `~/.claude/projects/` slug names back to filesystem paths (`/a-b-c` → `/a/b/c`); warns on stale dirs whose decoded path no longer exists
+- **C9 rules drift**: checks that every `~/.claude/rules/*.md` stem is referenced in `~/.claude/CLAUDE.md`; warns on unreferenced rules
+- **C10 missing hook files**: parses `settings.json` hook commands; errors on any absolute-path script that isn't present on disk
+- **C11 plugin health**: checks `~/.claude/plugins/*/plugin.json` exists and is valid JSON (skips `cache/` subdir); warns on broken plugins
+- **`flow claude watch [--interval N] [--stop] [--status]`**: background health watcher — runs `flow claude check` on a configurable interval (default: 30 min), writes state to `~/.flow/claude-health-state.json`, and fires a desktop notification via `terminal-notifier` when status changes between pass/warn/error; gracefully silent on Linux where `terminal-notifier` is absent
+
 ## [7.12.0] — 2026-06-19 — flow claude check: Claude Code environment health
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ flow-cli/
 ├── docs/                     # Documentation (MkDocs)
 │   └── internal/             # Internal conventions & contributor templates
 ├── scripts/                  # Standalone validators (check-math.zsh)
-├── tests/                    # 218 test files, 12000+ test functions
+├── tests/                    # 219 test files, 12000+ test functions
 │   └── fixtures/demo-course/ # STAT-101 demo course for E2E
 └── .archive/                 # Archived Node.js CLI
 ```
@@ -182,7 +182,7 @@ flow-cli/
 
 ## Testing
 
-**218 test files, 12000+ test functions.** Run: `./tests/run-all.sh` (66/66 passing, 1 expected interactive/tmux timeout) or individual suites in `tests/`.
+**219 test files, 12000+ test functions.** Run: `./tests/run-all.sh` (67/67 passing, 1 expected interactive/tmux timeout) or individual suites in `tests/`.
 
 See `docs/guides/TESTING.md` for patterns, mocks, assertions, TDD workflow.
 
@@ -216,7 +216,7 @@ export FLOW_FORCE_DISPATCHER_OBS=1           # Force-keep one dispatcher (FLOW_F
 
 ## Current Status
 
-**Version:** v7.12.0 | **Tests:** 12000+ (66/66 suite, 1 interactive timeout) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.12.0 | **Tests:** 12000+ (67/67 suite, 1 interactive timeout) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 

--- a/ORCHESTRATE-flow-claude-v2.md
+++ b/ORCHESTRATE-flow-claude-v2.md
@@ -1,0 +1,149 @@
+# ORCHESTRATE: flow claude v2 — Extended Checks + Watch
+
+**Branch:** `feature/flow-claude-v2`  
+**Spec:** `docs/specs/SPEC-flow-claude-v2.md`  
+**Target:** v7.13.0
+
+---
+
+## Objective
+
+Extend `flow claude check` with C4 two-tier fix and new checks C7–C11, then
+add `flow claude watch` background daemon with terminal-notifier alerts on
+WARN/ERROR state change.
+
+---
+
+## Task List
+
+### Wave 1 — Existing file changes (no new files)
+
+- [ ] **1a. Fix C4 two-tier threshold** (`commands/claude.zsh`)
+  - Change single `if (( line_count > 100 ))` to two-tier:
+    - `> 100` → `_flow_log_warning` + `has_warn=1`
+    - `> 180` → `_flow_log_error` + `has_error=1`
+  - Update help text: `C4  CLAUDE.md length      warns > 100 lines, errors > 180`
+  - Tests: 95 lines → pass, 150 → warn, 200 → error
+
+- [ ] **1b. Add C8: Orphaned memory dirs** (`commands/claude.zsh`)
+  - After C7 block, iterate `${FLOW_CLAUDE_HOME:-$HOME/.claude}/projects/*/`
+  - Decode slug to path: `/${slug//-//}` (leading `-` → `/`)
+  - Flag if `[[ ! -d "$decoded_path" ]]`
+  - Injectable: `FLOW_CLAUDE_HOME` (already used by C1–C4)
+  - Tests: mock a slug for a nonexistent dir → warn; valid dir → pass
+
+- [ ] **1c. Add C9: Rules drift** (`commands/claude.zsh`)
+  - Iterate `$claude_home/rules/*.md`
+  - Extract stem: `${rule_file:t:r}`
+  - Check `grep -qF "$stem" "$claude_home/CLAUDE.md"`
+  - Flag unreferenced stems
+  - Tests: rule file not cited in CLAUDE.md → warn; all cited → pass
+
+- [ ] **1d. Add C10: Missing hook files** (`commands/claude.zsh`)
+  - Requires `jq` (guard same as C1)
+  - Extract from settings.json: `jq -r '(.hooks // {}) | to_entries[] | .value[] | .command'`
+  - For each command starting with `/` or `~`: check file exists
+  - Severity: ERROR (not WARN — missing hook = silent breakage)
+  - Tests: hook path missing → error; hook path present → pass; no hooks → pass
+
+- [ ] **1e. Add C11: Plugin health** (`commands/claude.zsh`)
+  - Iterate `$claude_home/plugins/*/` (skip `cache/`)
+  - Check `plugin.json` exists + is valid JSON (`jq empty`)
+  - Severity: WARN
+  - Tests: missing plugin.json → warn; invalid JSON → warn; valid → pass
+
+### Wave 2 — C7 (needs helper + git calls)
+
+- [ ] **2a. Add `_flow_find_project_claude_mds` helper** (`commands/claude.zsh` or `lib/core.zsh`)
+  - `find "${FLOW_CLAUDE_PROJECTS_ROOT:-$HOME/projects}" -maxdepth 4 -name "CLAUDE.md" -not -path "*/.git/*" -not -path "*/node_modules/*"`
+  - Returns newline-separated paths via stdout
+
+- [ ] **2b. Add C7: Per-project CLAUDE.md audit** (`commands/claude.zsh`)
+  - Call `_flow_find_project_claude_mds` → iterate paths
+  - C7a: `wc -l < "$file"` > 180 → warn
+  - C7b: `git -C "$proj_dir" describe --tags --abbrev=0 2>/dev/null` → if succeeds,
+    grep file for `v[0-9]+\.[0-9]+\.[0-9]+`, compare each match against tag;
+    mismatch → warn; no tags → skip silently
+  - Injectable: `FLOW_CLAUDE_PROJECTS_ROOT`
+  - Tests: fixture dir with 200-line CLAUDE.md → warn; mocked git tag mismatch → warn;
+    no tags → pass (no false positive)
+
+### Wave 3 — Watch daemon
+
+- [ ] **3a. Add `flow claude watch` routing** (`commands/claude.zsh`)
+  - Add `watch)` case to `flow_claude()` dispatch
+  - Parse `--stop`, `--status`, `--interval N` flags
+
+- [ ] **3b. Implement `_flow_claude_watch_start`** (`commands/claude.zsh`)
+  - Stale PID check via `kill -0`
+  - Background loop: `_flow_claude_watch_run_check` → sleep → repeat
+  - Log rotation: keep last 50KB of `~/.flow/claude-watch.log`
+  - Write PID to `~/.flow/claude-watch.pid`
+  - `disown $!` after backgrounding
+
+- [ ] **3c. Implement `_flow_claude_watch_run_check`** (`commands/claude.zsh`)
+  - Runs `_flow_claude_check` in a subshell, captures exit code
+  - Translates exit code to result string: 0=pass, 1=error, 2=warn
+  - Reads previous state from `~/.flow/claude-health-state.json`
+  - Calls `_flow_claude_watch_notify` on state change
+  - Writes new state JSON
+
+- [ ] **3d. Implement `_flow_claude_watch_notify`** (`commands/claude.zsh`)
+  - Only notify if new/old state is warn or error (skip info/pass↔pass)
+  - `command -v terminal-notifier` guard — silent on Linux
+  - Call: `terminal-notifier -title "flow claude" -subtitle "..." -message "..." -sound default`
+
+- [ ] **3e. Implement `--stop` and `--status`** (`commands/claude.zsh`)
+  - `--stop`: read PID file, `kill $pid`, remove pid file
+  - `--status`: read state JSON, show PID/interval/last-check/result
+
+- [ ] **3f. Update `_flow_claude_help`** with watch subcommand docs
+
+### Wave 4 — Tests
+
+- [ ] **4a. Tests for C4 two-tier, C8, C9, C10, C11** (`tests/test-flow-claude.zsh`)
+  - Fixture dirs injected via `FLOW_CLAUDE_HOME` / `FLOW_CLAUDE_PROJECTS_ROOT`
+  - See full test list in `SPEC-flow-claude-v2.md`
+
+- [ ] **4b. Tests for C7** (`tests/test-flow-claude.zsh`)
+  - Mock `git describe` via function override in test scope
+
+- [ ] **4c. Tests for watch** (`tests/test-flow-claude.zsh`)
+  - Mock `_flow_claude_check` exit code
+  - Assert state file transitions
+  - Assert `--stop` removes pid file
+  - Assert `--status` doesn't crash when watcher is not running
+
+### Wave 5 — Docs + completions
+
+- [ ] **5a. Update `completions/_flow_claude`** — add `watch`, `--interval`, `--stop`, `--status`
+- [ ] **5b. Update `man/man1/flow.1`** — document watch + new checks
+- [ ] **5c. Update `CLAUDE.md`** — test count, suite count
+- [ ] **5d. Update `TESTING.md`** — test count (3 locations)
+- [ ] **5e. Update `CHANGELOG.md`** — Unreleased section
+
+---
+
+## Verification
+
+After each wave:
+```zsh
+source flow.plugin.zsh
+flow claude check
+./tests/run-all.sh
+```
+
+Final gate before PR:
+```zsh
+./tests/run-all.sh  # expect 66/66 suites passing (+ new test-flow-claude tests)
+flow claude check   # run against real ~/.claude — all checks should execute
+flow claude watch --interval 1  # start 1-min watcher, verify state file written
+flow claude watch --status       # confirm output
+flow claude watch --stop         # confirm clean shutdown
+```
+
+---
+
+## PR target
+
+`gh pr create --base dev --title "feat(claude): C7-C11 checks + watch daemon (v7.13.0)"`

--- a/commands/claude.zsh
+++ b/commands/claude.zsh
@@ -7,6 +7,7 @@ flow_claude() {
 
   case "$subcmd" in
     check|doctor) _flow_claude_check "$@" ;;
+    watch) _flow_claude_watch "$@" ;;
     help|--help|-h) _flow_claude_help ;;
     *)
       _flow_log_error "Unknown subcommand: $subcmd"
@@ -21,17 +22,26 @@ _flow_claude_help() {
   print "${b}flow claude${r} — Claude Code environment health checker"
   print ""
   print "${b}Usage:${r}"
-  print "  flow claude check          Run all environment checks"
-  print "  flow claude check --fix    Run checks + auto-repair safe mismatches (C1, C6)"
-  print "  flow claude doctor         Alias for check"
+  print "  flow claude check              Run all environment checks"
+  print "  flow claude check --fix        Run checks + auto-repair safe mismatches (C1, C6)"
+  print "  flow claude doctor             Alias for check"
+  print "  flow claude watch              Start background health watcher (30-min default)"
+  print "  flow claude watch --stop       Stop watcher"
+  print "  flow claude watch --status     Show watcher status + last result"
+  print "  flow claude watch --interval N Set poll interval in minutes"
   print ""
   print "${b}Checks:${r}"
   print "  C1  Settings parity       settings.json env block vs zshrc exports"
   print "  C2  Hook health           post-compact-reinject.sh exists + executable + shellcheck"
   print "  C3  Memory index drift    .md file count vs MEMORY.md entry count"
-  print "  C4  CLAUDE.md length      warns when > 100 lines"
+  print "  C4  CLAUDE.md length      warns > 100 lines, errors > 180"
   print "  C5  Shell env parity      CLAUDE_AUTOCOMPACT_PCT_OVERRIDE exported"
   print "  C6  Output token limit    CLAUDE_CODE_MAX_OUTPUT_TOKENS > 8192 (auto-fixable with --fix)"
+  print "  C7  Project CLAUDE.md     per-project line count + version drift"
+  print "  C8  Orphaned memory       ~/.claude/projects/ dirs for deleted projects"
+  print "  C9  Rules drift           ~/.claude/rules/*.md files not cited in CLAUDE.md"
+  print "  C10 Hook files            hooks in settings.json pointing to missing scripts"
+  print "  C11 Plugin health         ~/.claude/plugins/ dirs missing valid plugin.json"
   print ""
   print "${b}Exit codes:${r} 0=all pass  1=any ERROR  2=any WARN (no ERROR)"
 }
@@ -156,8 +166,11 @@ _flow_claude_check() {
   else
     local line_count
     line_count=$(wc -l < "$claude_md" | tr -d ' ')
-    if (( line_count > 100 )); then
-      _flow_log_warning "C4 CLAUDE.md length    $line_count lines — exceeds 100-line rule (trim before adding)"
+    if (( line_count > 180 )); then
+      _flow_log_error "C4 CLAUDE.md length    $line_count lines — exceeds 180-line hard limit (see ~/.claude/rules/claude-md-length.md)"
+      has_error=1
+    elif (( line_count > 100 )); then
+      _flow_log_warning "C4 CLAUDE.md length    $line_count lines — approaching 180-line limit (trim before adding)"
       has_warn=1
     else
       _flow_log_success "C4 CLAUDE.md length    $line_count lines — within limit"
@@ -198,6 +211,180 @@ _flow_claude_check() {
     _flow_log_success "C6 Output token limit  CLAUDE_CODE_MAX_OUTPUT_TOKENS=${token_val}"
   fi
 
+  # ── C7: Per-project CLAUDE.md audit ─────────────────────────────────────
+  local projects_root="${FLOW_CLAUDE_PROJECTS_ROOT:-$HOME/projects}"
+  if [[ -d "$projects_root" ]]; then
+    local c7_issues=() c7_scanned=0 c7_clean=0
+    local proj_file
+    while IFS= read -r proj_file; do
+      [[ -z "$proj_file" ]] && continue
+      (( c7_scanned++ ))
+      local proj_dir="${proj_file:h}"
+      local rel_path="${proj_file#$projects_root/}"
+      local file_has_issue=0
+
+      # C7a: line count
+      local plines
+      plines=$(wc -l < "$proj_file" | tr -d ' ')
+      if (( plines > 180 )); then
+        c7_issues+=("$rel_path: $plines lines (> 180)")
+        file_has_issue=1
+      fi
+
+      # C7b: version drift (only if repo has tags)
+      local git_tag
+      git_tag=$(git -C "$proj_dir" describe --tags --abbrev=0 2>/dev/null)
+      if [[ -n "$git_tag" ]]; then
+        local version_refs
+        version_refs=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' "$proj_file" 2>/dev/null)
+        local vref
+        while IFS= read -r vref; do
+          [[ -z "$vref" ]] && continue
+          if [[ "$vref" != "$git_tag" ]]; then
+            c7_issues+=("$rel_path: version ref $vref (current: $git_tag)")
+            file_has_issue=1
+          fi
+        done <<< "$version_refs"
+      fi
+
+      (( file_has_issue )) || (( c7_clean++ ))
+    done <<< "$(_flow_find_project_claude_mds "$projects_root")"
+
+    if (( ${#c7_issues[@]} > 0 )); then
+      _flow_log_warning "C7 Project CLAUDE.md   ${#c7_issues[@]} issue(s) ($c7_scanned files scanned):"
+      local issue
+      for issue in "${c7_issues[@]}"; do
+        print "    $issue"
+      done
+      if (( c7_clean > 0 )); then
+        _flow_log_success "C7 Project CLAUDE.md   $c7_clean clean"
+      fi
+      has_warn=1
+    else
+      _flow_log_success "C7 Project CLAUDE.md   $c7_scanned files scanned, all clean"
+    fi
+  else
+    _flow_log_success "C7 Project CLAUDE.md   projects root not found (skipped)"
+  fi
+
+  # ── C8: Orphaned memory dirs ────────────────────────────────────────────
+  local claude_projects="$claude_home/projects"
+  if [[ -d "$claude_projects" ]]; then
+    local orphaned=() valid_count=0
+    local proj_slug proj_dir_path decoded_path
+    for proj_dir_path in "$claude_projects"/*(N/); do
+      proj_slug="${proj_dir_path##*/}"
+      decoded_path="/${proj_slug//-//}"
+      if [[ ! -d "$decoded_path" ]]; then
+        orphaned+=("$proj_slug (path $decoded_path not found)")
+      else
+        (( valid_count++ ))
+      fi
+    done
+    if (( ${#orphaned[@]} > 0 )); then
+      _flow_log_warning "C8 Orphaned memory     ${#orphaned[@]} stale dir(s):"
+      local orphan
+      for orphan in "${orphaned[@]}"; do
+        print "    $orphan"
+      done
+      has_warn=1
+    else
+      _flow_log_success "C8 Orphaned memory     $valid_count dirs all valid"
+    fi
+  fi
+
+  # ── C9: Rules drift ─────────────────────────────────────────────────────
+  local rules_dir="$claude_home/rules"
+  local claude_md_global="$claude_home/CLAUDE.md"
+  if [[ -d "$rules_dir" ]] && [[ -f "$claude_md_global" ]]; then
+    local unreferenced=() ref_count=0
+    local rule_file rule_stem
+    for rule_file in "$rules_dir"/*.md(N); do
+      rule_stem="${rule_file:t:r}"
+      if ! grep -qF "$rule_stem" "$claude_md_global" 2>/dev/null; then
+        unreferenced+=("$rule_stem")
+      else
+        (( ref_count++ ))
+      fi
+    done
+    if (( ${#unreferenced[@]} > 0 )); then
+      _flow_log_warning "C9 Rules drift         ${#unreferenced[@]} unreferenced rule(s):"
+      local rule
+      for rule in "${unreferenced[@]}"; do
+        print "    $rule (not mentioned in CLAUDE.md)"
+      done
+      has_warn=1
+    else
+      _flow_log_success "C9 Rules drift         $ref_count rules all referenced"
+    fi
+  elif [[ ! -d "$rules_dir" ]]; then
+    _flow_log_success "C9 Rules drift         no rules dir found (skipped)"
+  fi
+
+  # ── C10: Missing hook files ──────────────────────────────────────────────
+  if [[ -f "$settings_json" ]]; then
+    if ! command -v jq &>/dev/null; then
+      _flow_log_warning "C10 Hook files         jq not installed — cannot check hooks"
+      has_warn=1
+    else
+      local missing_hooks=() hooks_present=0
+      local hook_cmd hook_cmds
+      hook_cmds=$(jq -r '(.hooks // {}) | to_entries[] | .value[] | .command' "$settings_json" 2>/dev/null)
+      while IFS= read -r hook_cmd; do
+        [[ -z "$hook_cmd" ]] && continue
+        # Only check file paths (absolute or home-relative)
+        if [[ "$hook_cmd" == /* ]] || [[ "$hook_cmd" == ~* ]]; then
+          local expanded_cmd="${hook_cmd/#\~/$HOME}"
+          local script_path="${expanded_cmd%% *}"
+          if [[ ! -f "$script_path" ]]; then
+            missing_hooks+=("$script_path (defined in settings.json, not found)")
+          else
+            (( hooks_present++ ))
+          fi
+        fi
+      done <<< "$hook_cmds"
+
+      if (( ${#missing_hooks[@]} > 0 )); then
+        _flow_log_error "C10 Hook files         ${#missing_hooks[@]} missing:"
+        local mh
+        for mh in "${missing_hooks[@]}"; do
+          print "    $mh"
+        done
+        has_error=1
+      else
+        _flow_log_success "C10 Hook files         $hooks_present hooks all present"
+      fi
+    fi
+  fi
+
+  # ── C11: Plugin health ───────────────────────────────────────────────────
+  local plugins_dir="$claude_home/plugins"
+  if [[ -d "$plugins_dir" ]] && command -v jq &>/dev/null; then
+    local broken_plugins=() healthy_plugins=0
+    local plugin_dir pjson
+    for plugin_dir in "$plugins_dir"/*(N/); do
+      [[ "${plugin_dir:t}" == "cache" ]] && continue
+      pjson="$plugin_dir/plugin.json"
+      if [[ ! -f "$pjson" ]]; then
+        broken_plugins+=("${plugin_dir:t}: missing plugin.json")
+      elif ! jq empty "$pjson" 2>/dev/null; then
+        broken_plugins+=("${plugin_dir:t}: invalid JSON in plugin.json")
+      else
+        (( healthy_plugins++ ))
+      fi
+    done
+    if (( ${#broken_plugins[@]} > 0 )); then
+      _flow_log_warning "C11 Plugin health      ${#broken_plugins[@]} broken plugin(s):"
+      local bp
+      for bp in "${broken_plugins[@]}"; do
+        print "    $bp"
+      done
+      has_warn=1
+    else
+      _flow_log_success "C11 Plugin health      $healthy_plugins plugins healthy"
+    fi
+  fi
+
   # ── Summary ──────────────────────────────────────────────────────────────
   print ""
   if (( has_error )); then
@@ -210,6 +397,15 @@ _flow_claude_check() {
     _flow_log_success "Result: all checks passed"
     return 0
   fi
+}
+
+# Find all project CLAUDE.md files under the given root
+_flow_find_project_claude_mds() {
+  local projects_root="${1:-$HOME/projects}"
+  find "$projects_root" -maxdepth 4 -name "CLAUDE.md" \
+    -not -path "*/.git/*" \
+    -not -path "*/node_modules/*" \
+    2>/dev/null
 }
 
 # Repair C6: set CLAUDE_CODE_MAX_OUTPUT_TOKENS=32000 in zshrc
@@ -240,4 +436,199 @@ _flow_claude_fix_c1() {
     print "\nexport ${key}=${val}" >> "$zshrc"
     _flow_log_success "  --fix: added $key to zshrc"
   fi
+}
+
+# ── Watch daemon ──────────────────────────────────────────────────────────
+
+_flow_claude_watch() {
+  local interval=30
+  local do_stop=0
+  local do_status=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --stop) do_stop=1; shift ;;
+      --status) do_status=1; shift ;;
+      --interval) interval="${2:-30}"; shift 2 ;;
+      --interval=*) interval="${1#--interval=}"; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  if (( do_stop )); then
+    _flow_claude_watch_stop
+  elif (( do_status )); then
+    _flow_claude_watch_status
+  else
+    _flow_claude_watch_start "$interval"
+  fi
+}
+
+_flow_claude_watch_start() {
+  local interval_min="${1:-30}"
+  local interval_sec=$(( interval_min * 60 ))
+  local flow_dir="$HOME/.flow"
+  local pid_file="$flow_dir/claude-watch.pid"
+  local state_file="$flow_dir/claude-health-state.json"
+  local log_file="$flow_dir/claude-watch.log"
+
+  mkdir -p "$flow_dir"
+
+  # Stale PID check
+  if [[ -f "$pid_file" ]]; then
+    local old_pid
+    old_pid=$(< "$pid_file")
+    if kill -0 "$old_pid" 2>/dev/null; then
+      _flow_log_warning "watch already running (PID $old_pid) — use --stop first"
+      return 1
+    fi
+    rm -f "$pid_file"
+  fi
+
+  # Launch background loop
+  (
+    print $$ > "$pid_file"
+    while true; do
+      _flow_claude_watch_run_check "$state_file" >> "$log_file" 2>&1
+      # Log rotation: keep last 50KB
+      if [[ -f "$log_file" ]] && (( $(wc -c < "$log_file") > 50000 )); then
+        tail -c 50000 "$log_file" > "${log_file}.tmp" && mv "${log_file}.tmp" "$log_file"
+      fi
+      sleep "$interval_sec"
+    done
+  ) &
+  disown $!
+  _flow_log_success "watch started (PID $!, interval ${interval_min}m)"
+}
+
+_flow_claude_watch_stop() {
+  local pid_file="$HOME/.flow/claude-watch.pid"
+  if [[ ! -f "$pid_file" ]]; then
+    _flow_log_warning "watch not running (no pid file)"
+    return 0
+  fi
+  local pid
+  pid=$(< "$pid_file")
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null
+    rm -f "$pid_file"
+    _flow_log_success "watch stopped (PID $pid)"
+  else
+    rm -f "$pid_file"
+    _flow_log_warning "watch was not running (stale pid $pid), cleaned up"
+  fi
+}
+
+_flow_claude_watch_status() {
+  local pid_file="$HOME/.flow/claude-watch.pid"
+  local state_file="$HOME/.flow/claude-health-state.json"
+
+  local is_running=0 pid=""
+  if [[ -f "$pid_file" ]]; then
+    pid=$(< "$pid_file")
+    kill -0 "$pid" 2>/dev/null && is_running=1
+  fi
+
+  if (( is_running )); then
+    print "● flow claude watch   running (PID $pid)"
+  else
+    print "○ flow claude watch   not running"
+  fi
+
+  if [[ -f "$state_file" ]] && command -v jq &>/dev/null; then
+    local last_check result interval_sec interval_min
+    last_check=$(jq -r '.last_check // "unknown"' "$state_file" 2>/dev/null)
+    result=$(jq -r '.result // "unknown"' "$state_file" 2>/dev/null)
+    interval_sec=$(jq -r '.interval // 1800' "$state_file" 2>/dev/null)
+    interval_min=$(( interval_sec / 60 ))
+    print "  Last check: $last_check — $(print "$result" | tr '[:lower:]' '[:upper:]')"
+    if (( is_running )); then
+      print "  (interval: ${interval_min}m)"
+    else
+      print "  (watcher was stopped)"
+    fi
+  fi
+}
+
+_flow_claude_watch_run_check() {
+  local state_file="${1:-$HOME/.flow/claude-health-state.json}"
+
+  # Read previous result
+  local prev_result="pass"
+  if [[ -f "$state_file" ]] && command -v jq &>/dev/null; then
+    prev_result=$(jq -r '.result // "pass"' "$state_file" 2>/dev/null)
+  fi
+
+  # Run check in subshell, capture exit code
+  local check_rc
+  _flow_claude_check > /dev/null 2>&1
+  check_rc=$?
+
+  local new_result
+  case "$check_rc" in
+    0) new_result="pass" ;;
+    1) new_result="error" ;;
+    2) new_result="warn" ;;
+    *) new_result="error" ;;
+  esac
+
+  local now
+  now=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
+
+  # Preserve interval from existing state or default to 1800
+  local interval=1800
+  if [[ -f "$state_file" ]] && command -v jq &>/dev/null; then
+    interval=$(jq -r '.interval // 1800' "$state_file" 2>/dev/null)
+  fi
+
+  local pid_file="$HOME/.flow/claude-watch.pid"
+  local pid=""
+  [[ -f "$pid_file" ]] && pid=$(< "$pid_file")
+
+  # Write new state JSON
+  if command -v jq &>/dev/null; then
+    jq -n \
+      --arg pid "$pid" \
+      --argjson interval "$interval" \
+      --arg last_check "$now" \
+      --arg result "$new_result" \
+      '{pid: $pid, interval: $interval, last_check: $last_check, result: $result}' \
+      > "$state_file" 2>/dev/null
+  else
+    print "{\"pid\":\"$pid\",\"interval\":$interval,\"last_check\":\"$now\",\"result\":\"$new_result\"}" > "$state_file"
+  fi
+
+  # Notify on state change
+  _flow_claude_watch_notify "$prev_result" "$new_result" "Health state changed to $new_result"
+}
+
+_flow_claude_watch_notify() {
+  local prev_result="$1"
+  local new_result="$2"
+  local summary="$3"
+
+  # No change, silent
+  [[ "$prev_result" == "$new_result" ]] && return
+
+  # Only notify if new or old state is warn/error (skip pass↔pass)
+  if [[ "$new_result" == "pass" && "$prev_result" == "pass" ]]; then return; fi
+
+  local title="flow claude"
+  local subtitle message
+  if [[ "$new_result" == "pass" ]]; then
+    subtitle="Health restored"
+    message="All checks passing"
+  elif [[ "$new_result" == "error" ]]; then
+    subtitle="Health degraded — ERROR"
+    message="$summary"
+  else
+    subtitle="Health warning"
+    message="$summary"
+  fi
+
+  if command -v terminal-notifier &>/dev/null; then
+    terminal-notifier -title "$title" -subtitle "$subtitle" \
+      -message "$message" -sound default
+  fi
+  # Silent fallback on Linux (no terminal-notifier)
 }

--- a/completions/_flow
+++ b/completions/_flow
@@ -446,13 +446,21 @@ _flow() {
           claude_subcmds=(
             'check:Run all environment checks'
             'doctor:Alias for check'
+            'watch:Background health watcher with desktop notifications'
           )
           claude_opts=(
             '--fix:Auto-repair safe mismatches (C1 settings parity only)'
             '--help:Show help'
           )
+          local -a watch_opts
+          watch_opts=(
+            '--interval:Check interval in minutes (default: 30)'
+            '--stop:Stop the background watcher'
+            '--status:Show watcher status and last result'
+          )
           _describe -t commands 'claude subcommand' claude_subcmds
           _describe -t options 'option' claude_opts
+          _describe -t watch-options 'watch option' watch_opts
           ;;
         *)
           _files

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ## [Unreleased]
 
+## [7.13.0] — TBD — flow claude: C7-C11 checks + watch daemon
+
+### Added
+
+- **C4 two-tier threshold** (`commands/claude.zsh`): >100 lines → WARN "approaching 180-line limit"; >180 lines → ERROR "exceeds 180-line hard limit" (was a single >100 check)
+- **C7 per-project CLAUDE.md audit**: scans `$FLOW_CLAUDE_PROJECTS_ROOT` (default: `~/projects`) up to depth 4; warns on files >180 lines or version refs that don't match `git describe --tags`; injectable via `FLOW_CLAUDE_PROJECTS_ROOT`
+- **C8 orphaned memory dirs**: decodes `~/.claude/projects/` slug names back to filesystem paths (`/a-b-c` → `/a/b/c`); warns on stale dirs whose decoded path no longer exists
+- **C9 rules drift**: checks that every `~/.claude/rules/*.md` stem is referenced in `~/.claude/CLAUDE.md`; warns on unreferenced rules
+- **C10 missing hook files**: parses `settings.json` hook commands; errors on any absolute-path script that isn't present on disk
+- **C11 plugin health**: checks `~/.claude/plugins/*/plugin.json` exists and is valid JSON (skips `cache/` subdir); warns on broken plugins
+- **`flow claude watch [--interval N] [--stop] [--status]`**: background health watcher — runs `flow claude check` on a configurable interval (default: 30 min), writes state to `~/.flow/claude-health-state.json`, and fires a desktop notification via `terminal-notifier` when status changes between pass/warn/error; gracefully silent on Linux where `terminal-notifier` is absent
+
 ## [7.11.0] — 2026-06-19 — at-dispatcher completions + atlas doctor fixes
 
 ### Added

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -23,7 +23,7 @@ flow-cli uses a **shared test framework** (`tests/test-framework.zsh`) with comp
 
 | Metric | Count |
 |--------|-------|
-| Test files | 218 |
+| Test files | 219 |
 | Test suites (run-all.sh) | 67 total — 66 passed, 1 skipped, 0 failed |
 | Test functions | 12,000+ |
 | Expected skips | 1 (`e2e-em-dispatcher` — needs configured IMAP account) |
@@ -408,4 +408,4 @@ When adding new functionality:
 
 **Established:** v5.0.0 (2026-01-11)
 **Overhauled:** v7.4.0 (2026-02-16) — shared framework, mock registry, dogfood scanner
-**Test Count:** 218 test files, 12000+ assertions, 66/66 suites passing
+**Test Count:** 219 test files, 12000+ assertions, 67/67 suites passing

--- a/tests/test-flow-claude.zsh
+++ b/tests/test-flow-claude.zsh
@@ -1,5 +1,5 @@
 #!/usr/bin/env zsh
-# tests/test-flow-claude.zsh — Tests for flow claude check (C1-C6)
+# tests/test-flow-claude.zsh — Tests for flow claude check (C1-C11) + watch
 
 SCRIPT_DIR="${0:A:h}"
 PROJECT_ROOT="${SCRIPT_DIR:h}"
@@ -19,13 +19,19 @@ _tc_setup() {
   _TC_TMP=$(mktemp -d)
   export FLOW_CLAUDE_HOME="$_TC_TMP/claude"
   export FLOW_CLAUDE_ZSHRC="$_TC_TMP/zshrc"
-  mkdir -p "$FLOW_CLAUDE_HOME/hooks" "$FLOW_CLAUDE_HOME/projects"
+  export FLOW_CLAUDE_PROJECTS_ROOT="$_TC_TMP/projects"
+  mkdir -p "$FLOW_CLAUDE_HOME/hooks" "$FLOW_CLAUDE_HOME/projects" "$FLOW_CLAUDE_PROJECTS_ROOT"
   print 'export CLAUDE_CODE_MAX_OUTPUT_TOKENS=32000' > "$FLOW_CLAUDE_ZSHRC"
 }
 
 _tc_teardown() {
   [[ -n "${_TC_TMP:-}" ]] && rm -rf "$_TC_TMP"
-  unset FLOW_CLAUDE_HOME FLOW_CLAUDE_ZSHRC _TC_TMP
+  unset FLOW_CLAUDE_HOME FLOW_CLAUDE_ZSHRC FLOW_CLAUDE_PROJECTS_ROOT _TC_TMP
+}
+
+_tc_make_hook() {
+  local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
+  print '#!/bin/bash' > "$hook" && chmod +x "$hook"
 }
 
 # ── C1: Settings parity ───────────────────────────────────────────────────
@@ -33,8 +39,7 @@ _tc_teardown() {
 test_case "C1: passes when settings.json has no env block"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
 if command -v jq &>/dev/null; then
@@ -48,8 +53,7 @@ _tc_teardown
 test_case "C1: warns when key missing from zshrc"
 _tc_setup
 print '{"env":{"MY_TEST_VAR":"99"}}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash\necho ok' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
 if command -v jq &>/dev/null; then
@@ -64,8 +68,7 @@ test_case "C1: passes when key matches zshrc"
 _tc_setup
 print '{"env":{"MY_TEST_VAR":"99"}}' > "$FLOW_CLAUDE_HOME/settings.json"
 print 'export MY_TEST_VAR=99' >> "$FLOW_CLAUDE_ZSHRC"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash\necho ok' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
 if command -v jq &>/dev/null; then
@@ -79,8 +82,7 @@ _tc_teardown
 test_case "C1: --fix appends missing key to zshrc"
 _tc_setup
 print '{"env":{"FIX_VAR":"42"}}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash\necho ok' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 _flow_claude_check --fix 2>&1
 if command -v jq &>/dev/null; then
   assert_contains "$(cat "$FLOW_CLAUDE_ZSHRC")" "FIX_VAR=42" "--fix appended key"
@@ -93,8 +95,7 @@ test_case "C1: --fix updates existing mismatched value"
 _tc_setup
 print '{"env":{"FIX_VAR":"new"}}' > "$FLOW_CLAUDE_HOME/settings.json"
 print 'export FIX_VAR=old' > "$FLOW_CLAUDE_ZSHRC"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash\necho ok' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 _flow_claude_check --fix 2>&1
 if command -v jq &>/dev/null; then
   assert_contains "$(cat "$FLOW_CLAUDE_ZSHRC")" "FIX_VAR=new" "--fix updated value"
@@ -129,8 +130,7 @@ _tc_teardown
 test_case "C2: passes when hook exists and is executable"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash\necho ok' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
 assert_contains "$out" "Hook health" "C2 output present"
@@ -142,11 +142,13 @@ _tc_teardown
 test_case "C3: passes when file count matches MEMORY.md entries"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
-local mem="$FLOW_CLAUDE_HOME/projects/testproj/memory"
+_tc_make_hook
+# Slug must decode to an existing path so C8 doesn't fire (/${slug//-//} = _TC_TMP)
+local proj_slug="${_TC_TMP:1}"     # strip leading /
+proj_slug="${proj_slug//\//-}"     # / → -
+local mem="$FLOW_CLAUDE_HOME/projects/$proj_slug/memory"
 mkdir -p "$mem"
-print -- '- [a](a.md) — x\n- [b](b.md) — y' > "$mem/MEMORY.md"
+printf -- '- [a](a.md) — x\n- [b](b.md) — y\n' > "$mem/MEMORY.md"
 print 'a' > "$mem/a.md"
 print 'b' > "$mem/b.md"
 local out rc
@@ -158,11 +160,12 @@ _tc_teardown
 test_case "C3: warns when file count exceeds MEMORY.md entries"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
-local mem="$FLOW_CLAUDE_HOME/projects/testproj/memory"
+_tc_make_hook
+local proj_slug="${_TC_TMP:1}"
+proj_slug="${proj_slug//\//-}"
+local mem="$FLOW_CLAUDE_HOME/projects/$proj_slug/memory"
 mkdir -p "$mem"
-print -- '- [a](a.md) — x' > "$mem/MEMORY.md"
+printf -- '- [a](a.md) — x\n' > "$mem/MEMORY.md"
 print 'a' > "$mem/a.md"
 print 'b' > "$mem/b.md"  # extra file not in index
 local out rc
@@ -171,30 +174,39 @@ assert_contains "$out" "drift" "C3 warns on drift"
 [[ $rc -ge 1 ]] && test_pass "non-zero on drift" || test_fail "non-zero on drift" "rc=$rc"
 _tc_teardown
 
-# ── C4: CLAUDE.md length ──────────────────────────────────────────────────
+# ── C4: CLAUDE.md length (two-tier) ──────────────────────────────────────
 
 test_case "C4: passes when CLAUDE.md <= 100 lines"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
-printf '%s\n' {1..50} > "$FLOW_CLAUDE_HOME/CLAUDE.md"
+_tc_make_hook
+printf '%s\n' {1..95} > "$FLOW_CLAUDE_HOME/CLAUDE.md"
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
 assert_contains "$out" "CLAUDE.md length" "C4 runs"
 [[ $rc -eq 0 ]] && test_pass "exit 0 under limit" || test_fail "exit 0 under limit" "rc=$rc"
 _tc_teardown
 
-test_case "C4: warns when CLAUDE.md > 100 lines"
+test_case "C4: warns when CLAUDE.md > 100 lines (approaching limit)"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
-printf '%s\n' {1..101} > "$FLOW_CLAUDE_HOME/CLAUDE.md"
+_tc_make_hook
+printf '%s\n' {1..150} > "$FLOW_CLAUDE_HOME/CLAUDE.md"
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
-assert_contains "$out" "exceeds 100-line rule" "C4 warns on overflow"
-[[ $rc -ge 1 ]] && test_pass "non-zero on overflow" || test_fail "non-zero on overflow" "rc=$rc"
+assert_contains "$out" "approaching 180-line limit" "C4 warns on approaching limit"
+[[ $rc -eq 2 ]] && test_pass "exit 2 on WARN" || test_fail "exit 2 on WARN" "rc=$rc"
+_tc_teardown
+
+test_case "C4: errors when CLAUDE.md > 180 lines"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+printf '%s\n' {1..200} > "$FLOW_CLAUDE_HOME/CLAUDE.md"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+assert_contains "$out" "exceeds 180-line hard limit" "C4 errors on overflow"
+[[ $rc -eq 1 ]] && test_pass "exit 1 on ERROR" || test_fail "exit 1 on ERROR" "rc=$rc"
 _tc_teardown
 
 # ── C5: Shell env parity ──────────────────────────────────────────────────
@@ -202,8 +214,7 @@ _tc_teardown
 test_case "C5: reports when CLAUDE_AUTOCOMPACT_PCT_OVERRIDE is set"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=65
 local out
 out=$(_flow_claude_check 2>&1)
@@ -214,8 +225,7 @@ _tc_teardown
 test_case "C5: reports when CLAUDE_AUTOCOMPACT_PCT_OVERRIDE is unset"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 unset CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
 local out
 out=$(_flow_claude_check 2>&1)
@@ -228,8 +238,7 @@ test_case "C6: warns when CLAUDE_CODE_MAX_OUTPUT_TOKENS not set"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
 > "$FLOW_CLAUDE_ZSHRC"  # clear default token so C6 warns
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
 assert_contains "$out" "Output token limit" "C6 output present"
@@ -241,8 +250,7 @@ test_case "C6: passes when CLAUDE_CODE_MAX_OUTPUT_TOKENS=32000 in zshrc"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
 print 'export CLAUDE_CODE_MAX_OUTPUT_TOKENS=32000' > "$FLOW_CLAUDE_ZSHRC"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
 assert_contains "$out" "Output token limit" "C6 output present"
@@ -254,8 +262,7 @@ test_case "C6: warns when value is at default 8192"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
 print 'export CLAUDE_CODE_MAX_OUTPUT_TOKENS=8192' > "$FLOW_CLAUDE_ZSHRC"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
 assert_contains "$out" "8192" "C6 shows value"
@@ -266,12 +273,290 @@ _tc_teardown
 test_case "C6: --fix appends CLAUDE_CODE_MAX_OUTPUT_TOKENS=32000 to zshrc"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 _flow_claude_check --fix 2>&1
 local zshrc_content
 zshrc_content=$(cat "$FLOW_CLAUDE_ZSHRC")
 assert_contains "$zshrc_content" "CLAUDE_CODE_MAX_OUTPUT_TOKENS=32000" "C6 --fix writes to zshrc"
+_tc_teardown
+
+# ── C7: Per-project CLAUDE.md audit ───────────────────────────────────────
+
+test_case "C7: passes when no projects root exists"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+export FLOW_CLAUDE_PROJECTS_ROOT="$_TC_TMP/no-such-dir"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+assert_contains "$out" "Project CLAUDE.md" "C7 output present"
+assert_contains "$out" "not found" "C7 skips gracefully"
+[[ $rc -eq 0 ]] && test_pass "exit 0 when no projects" || test_fail "exit 0 when no projects" "rc=$rc"
+_tc_teardown
+
+test_case "C7a: warns when project CLAUDE.md > 180 lines"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+local proj="$FLOW_CLAUDE_PROJECTS_ROOT/myproject"
+mkdir -p "$proj"
+printf '%s\n' {1..200} > "$proj/CLAUDE.md"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+assert_contains "$out" "200 lines" "C7a reports line count"
+assert_contains "$out" "> 180" "C7a flags threshold"
+[[ $rc -ge 2 ]] && test_pass "non-zero on C7a issue" || test_fail "non-zero on C7a issue" "rc=$rc"
+_tc_teardown
+
+test_case "C7a: passes when project CLAUDE.md <= 180 lines"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+local proj="$FLOW_CLAUDE_PROJECTS_ROOT/myproject"
+mkdir -p "$proj"
+printf '%s\n' {1..100} > "$proj/CLAUDE.md"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+assert_contains "$out" "all clean" "C7 all clean"
+[[ $rc -eq 0 ]] && test_pass "exit 0 on clean" || test_fail "exit 0 on clean" "rc=$rc"
+_tc_teardown
+
+test_case "C7b: warns on version drift when git tag differs"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+local proj="$FLOW_CLAUDE_PROJECTS_ROOT/myproject"
+mkdir -p "$proj"
+printf 'Current Version: v1.0.0\n' > "$proj/CLAUDE.md"
+# Mock git to return a different tag
+git() {
+  if [[ "$*" == *"describe"* ]]; then
+    print "v2.0.0"
+    return 0
+  fi
+  command git "$@"
+}
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+unfunction git 2>/dev/null
+assert_contains "$out" "version ref v1.0.0" "C7b reports version drift"
+assert_contains "$out" "current: v2.0.0" "C7b shows current tag"
+[[ $rc -ge 2 ]] && test_pass "non-zero on version drift" || test_fail "non-zero on version drift" "rc=$rc"
+_tc_teardown
+
+test_case "C7b: passes when no git tags exist"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+local proj="$FLOW_CLAUDE_PROJECTS_ROOT/myproject"
+mkdir -p "$proj"
+printf 'Current Version: v1.0.0\n' > "$proj/CLAUDE.md"
+# Mock git to return no tags (non-zero exit)
+git() {
+  if [[ "$*" == *"describe"* ]]; then
+    return 1
+  fi
+  command git "$@"
+}
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+unfunction git 2>/dev/null
+assert_contains "$out" "all clean" "C7b skips when no tags"
+[[ $rc -eq 0 ]] && test_pass "exit 0 — no false positive on missing tags" || test_fail "exit 0" "rc=$rc"
+_tc_teardown
+
+# ── C8: Orphaned memory dirs ───────────────────────────────────────────────
+
+test_case "C8: warns when memory dir decodes to missing path"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+# Create a slug that decodes to a nonexistent path
+local fake_slug="-tmp-no-such-project-xyzzy"
+mkdir -p "$FLOW_CLAUDE_HOME/projects/$fake_slug"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+assert_contains "$out" "Orphaned memory" "C8 output present"
+assert_contains "$out" "stale" "C8 reports stale dir"
+[[ $rc -ge 2 ]] && test_pass "non-zero on orphaned dir" || test_fail "non-zero on orphaned dir" "rc=$rc"
+_tc_teardown
+
+test_case "C8: passes when all memory dirs decode to valid paths"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+# Create a slug that decodes to an existing path (tmp dir itself)
+local tmp_slug="${_TC_TMP/\//}"       # strip leading /
+tmp_slug="${tmp_slug//\//-}"          # replace / with -
+tmp_slug="-$tmp_slug"                 # add leading - to represent leading /
+mkdir -p "$FLOW_CLAUDE_HOME/projects/$tmp_slug"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+assert_contains "$out" "Orphaned memory" "C8 output present"
+assert_contains "$out" "valid" "C8 passes for valid dir"
+[[ $rc -eq 0 ]] && test_pass "exit 0 on valid dirs" || test_fail "exit 0 on valid dirs" "rc=$rc"
+_tc_teardown
+
+# ── C9: Rules drift ────────────────────────────────────────────────────────
+
+test_case "C9: warns when rule file not cited in CLAUDE.md"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+mkdir -p "$FLOW_CLAUDE_HOME/rules"
+print 'some rule content' > "$FLOW_CLAUDE_HOME/rules/my-uncited-rule.md"
+# CLAUDE.md does not mention the rule stem
+print 'This is CLAUDE.md with no rule references.' > "$FLOW_CLAUDE_HOME/CLAUDE.md"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+assert_contains "$out" "Rules drift" "C9 output present"
+assert_contains "$out" "my-uncited-rule" "C9 reports unreferenced rule"
+[[ $rc -ge 2 ]] && test_pass "non-zero on rules drift" || test_fail "non-zero on rules drift" "rc=$rc"
+_tc_teardown
+
+test_case "C9: passes when all rules are referenced in CLAUDE.md"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+mkdir -p "$FLOW_CLAUDE_HOME/rules"
+print 'some rule content' > "$FLOW_CLAUDE_HOME/rules/my-cited-rule.md"
+# CLAUDE.md mentions the rule stem
+print 'See my-cited-rule for details.' > "$FLOW_CLAUDE_HOME/CLAUDE.md"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+assert_contains "$out" "Rules drift" "C9 output present"
+assert_contains "$out" "referenced" "C9 passes on all referenced"
+[[ $rc -eq 0 ]] && test_pass "exit 0 on all referenced" || test_fail "exit 0 on all referenced" "rc=$rc"
+_tc_teardown
+
+test_case "C9: skips gracefully when no rules dir"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+# No rules dir created
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+assert_contains "$out" "Rules drift" "C9 output present"
+assert_contains "$out" "skipped" "C9 skips without rules dir"
+[[ $rc -eq 0 ]] && test_pass "exit 0 without rules dir" || test_fail "exit 0 without rules dir" "rc=$rc"
+_tc_teardown
+
+# ── C10: Missing hook files ────────────────────────────────────────────────
+
+test_case "C10: passes when settings.json has no hooks"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+if command -v jq &>/dev/null; then
+  assert_contains "$out" "Hook files" "C10 output present"
+  assert_contains "$out" "present" "C10 passes with no hooks"
+  [[ $rc -eq 0 ]] && test_pass "exit 0 with no hooks" || test_fail "exit 0 with no hooks" "rc=$rc"
+else
+  test_skip "jq not installed"
+fi
+_tc_teardown
+
+test_case "C10: passes when all hook paths exist"
+_tc_setup
+local hook_script="$_TC_TMP/myhook.sh"
+print '#!/bin/bash\necho ok' > "$hook_script" && chmod +x "$hook_script"
+print "{\"hooks\":{\"PreToolUse\":[{\"command\":\"$hook_script\"}]}}" > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+if command -v jq &>/dev/null; then
+  assert_contains "$out" "Hook files" "C10 output present"
+  assert_contains "$out" "present" "C10 passes for existing hook"
+  [[ $rc -eq 0 ]] && test_pass "exit 0 when hook exists" || test_fail "exit 0 when hook exists" "rc=$rc"
+else
+  test_skip "jq not installed"
+fi
+_tc_teardown
+
+test_case "C10: errors when hook path does not exist"
+_tc_setup
+local missing_hook="$_TC_TMP/nonexistent-hook.sh"
+print "{\"hooks\":{\"PreToolUse\":[{\"command\":\"$missing_hook\"}]}}" > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+if command -v jq &>/dev/null; then
+  assert_contains "$out" "Hook files" "C10 output present"
+  assert_contains "$out" "missing" "C10 errors on missing hook"
+  [[ $rc -eq 1 ]] && test_pass "exit 1 on missing hook" || test_fail "exit 1 on missing hook" "rc=$rc"
+else
+  test_skip "jq not installed"
+fi
+_tc_teardown
+
+# ── C11: Plugin health ─────────────────────────────────────────────────────
+
+test_case "C11: passes when all plugins have valid plugin.json"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+mkdir -p "$FLOW_CLAUDE_HOME/plugins/myplugin"
+print '{"name":"myplugin","version":"1.0.0"}' > "$FLOW_CLAUDE_HOME/plugins/myplugin/plugin.json"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+if command -v jq &>/dev/null; then
+  assert_contains "$out" "Plugin health" "C11 output present"
+  assert_contains "$out" "healthy" "C11 passes for valid plugin"
+  [[ $rc -eq 0 ]] && test_pass "exit 0 for valid plugin" || test_fail "exit 0 for valid plugin" "rc=$rc"
+else
+  test_skip "jq not installed"
+fi
+_tc_teardown
+
+test_case "C11: warns when plugin is missing plugin.json"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+mkdir -p "$FLOW_CLAUDE_HOME/plugins/broken-plugin"
+# No plugin.json created
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+if command -v jq &>/dev/null; then
+  assert_contains "$out" "Plugin health" "C11 output present"
+  assert_contains "$out" "missing plugin.json" "C11 warns on missing file"
+  [[ $rc -ge 2 ]] && test_pass "non-zero on missing plugin.json" || test_fail "non-zero on missing plugin.json" "rc=$rc"
+else
+  test_skip "jq not installed"
+fi
+_tc_teardown
+
+test_case "C11: warns when plugin.json is invalid JSON"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+mkdir -p "$FLOW_CLAUDE_HOME/plugins/bad-json-plugin"
+print 'not valid json {{{' > "$FLOW_CLAUDE_HOME/plugins/bad-json-plugin/plugin.json"
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+if command -v jq &>/dev/null; then
+  assert_contains "$out" "Plugin health" "C11 output present"
+  assert_contains "$out" "invalid JSON" "C11 warns on invalid JSON"
+  [[ $rc -ge 2 ]] && test_pass "non-zero on invalid JSON" || test_fail "non-zero on invalid JSON" "rc=$rc"
+else
+  test_skip "jq not installed"
+fi
+_tc_teardown
+
+test_case "C11: skips cache/ subdirectory"
+_tc_setup
+print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
+_tc_make_hook
+mkdir -p "$FLOW_CLAUDE_HOME/plugins/cache/some-cached-plugin"
+# No plugin.json in cache subdir — should be ignored
+local out rc
+out=$(_flow_claude_check 2>&1); rc=$?
+if command -v jq &>/dev/null; then
+  [[ $rc -eq 0 ]] && test_pass "exit 0 — cache/ dir skipped" || test_fail "exit 0 — cache/ dir skipped" "rc=$rc"
+else
+  test_skip "jq not installed"
+fi
 _tc_teardown
 
 # ── Exit codes ─────────────────────────────────────────────────────────────
@@ -289,8 +574,7 @@ _tc_teardown
 test_case "exit 2: WARN only"
 _tc_setup
 print '{}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 printf '%s\n' {1..150} > "$FLOW_CLAUDE_HOME/CLAUDE.md"
 local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
@@ -302,8 +586,7 @@ _tc_teardown
 test_case "C1: degrades gracefully when jq not installed"
 _tc_setup
 print '{"env":{"FOO":"bar"}}' > "$FLOW_CLAUDE_HOME/settings.json"
-local hook="$FLOW_CLAUDE_HOME/hooks/post-compact-reinject.sh"
-print '#!/bin/bash' > "$hook" && chmod +x "$hook"
+_tc_make_hook
 # Hide jq via PATH override in subshell
 local orig_path="$PATH"
 export PATH="/usr/bin:/bin"
@@ -311,6 +594,109 @@ local out rc
 out=$(_flow_claude_check 2>&1); rc=$?
 export PATH="$orig_path"
 assert_contains "$out" "Settings parity" "C1 output present without jq"
+_tc_teardown
+
+# ── Watch daemon ───────────────────────────────────────────────────────────
+
+test_case "watch --status: shows not-running when no pid file"
+local flow_dir
+flow_dir=$(mktemp -d)
+local pid_file="$flow_dir/claude-watch.pid"
+local state_file="$flow_dir/claude-health-state.json"
+# No pid file — status should say not running without crashing
+local orig_home="$HOME"
+HOME="$flow_dir"
+local out rc
+out=$(_flow_claude_watch_status 2>&1); rc=$?
+HOME="$orig_home"
+rm -rf "$flow_dir"
+assert_contains "$out" "not running" "status shows not running"
+[[ $rc -eq 0 ]] && test_pass "exit 0 on status when not running" || test_fail "exit 0 on status" "rc=$rc"
+
+test_case "watch --stop: no-ops cleanly when watcher not running"
+local flow_dir saved_home
+flow_dir=$(mktemp -d)
+saved_home="$HOME"
+HOME="$flow_dir"
+local out rc
+out=$(_flow_claude_watch_stop 2>&1); rc=$?
+HOME="$saved_home"
+rm -rf "$flow_dir"
+[[ $rc -eq 0 ]] && test_pass "exit 0 on stop when not running" || test_fail "exit 0 on stop" "rc=$rc"
+
+test_case "watch --stop: kills process and removes pid file"
+local flow_dir saved_home
+flow_dir=$(mktemp -d)
+mkdir -p "$flow_dir/.flow"
+# Start a background sleep and write its PID where _flow_claude_watch_stop expects it
+sleep 999 &
+local fake_pid=$!
+print "$fake_pid" > "$flow_dir/.flow/claude-watch.pid"
+saved_home="$HOME"
+HOME="$flow_dir"
+local out rc
+out=$(_flow_claude_watch_stop 2>&1); rc=$?
+HOME="$saved_home"
+assert_not_contains "$out" "not running" "stop reports success"
+[[ ! -f "$flow_dir/.flow/claude-watch.pid" ]] && test_pass "pid file removed after stop" || test_fail "pid file removed after stop"
+kill "$fake_pid" 2>/dev/null || true
+rm -rf "$flow_dir"
+
+test_case "watch notify: warn→pass fires notifier"
+# Use a real executable in PATH — command -v doesn't find shell functions
+local notif_dir called_file saved_path
+notif_dir=$(mktemp -d)
+called_file="$notif_dir/notif-args.txt"
+print "#!/bin/sh" > "$notif_dir/terminal-notifier"
+print "echo \"\$@\" >> \"$called_file\"" >> "$notif_dir/terminal-notifier"
+chmod +x "$notif_dir/terminal-notifier"
+saved_path="$PATH"
+export PATH="$notif_dir:$PATH"
+_flow_claude_watch_notify "warn" "pass" "All clear"
+export PATH="$saved_path"
+if [[ -f "$called_file" ]]; then
+  local notif_args
+  notif_args=$(cat "$called_file")
+  assert_contains "$notif_args" "restored" "notifier output shows restored on warn→pass"
+  test_pass "notifier called on state change"
+else
+  test_fail "notifier should have been called on warn→pass (args file missing)"
+fi
+rm -rf "$notif_dir"
+
+test_case "watch notify: pass→pass is silent"
+local notif_dir saved_path
+notif_dir=$(mktemp -d)
+print "#!/bin/sh" > "$notif_dir/terminal-notifier"
+print "touch \"$notif_dir/was-called\"" >> "$notif_dir/terminal-notifier"
+chmod +x "$notif_dir/terminal-notifier"
+saved_path="$PATH"
+export PATH="$notif_dir:$PATH"
+_flow_claude_watch_notify "pass" "pass" "still passing"
+export PATH="$saved_path"
+[[ ! -f "$notif_dir/was-called" ]] && test_pass "no notification on pass→pass" || test_fail "no notification on pass→pass" "notifier was called"
+rm -rf "$notif_dir"
+
+test_case "watch run_check: writes state file with result"
+_tc_setup
+local flow_dir
+flow_dir=$(mktemp -d)
+local state_file="$flow_dir/state.json"
+# Mock _flow_claude_check to return WARN (rc=2)
+_flow_claude_check() { return 2 }
+local orig_home="$HOME"
+HOME="$flow_dir"
+_flow_claude_watch_run_check "$state_file" 2>/dev/null
+HOME="$orig_home"
+unfunction _flow_claude_check 2>/dev/null
+if command -v jq &>/dev/null && [[ -f "$state_file" ]]; then
+  local result
+  result=$(jq -r '.result' "$state_file" 2>/dev/null)
+  [[ "$result" == "warn" ]] && test_pass "state file has result=warn" || test_fail "state file has result=warn" "got: $result"
+else
+  test_skip "jq not installed or state file missing"
+fi
+rm -rf "$flow_dir"
 _tc_teardown
 
 test_suite_end


### PR DESCRIPTION
## Summary

- **C4 two-tier threshold**: >100 lines → WARN "approaching limit"; >180 → ERROR "exceeds hard limit" (was a single >100 WARN)
- **C7 per-project CLAUDE.md audit**: scans `$FLOW_CLAUDE_PROJECTS_ROOT` (depth 4); warns on overlength files or stale version refs
- **C8 orphaned memory dirs**: slug-decodes `~/.claude/projects/` entries; warns on dirs whose decoded path no longer exists
- **C9 rules drift**: warns on any `~/.claude/rules/*.md` stem not referenced in the main `CLAUDE.md`
- **C10 missing hook files**: errors on absolute-path hook scripts listed in `settings.json` that aren't on disk
- **C11 plugin health**: warns on `~/.claude/plugins/*/plugin.json` that's missing or invalid JSON
- **`flow claude watch [--interval N] [--stop] [--status]`**: background daemon writing state JSON, firing `terminal-notifier` desktop notifications on status transitions; gracefully absent on Linux

All injectable via `FLOW_CLAUDE_HOME` / `FLOW_CLAUDE_ZSHRC` / `FLOW_CLAUDE_PROJECTS_ROOT` for test isolation.

## Test plan

- [x] `./tests/run-all.sh` — 66 passed, 0 failed, 0 timeout, 1 skipped (67/67 suites)
- [x] `tests/test-flow-claude.zsh` — 39 passed, 6 skipped (tool-absent), 0 failed
- [x] C4 two-tier: 95-line file → pass; 150-line → WARN; 200-line → ERROR
- [x] Watch notify: PATH-based mock verifies `terminal-notifier` called on state change
- [x] Watch stop: pid file created and removed correctly, HOME restored after test
- [x] C3 memory test: slug encoded from `_TC_TMP` path to avoid spurious C8 WARN

🤖 Generated with [Claude Code](https://claude.com/claude-code)