### PR TITLE
feat: tok mint — generate GitHub App installation tokens locally

### DIFF
--- a/completions/_tok
+++ b/completions/_tok
@@ -14,6 +14,7 @@ _tok() {
     'rotate:Token rotation'
     'refresh:Refresh expiring tokens'
     'expiring:Show expiring tokens'
+    'mint:Mint GitHub App installation token (ghs_)'
     'sync:Sync to GitHub secrets'
     'doctor:Token-specific diagnostics'
     'dr:Token-specific diagnostics (alias)'
@@ -31,6 +32,17 @@ _tok() {
       ;;
     args)
       case "$line[1]" in
+        mint)
+          if [[ ${#line[@]} -eq 1 ]]; then
+            local -a mint_args
+            mint_args=(
+              '--org:GitHub organization (default: Data-Wise)'
+              '--dry-run:Generate JWT without exchanging'
+              '--verbose:Show token details'
+            )
+            _describe -t args 'mint options' mint_args
+          fi
+          ;;
         rotate)
           if [[ ${#line[@]} -eq 1 ]]; then
             local -a token_types

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ## [Unreleased]
 
+### Added
+
+- **`tok mint`** — Generate short-lived GitHub App installation tokens (`ghs_`)
+  (`lib/dispatchers/tok-dispatcher.zsh`). Reads `github_app_id` and
+  `github_app_private_key` from Keychain, builds an RS256 JWT, resolves the
+  org installation, and exchanges for a `ghs_` token. Supports `--org`,
+  `--dry-run`, and `--verbose` flags. Interactive `tok mint setup` wizard for
+  one-time credential storage ([#479](https://github.com/Data-Wise/flow-cli/issues/479)).
+
 ## [7.13.0] — 2026-06-19 — flow claude: C7-C11 checks + watch daemon
 
 ### Added

--- a/docs/guides/TOKEN-COOKBOOK.md
+++ b/docs/guides/TOKEN-COOKBOOK.md
@@ -24,6 +24,7 @@ For full reference, see the [refcard](../reference/REFCARD-TOKEN-SECRETS.md) and
 8. [Proactively Rotate Tokens Nearing Expiry](#8-proactively-rotate-tokens-nearing-expiry)
 9. [Set Up the Sync Config From Scratch](#9-set-up-the-sync-config-from-scratch)
 10. [Verify What Landed on a Repo After a Push](#10-verify-what-landed-on-a-repo-after-a-push)
+11. [Mint a Short-Lived GitHub App Token (ghs_)](#11-mint-a-short-lived-github-app-token-ghs_)
 
 ---
 
@@ -286,6 +287,52 @@ gh secret list --repo data-wise/flow-cli
 
 ---
 
+## 11. Mint a Short-Lived GitHub App Token (`ghs_`)
+
+> **Goal:** Generate an ephemeral installation token from a GitHub App, no PAT required.
+
+```bash
+# ─────────────────────────────────────────────────────────────────
+# Step 1: One-time setup — store App ID + private key in Keychain
+# ─────────────────────────────────────────────────────────────────
+tok mint setup
+# Prompts:
+#   GitHub App ID: 123456
+#   Path to private key PEM file: ~/Downloads/my-app.private-key.pem
+# Validates credentials against api.github.com/app
+# Stores in Keychain (service: flow-cli-secrets)
+
+# ─────────────────────────────────────────────────────────────────
+# Step 2: Mint a token
+# ─────────────────────────────────────────────────────────────────
+tok mint
+# Output: ghs_A1B2C3_eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
+
+# ─────────────────────────────────────────────────────────────────
+# Step 3: Use the token immediately
+# ─────────────────────────────────────────────────────────────────
+export GITHUB_TOKEN=$(tok mint)
+curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user
+
+# ─────────────────────────────────────────────────────────────────
+# Step 4: Mint for a different org + see details
+# ─────────────────────────────────────────────────────────────────
+tok mint --org MyOrg --verbose
+# Token: ghs_D4E5F6_... | Expires: 2026-06-29T06:30:00Z | Org: MyOrg
+
+# ─────────────────────────────────────────────────────────────────
+# Step 5: Dry run — inspect the JWT without minting
+# ─────────────────────────────────────────────────────────────────
+tok mint --dry-run
+# Shows decoded header, payload, and JWT preview
+```
+
+Tokens expire in 1 hour (GitHub server-side). Mint a fresh one per
+session or per command. Requires `openssl` and `curl` (both ship with
+macOS).
+
+---
+
 ## See Also
 
 - [47-tok-auto-sync.md](../tutorials/47-tok-auto-sync.md) — Step-by-step tutorial for the auto-sync feature
@@ -297,4 +344,4 @@ gh secret list --repo data-wise/flow-cli
 ---
 
 **Feature:** tok auto-sync — flow-cli
-**Last Updated:** 2026-06-03
+**Last Updated:** 2026-06-29

--- a/docs/guides/TOKEN-MANAGEMENT-COMPLETE.md
+++ b/docs/guides/TOKEN-MANAGEMENT-COMPLETE.md
@@ -17,6 +17,8 @@ tags:
 
 1. [Architecture Overview](#1-architecture-overview)
 2. [Adding Tokens](#2-adding-tokens)
+    - [GitHub Personal Access Token](#21-github-personal-access-token)
+    - [GitHub App Installation Token](#23-github-app-installation-token)
 3. [Retrieving and Using Tokens](#3-retrieving-and-using-tokens)
 4. [Updating Tokens](#4-updating-tokens)
 5. [Rotating Tokens](#5-rotating-tokens)
@@ -287,6 +289,65 @@ Expires: 2026-04-24 (90 days)
 ```
 
 **Token format:** `github_pat_*` (different from classic `ghp_*`)
+
+### 2.3 GitHub App Installation Token
+
+**When to use:**
+- MCP servers needing `ghs_` tokens
+- CI/CD that needs short-lived tokens (1hr expiry)
+- Replacing static PATs for security
+- Any scenario where you'd use `actions/create-github-app-token@v3` locally
+
+**What you need:**
+- A GitHub App installed on your org (App ID + private key PEM)
+- `openssl` and `curl` (both ship with macOS)
+
+**One-time setup:**
+
+```bash
+tok mint setup
+```
+
+Prompts for:
+1. **App ID** — from GitHub App settings page
+2. **Private key path** — path to downloaded `.pem` file
+
+It validates by generating a test JWT and calling `GET /app`, then stores
+both credentials in macOS Keychain.
+
+**Mint a token:**
+
+```bash
+# Default org (Data-Wise)
+tok mint
+
+# Specific org
+tok mint --org MyOrg
+
+# With details
+tok mint --verbose
+
+# Dry run (inspect JWT, no token generated)
+tok mint --dry-run
+```
+
+**How it works:**
+1. Reads credentials from Keychain
+2. Builds RS256 JWT (`iat`, `exp` + 10min, `iss` = App ID)
+3. Resolves installation: `GET /orgs/{org}/installation`
+4. Exchanges JWT: `POST /app/installations/:id/access_tokens`
+5. Prints `ghs_` token to stdout
+
+**Use in scripts:**
+
+```bash
+export GITHUB_TOKEN=$(tok mint)
+export GITHUB_MCP_PAT=$(tok mint)
+```
+
+**Note:** Tokens expire server-side in 1 hour. Mint per session.
+
+---
 
 ### 2.2 npm Token
 

--- a/docs/help/QUICK-REFERENCE.md
+++ b/docs/help/QUICK-REFERENCE.md
@@ -641,6 +641,34 @@ sec help
 
 ## Tokens (tok)
 
+### GitHub App Token Minting (v7.14.0)
+
+```bash
+# Interactive setup: store App ID + private key in Keychain
+tok mint setup
+# Output: [Prompts for App ID + PEM path, validates, stores]
+
+# Mint default org (Data-Wise)
+tok mint
+# Output: ghs_A1B2C3_eyJhbGci...
+
+# Mint for a specific org
+tok mint --org MyOrg
+# Output: ghs_D4E5F6_eyJhbGci...
+
+# Dry-run: show JWT without exchanging for token
+tok mint --dry-run
+# Output: [Decoded JWT header + payload + JWT preview]
+
+# Show token details
+tok mint --verbose
+# Output: Token: ghs_A1B2C3_eyJhbGci... | Expires: 2026-06-29T06:28:03Z | Org: Data-Wise
+```
+
+Requires `github_app_id` and `github_app_private_key` in Keychain
+(store via `tok mint setup`). The token is printed to stdout for piping
+(use `--verbose` for metadata on stderr).
+
 ### Token Management (v5.17.0)
 
 ```bash

--- a/docs/reference/MASTER-DISPATCHER-GUIDE.md
+++ b/docs/reference/MASTER-DISPATCHER-GUIDE.md
@@ -1578,6 +1578,54 @@ export GITHUB_TOKEN=$(sec GITHUB_TOKEN)
 **Complexity:** Intermediate → Advanced
 **Most Used:** Yes (token lifecycle)
 
+### GitHub App Token Minting (v7.14.0)
+
+**What it does:** Mints short-lived `ghs_` installation tokens from a GitHub App
+(stored in Keychain). No PAT needed.
+
+#### Setup (one-time)
+
+```bash
+tok mint setup
+```
+
+Interactive wizard:
+1. Prompts for **App ID** (from GitHub App settings)
+2. Prompts for **path to private key PEM file** (downloaded from GitHub App)
+3. Generates a test JWT and validates against `api.github.com/app`
+4. Stores both credentials in macOS Keychain (`flow-cli-secrets` service)
+
+#### Mint a Token
+
+```bash
+# Default org: Data-Wise
+tok mint
+
+# Specific org
+tok mint --org MyOrg
+
+# Dry run — decode JWT without exchanging
+tok mint --dry-run
+
+# Verbose — show token preview + expiration
+tok mint --verbose
+```
+
+The token is printed to stdout (pipe into scripts). Use `--verbose` for
+expiration metadata (printed to stderr, safe to ignore in pipes).
+
+#### How It Works
+
+1. Reads `github_app_id` and `github_app_private_key` from Keychain
+2. Builds RS256 JWT (`iat` + 10min `exp` + `iss: app_id`)
+3. Resolves installation ID via `GET /orgs/{org}/installation`
+4. Exchanges JWT for token via `POST /app/installations/:id/access_tokens`
+5. Prints `ghs_` token to stdout
+
+Requires `openssl` (built-in on macOS) and `curl`.
+
+---
+
 ### Basics (Beginner)
 
 **What it does:** Creates, rotates, and monitors API tokens with guided wizards.
@@ -1841,6 +1889,11 @@ A copyable seed lives at
 - `tok github` - Create GitHub token (wizard)
 - `tok npm` - Create npm token (wizard)
 - `tok pypi` - Create PyPI token (wizard)
+- `tok mint` - Mint GitHub App installation token (`ghs_`)
+- `tok mint --org <org>` - Mint for a specific org (default: Data-Wise)
+- `tok mint --dry-run` - Generate JWT without exchanging for token
+- `tok mint --verbose` - Show token preview + expiration
+- `tok mint setup` - Store App ID + private key in Keychain (one-time)
 - `tok expiring` - Check token expiration (cached)
 - `tok expiring --force` - Force fresh check
 - `tok rotate <provider>` - Rotate token

--- a/docs/reference/REFCARD-TOKEN-SECRETS.md
+++ b/docs/reference/REFCARD-TOKEN-SECRETS.md
@@ -38,6 +38,9 @@ sec status
 | `tok github` | Create GitHub token | Interactive wizard |
 | `tok npm` | Create npm token | Interactive wizard |
 | `tok pypi` | Create PyPI token | Interactive wizard |
+| `tok mint` | Mint GitHub App token (`ghs_`) | `tok mint --org Data-Wise` |
+| `tok mint setup` | Store App credentials in Keychain | Interactive wizard |
+| `tok mint --dry-run` | Show JWT without exchanging | `tok mint --dry-run` |
 | `sec <name>` | Get secret | `GITHUB_TOKEN=$(sec github-token)` |
 | `sec list` | List all secrets | Shows names only |
 | `sec add <name>` | Add arbitrary secret | Prompts for value |
@@ -100,6 +103,26 @@ tok expiring
 # ✅  npm-token expires in 67 days
 ```
 
+### Mint a GitHub App Token
+
+```bash
+# One-time setup
+tok mint setup
+# Follow prompts: enter App ID, path to PEM file, validates automatically
+
+# Then mint tokens as needed
+tok mint
+# Output: ghs_A1B2C3_eyJhbGci...
+
+# With details
+tok mint --org Data-Wise --verbose
+# Token: ghs_A1B2C3_eyJhbGci... | Expires: 2026-06-29T06:28:03Z
+
+# Dry run to inspect the JWT
+tok mint --dry-run
+# Shows decoded header + payload + JWT preview (no API call)
+```
+
 ### Rotate Expiring Token
 
 ```bash
@@ -113,6 +136,16 @@ tok rotate
 # 4. Paste new token
 # 5. Updates both Bitwarden & Keychain
 # 6. Old token backed up for 7 days
+```
+
+### Use Minted Token in Scripts
+
+```bash
+# One-liner: export and use in same command
+export GITHUB_MCP_PAT=$(tok mint)
+
+# For CI-like usage with specific org
+export GITHUB_TOKEN=$(tok mint --org Data-Wise)
 ```
 
 ### Delete Old Token

--- a/lib/dispatchers/tok-dispatcher.zsh
+++ b/lib/dispatchers/tok-dispatcher.zsh
@@ -83,6 +83,12 @@ tok() {
         *)          _flow_log_error "Usage: tok sync <gh|push|repos> [name]"; return 1 ;;
       esac
       ;;
+    mint)
+      case "$1" in
+        setup)  shift; _tok_mint_setup "$@" ;;
+        *)      _tok_mint "$@" ;;
+      esac
+      ;;
     doctor|dr)    _tok_doctor "$@" ;;
     help|--help|-h) _tok_help ;;
     *)
@@ -106,7 +112,7 @@ tok() {
       fi
 
       _flow_log_error "Unknown token provider: $subcommand"
-      _flow_log_info "Supported: github, npm, pypi"
+      _flow_log_info "Supported: github, npm, pypi, mint"
       _flow_log_muted "Or use: tok <name> --refresh"
       echo ""
       _tok_help
@@ -137,7 +143,10 @@ ${_C_GREEN}🔥 MOST COMMON${_C_NC} ${_C_DIM}(80% of daily use)${_C_NC}:
   ${_C_CYAN}tok rotate${_C_NC}          Rotate existing token
   ${_C_CYAN}tok doctor${_C_NC}          Token health check
 
-${_C_YELLOW}💡 QUICK EXAMPLES${_C_NC}:
+  ${_C_YELLOW}💡 QUICK EXAMPLES${_C_NC}:
+  ${_C_DIM}\$${_C_NC} tok mint                      ${_C_DIM}# Mint GitHub App token (ghs_)${_C_NC}
+  ${_C_DIM}\$${_C_NC} tok mint --org MyOrg         ${_C_DIM}# Mint for a specific org${_C_NC}
+  ${_C_DIM}\$${_C_NC} tok mint setup               ${_C_DIM}# Store GitHub App credentials${_C_NC}
   ${_C_DIM}\$${_C_NC} tok github                    ${_C_DIM}# Create new GitHub PAT${_C_NC}
   ${_C_DIM}\$${_C_NC} tok expiring                  ${_C_DIM}# Check what's expiring${_C_NC}
   ${_C_DIM}\$${_C_NC} tok github-token --refresh    ${_C_DIM}# Rotate a token${_C_NC}
@@ -146,6 +155,11 @@ ${_C_BLUE}📋 TOKEN WIZARDS${_C_NC}:
   ${_C_CYAN}tok github${_C_NC}          GitHub PAT wizard
   ${_C_CYAN}tok npm${_C_NC}             NPM token wizard
   ${_C_CYAN}tok pypi${_C_NC}            PyPI token wizard
+
+${_C_GREEN}🔐 GITHUB APP TOKENS${_C_NC}:
+  ${_C_CYAN}tok mint [--org ORG]${_C_NC}  Mint short-lived ghs_ token from GitHub App
+  ${_C_CYAN}tok mint setup${_C_NC}        Store App ID + private key in Keychain
+  ${_C_CYAN}tok mint --dry-run${_C_NC}    Generate JWT without exchanging for token
 
 ${_C_BLUE}📋 TOKEN AUTOMATION${_C_NC}:
   ${_C_CYAN}tok expiring${_C_NC}        Check expiration status
@@ -1399,6 +1413,214 @@ EOF
 
   # Post-store auto-sync: fan out to configured GitHub Actions secrets.
   _tok_autosync_hook "$token_name" "$token_value"
+}
+
+# ───────────────────────────────────────────────────────────────────
+# TOKEN MINT - GitHub App installation token (ghs_) (issue #479)
+# ───────────────────────────────────────────────────────────────────
+
+# Mint a short-lived GitHub App installation token.
+# Reads github_app_id + github_app_private_key from Keychain,
+# generates an RS256 JWT, resolves the installation, and exchanges
+# for a ghs_ token.
+_tok_mint() {
+  local org="Data-Wise"
+  local dry_run=false
+  local verbose=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --org) shift; org="$1" ;;
+      --dry-run) dry_run=true ;;
+      --verbose|-v) verbose=true ;;
+      *) _flow_log_error "Unknown option: $1"
+         echo "Usage: tok mint [--org ORG] [--dry-run] [--verbose]"
+         return 1 ;;
+    esac
+    shift
+  done
+
+  local app_id private_key
+  app_id=$(security find-generic-password -a "github_app_id" -s "$_DOT_KEYCHAIN_SERVICE" -w 2>/dev/null)
+  if [[ $? -ne 0 || -z "$app_id" ]]; then
+    _flow_log_error "GitHub App ID not found in Keychain"
+    _flow_log_info "Run: tok mint setup"
+    return 2
+  fi
+
+  private_key=$(security find-generic-password -a "github_app_private_key" -s "$_DOT_KEYCHAIN_SERVICE" -w 2>/dev/null)
+  if [[ $? -ne 0 || -z "$private_key" ]]; then
+    _flow_log_error "GitHub App private key not found in Keychain"
+    _flow_log_info "Run: tok mint setup"
+    return 2
+  fi
+
+  local jwt
+  jwt=$(_tok_mint_jwt "$app_id" "$private_key") || {
+    _flow_log_error "Failed to generate JWT"
+    return 3
+  }
+
+  if [[ "$dry_run" == true ]]; then
+    local b64_header="${jwt%%.*}"
+    local b64_payload
+    b64_payload=$(echo "$jwt" | cut -d. -f2)
+    local decoded_header decoded_payload
+    decoded_header=$(printf '%s' "$b64_header" | openssl enc -base64 -d -A 2>/dev/null || echo "decode error")
+    decoded_payload=$(printf '%s' "$b64_payload" | openssl enc -base64 -d -A 2>/dev/null || echo "decode error")
+    echo "${FLOW_COLORS[header]}╭────────────────────────────────────────────────────╮${FLOW_COLORS[reset]}"
+    echo "${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}  ${FLOW_COLORS[bold]}JWT (DRY RUN)${FLOW_COLORS[reset]}                                ${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}"
+    echo "${FLOW_COLORS[header]}├────────────────────────────────────────────────────┤${FLOW_COLORS[reset]}"
+    echo "${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}  Org:       $org"
+    echo "${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}  Issuer:    $app_id"
+    echo "${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}  Header:    $decoded_header"
+    echo "${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}  Payload:   $decoded_payload"
+    echo "${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}  JWT:       ${jwt:0:40}..."
+    echo "${FLOW_COLORS[header]}╰────────────────────────────────────────────────────╯${FLOW_COLORS[reset]}"
+    return 0
+  fi
+
+  if [[ "$verbose" == true ]]; then
+    _flow_log_info "Resolving installation for org: $org"
+  fi
+
+  local install_response
+  install_response=$(curl -s -H "Authorization: Bearer $jwt" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/orgs/$org/installation" 2>/dev/null)
+
+  local install_id
+  install_id=$(echo "$install_response" | grep -o '"id":[0-9]*' | head -1 | cut -d: -f2)
+  if [[ -z "$install_id" ]]; then
+    _flow_log_error "App not installed on org: $org"
+    [[ "$verbose" == true ]] && echo "$install_response"
+    return 4
+  fi
+
+  if [[ "$verbose" == true ]]; then
+    _flow_log_info "Installation ID: $install_id"
+  fi
+
+  local token_response
+  token_response=$(curl -s -X POST \
+    -H "Authorization: Bearer $jwt" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/app/installations/$install_id/access_tokens" 2>/dev/null)
+
+  local token
+  token=$(echo "$token_response" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+  if [[ -z "$token" ]]; then
+    _flow_log_error "Token exchange failed"
+    [[ "$verbose" == true ]] && echo "$token_response"
+    return 5
+  fi
+
+  echo "$token"
+
+  if [[ "$verbose" == true ]]; then
+    local expires_at
+    expires_at=$(echo "$token_response" | grep -o '"expires_at":"[^"]*"' | cut -d'"' -f4)
+    echo "${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}  Token:     ${token:0:20}..."
+    echo "${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}  Expires:   ${expires_at:-unknown}"
+    echo "${FLOW_COLORS[header]}│${FLOW_COLORS[reset]}  Org:       $org"
+  fi
+}
+
+# Generate an RS256 JWT for a GitHub App.
+# Uses a temp file for the private key (openssl dgst -sign requires a file).
+_tok_mint_jwt() {
+  local app_id="$1"
+  local private_key="$2"
+  local now exp header payload b64_header b64_payload tmp_key signature
+
+  now=$(date +%s)
+  exp=$((now + 600))
+
+  header='{"alg":"RS256","typ":"JWT"}'
+  payload="{\"iat\":$now,\"exp\":$exp,\"iss\":\"$app_id\"}"
+
+  b64_header=$(printf '%s' "$header" | openssl enc -base64 -A | tr '+/' '-_' | tr -d '=')
+  b64_payload=$(printf '%s' "$payload" | openssl enc -base64 -A | tr '+/' '-_' | tr -d '=')
+
+  tmp_key=$(mktemp)
+  printf '%s' "$private_key" > "$tmp_key"
+
+  signature=$(printf '%s.%s' "$b64_header" "$b64_payload" | \
+    openssl dgst -sha256 -sign "$tmp_key" -binary 2>/dev/null | \
+    openssl enc -base64 -A | tr '+/' '-_' | tr -d '=')
+
+  rm -f "$tmp_key"
+
+  [[ -z "$signature" ]] && return 1
+
+  echo "${b64_header}.${b64_payload}.${signature}"
+}
+
+# Guided setup: prompt for App ID + private key, validate, store in Keychain.
+_tok_mint_setup() {
+  _flow_log_info "GitHub App Token Setup"
+  echo ""
+
+  echo -n "${FLOW_COLORS[bold]}GitHub App ID:${FLOW_COLORS[reset]} "
+  local app_id
+  read app_id
+  if [[ -z "$app_id" ]]; then
+    _flow_log_error "App ID is required"
+    return 1
+  fi
+
+  echo -n "${FLOW_COLORS[bold]}Path to private key PEM file:${FLOW_COLORS[reset]} "
+  local key_path
+  read key_path
+  key_path=${key_path/#\~/$HOME}
+
+  if [[ ! -f "$key_path" ]]; then
+    _flow_log_error "File not found: $key_path"
+    return 1
+  fi
+
+  _flow_log_info "Validating credentials..."
+
+  local private_key
+  private_key=$(<"$key_path")
+
+  local test_jwt
+  test_jwt=$(_tok_mint_jwt "$app_id" "$private_key") || {
+    _flow_log_error "Failed to generate test JWT"
+    return 3
+  }
+
+  local app_response
+  app_response=$(curl -s -H "Authorization: Bearer $test_jwt" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/app" 2>/dev/null)
+
+  if echo "$app_response" | grep -q '"slug"'; then
+    local app_slug
+    app_slug=$(echo "$app_response" | grep -o '"slug":"[^"]*"' | cut -d'"' -f4)
+    _flow_log_success "Credentials validated! App: $app_slug"
+  else
+    _flow_log_warning "JWT generated but app verification failed"
+    _flow_log_info "Check that App ID matches the private key"
+  fi
+
+  echo ""
+  _flow_log_info "Storing in Keychain..."
+
+  cat "$key_path" | security add-generic-password \
+    -a "github_app_private_key" \
+    -s "$_DOT_KEYCHAIN_SERVICE" \
+    -w - \
+    -U 2>/dev/null
+
+  security add-generic-password \
+    -a "github_app_id" \
+    -s "$_DOT_KEYCHAIN_SERVICE" \
+    -w "$app_id" \
+    -U 2>/dev/null
+
+  _flow_log_success "Stored github_app_id and github_app_private_key"
+  _flow_log_info "Run: tok mint [--org Data-Wise]"
 }
 
 # ───────────────────────────────────────────────────────────────────

--- a/man/man1/tok.1
+++ b/man/man1/tok.1
@@ -59,6 +59,47 @@ Selects the secret storage backend.  Values:
 .B both
 (Keychain primary + Bitwarden mirror).
 .SH COMMANDS
+.SS GitHub App Tokens
+Generate ephemeral GitHub App installation tokens without a PAT.
+.TP
+.B mint
+Mint a short-lived GitHub App installation access token
+.RI ( ghs_* ).
+Reads the App ID and private key from Keychain (stored under
+.I github_app_id
+and
+.I github_app_private_key
+in the
+.B flow-cli-secrets
+service), generates an RS256 JWT signed with the private key,
+resolves the installation via
+.IR "GET /orgs/{org}/installation" ,
+and exchanges the JWT for a token via
+.IR "POST /app/installations/:id/access_tokens" .
+The token is printed to stdout.
+.RS
+.PP
+Options:
+.RS
+.TP
+.B \-\-org \fIorg
+GitHub organization (default: \fBData-Wise\fR).
+.TP
+.B \-\-dry\-run
+Generate the RS256 JWT and show decoded header, payload, and JWT
+preview without resolving or exchanging for a token.
+.TP
+.B \-\-verbose\fR, \fB\-v
+Print token preview, expiration timestamp, and org to stderr (safe
+to ignore when piping stdout).
+.RE
+.RE
+.TP
+.B mint setup
+Interactive wizard.  Prompts for the GitHub App ID and path to the
+private key PEM file, generates a test JWT and validates it against
+.IR "api.github.com/app" ,
+then stores both credentials in macOS Keychain.
 .SS Token Wizards
 Interactive guided flows that open the provider's website, validate the
 token, store it with expiry metadata, and auto-sync to GitHub Actions.
@@ -150,6 +191,34 @@ See also
 .B help\fR, \fB\-\-help\fR, \fB\-h
 Show the help screen.
 .SH EXAMPLES
+Store GitHub App credentials (one-time setup):
+.RS
+.nf
+tok mint setup
+.fi
+.RE
+.PP
+Mint a token for the default org:
+.RS
+.nf
+tok mint
+.fi
+.RE
+.PP
+Mint a token for a specific org with details:
+.RS
+.nf
+tok mint --org Data-Wise --verbose
+.fi
+.RE
+.PP
+Inspect the JWT without minting a token:
+.RS
+.nf
+tok mint --dry-run
+.fi
+.RE
+.PP
 Create a new GitHub PAT:
 .RS
 .nf


### PR DESCRIPTION
## Summary

Adds `tok mint` — generate short-lived `ghs_` GitHub App installation tokens from Keychain-stored credentials. Closes #479.

## Changes

### Core (`lib/dispatchers/tok-dispatcher.zsh`)

- **`tok mint`** — reads `github_app_id` + `github_app_private_key` from Keychain, builds RS256 JWT, resolves org installation, exchanges for `ghs_` token
  - `--org ORG` — target org (default: `Data-Wise`)
  - `--dry-run` — decode JWT without exchanging
  - `--verbose` / `-v` — print token preview + expiration
- **`tok mint setup`** — interactive wizard: prompt for App ID + PEM path, validate via `GET /app`, store in Keychain
- **`_tok_mint_jwt()`** — RS256 JWT signing via `openssl dgst -sha256 -sign`

### Docs & Help

- `docs/help/QUICK-REFERENCE.md` — mint section
- `docs/reference/MASTER-DISPATCHER-GUIDE.md` — GitHub App Token Minting section
- `docs/reference/REFCARD-TOKEN-SECRETS.md` — mint command + quick workflow
- `docs/guides/TOKEN-COOKBOOK.md` — Recipe 11
- `docs/guides/TOKEN-MANAGEMENT-COMPLETE.md` — Section 2.3
- `docs/CHANGELOG.md` — unreleased entry
- `man/man1/tok.1` — full man page sections

### Testing

```
zsh tests/test-tok.zsh    # 14/14 pass
mkdocs build              # 0 warnings
```