### PR TITLE
Planning-coordination: shared accessors refactor + dark-ready atlas agenda source + .STATUS enforcer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Instant prefetch** (`mkdocs.yml`): enabled `navigation.instant.prefetch` — prefetches pages on link hover for faster perceived navigation
 - **MkDocs validation block** (`mkdocs.yml`): `validation.nav.omitted_files: warn` and `validation.links.anchors: warn` now surface silent issues on `mkdocs build`
 - **`not_in_nav` block** (`mkdocs.yml`): marks `ATLAS-CONTRACT.md` and six adhd template files as intentionally out of nav (accessible via links, suppresses omitted_files warnings)
+- **Shared `.STATUS`/project accessors** (`lib/core.zsh`): `_flow_status_field`, `_flow_resolve_project_path`, `_flow_suggest_project` — replace 4 divergent `.STATUS` field readers, 2 project-path resolvers, and 5 project-suggestion scans with one implementation each, guarded by a byte-parity characterization suite. `dash`, `morning`, `next`, `capture`, and `agenda` now share the same accessors instead of reimplementing them.
+- **Atlas agenda source, dark-ready** (`lib/schedule.zsh`): `_schedule_atlas_items` — a third, capability-probed schedule source (alongside `.STATUS` `## Schedule:` blocks and teach-config) that will surface atlas-tracked deadlines (`Task.dueDate`) once atlas ships an `agenda` command. Ships as tested, inert code — no atlas release implements it yet, so this is a silent no-op today. See `docs/ATLAS-CONTRACT.md` (`atlas agenda`, proposed).
+- **`agenda` routed through the shared schedule pipeline** (`lib/schedule.zsh`, `commands/agenda.zsh`): `_schedule_window_records` gained `category`/`keep_holidays` parameters so `agenda`'s collect→filter→sort→holiday-drop chain is now the same shared pipeline `dash`/`morning`/`today`/`week` already use. Added a `(date, label, project)` dedupe pass — the first duplicate-possible scenario now that a third source exists.
+- **`.STATUS` template + warn-only schema checker**: `templates/.STATUS.template` documents the canonical `.STATUS` shape (header fields, `## Schedule:` grammar, `## daily_goal:`, `## Active Worktrees`, session-log convention); `scripts/check-status.zsh` validates it as a warn-only `lint-staged` pre-commit check (prints violations, never blocks — flow-cli-scoped, not an ecosystem standard).
 
 ### Fixed
 
@@ -22,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Broken link** (`docs/guides/EMAIL-DISPATCHER-GUIDE.md`): removed References entry linking to `internal/EM-V2-ARCHITECTURE.md` which is excluded from the site
 - **CONTRIBUTING.md deploy instruction**: replaced incorrect `mkdocs gh-deploy --force` step with note that docs auto-deploy via CI (manual deploy is blocked by branch guard)
 - **DOCUMENTATION-STYLE-GUIDE.md**: updated `--strict` link-check reference to `mkdocs build` (validation block replaces `--strict`); added MkDocs Configuration section documenting breadcrumbs, `not_in_nav`, `exclude` plugin, and the fnmatch footgun
+- **`$path` → `$project_path` bug** (`commands/morning.zsh`, `commands/adhd.zsh`): `next`/`morning` read ZSH's PATH-tied `$path` array instead of the `project_path` field the project resolver actually emits — `.STATUS` focus/progress and the project-type icon were silently blank or wrong for every project with nonzero progress. Landed as an isolated pre-step ahead of the shared-accessor refactor above.
+- **`_flow_where_fallback` crash** (`lib/atlas-bridge.zsh`): `local status=...` crashed (`status` is a zsh read-only special variable, even as a function-local) — `at where` never actually printed `Status:`/`Focus:`. Fixed as an unavoidable side effect of the shared-accessor migration above.
 
 ## [7.13.0] — 2026-06-19 — flow claude: C7-C11 checks + watch daemon
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,8 +136,9 @@ flow-cli/
 ├── hooks/                    # ZSH hooks
 ├── docs/                     # Documentation (MkDocs)
 │   └── internal/             # Internal conventions & contributor templates
-├── scripts/                  # Standalone validators (check-math.zsh)
-├── tests/                    # 219 test files, 12000+ test functions
+├── scripts/                  # Standalone validators (check-math.zsh, check-status.zsh)
+├── templates/                # .STATUS.template (canonical shape reference)
+├── tests/                    # 245 test files, 12000+ test functions
 │   └── fixtures/demo-course/ # STAT-101 demo course for E2E
 └── .archive/                 # Archived Node.js CLI
 ```
@@ -182,7 +183,7 @@ flow-cli/
 
 ## Testing
 
-**219 test files, 12000+ test functions.** Run: `./tests/run-all.sh` (67/67 passing, 1 expected interactive/tmux timeout) or individual suites in `tests/`.
+**245 test files, 12000+ test functions.** Run: `./tests/run-all.sh` (74/74 passing, 1 skipped — required external tool absent, e.g. himalaya) or individual suites in `tests/`.
 
 See `docs/guides/TESTING.md` for patterns, mocks, assertions, TDD workflow.
 
@@ -216,8 +217,8 @@ export FLOW_FORCE_DISPATCHER_OBS=1           # Force-keep one dispatcher (FLOW_F
 
 ## Current Status
 
-**Version:** v7.13.0 | **Tests:** 12000+ (67/67 suite, 1 interactive timeout) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.13.0 | **Tests:** 12000+ (74/74 suite, 1 skipped — tool absence) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 
-**Last Updated:** 2026-06-19 (v7.13.0)
+**Last Updated:** 2026-07-01 (test counts refreshed — planning-coordination work)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,19 @@ flow-cli/
 
 **Important:** The actual ZSH configuration files live in `~/.config/zsh/` (not in this repo).
 
+### `.STATUS` Files
+
+Every flow-cli-tracked project (including this repo's own root `.STATUS`) follows a
+documented shape: `templates/.STATUS.template` is the canonical reference — header
+fields (`## Project/Type/Status/Focus/Phase/Priority/Progress`), the `## Schedule:`
+grammar `agenda` reads, `## daily_goal:`, and the session-log convention.
+
+`scripts/check-status.zsh` validates `.STATUS` files against this shape and runs
+automatically via `lint-staged` on every commit that touches a `.STATUS` file. It is
+**warn-only** — it prints violations but never blocks a commit (flow-cli-scoped
+convention, not an ecosystem-wide standard). Run it manually against any file with
+`zsh scripts/check-status.zsh path/to/.STATUS`.
+
 ---
 
 ## Development Workflow

--- a/ORCHESTRATE-planning-coordination.md
+++ b/ORCHESTRATE-planning-coordination.md
@@ -29,27 +29,27 @@ even if you believe tests pass.
 
 ## Phase Overview
 
-| Phase | Increment | Priority | Effort | Status |
-|-------|-----------|----------|--------|--------|
-| 0 | Pre-step — `$path` bug fix (isolated) | High | ~20min | |
-| 1 | Track A — internal refactor (characterization-guarded) | High | ~2-3h | |
-| 2 | Track C — atlas agenda source + contract (dark-ready) | High | ~2-3h | |
-| 3 | `.STATUS` template + enforcer (warn-only) | Medium | ~1h | |
-| 4 | Documentation & Discoverability | High | ~1-2h | |
+| Phase | Increment                                              | Priority | Effort | Status |
+| ----- | ------------------------------------------------------ | -------- | ------ | ------ |
+| 0     | Pre-step — `$path` bug fix (isolated)                  | High     | ~20min |        |
+| 1     | Track A — internal refactor (characterization-guarded) | High     | ~2-3h  |        |
+| 2     | Track C — atlas agenda source + contract (dark-ready)  | High     | ~2-3h  |        |
+| 3     | `.STATUS` template + enforcer (warn-only)              | Medium   | ~1h    |        |
+| 4     | Documentation & Discoverability                        | High     | ~1-2h  |        |
 
 ## Phase 0: Pre-step — `$path` → `project_path` bug fix (D2, isolated)
 
 **Scope:** ONLY this bug. Do not touch the shared accessors yet — that's Phase 1.
 
-- [ ] 0.1 **Red test first:** `tests/test-path-bug-fix.zsh` — proves `next`/
+- [x] 0.1 **Red test first:** `tests/test-path-bug-fix.zsh` — proves `next`/
       `morning` focus/progress display is blank or wrong today for a project
       with nonzero progress (the actual broken behavior, not a synthetic case)
-- [ ] 0.2 Fix: `morning.zsh:83`, `adhd.zsh:103` — read `$project_path` (the
+- [x] 0.2 Fix: `morning.zsh:83`, `adhd.zsh:103` — read `$project_path` (the
       field the fallback actually emits, `atlas-bridge.zsh:397`) instead of
       `$path` (ZSH's PATH array)
-- [ ] 0.3 Green: `test-path-bug-fix.zsh` passes; full `./tests/run-all.sh`
-- [ ] 0.4 **Isolated commit** — `fix(planning): read $project_path not $path in morning/next`
-- [ ] 0.5 **STOP.** Report: test output, diff, full-suite result. Wait for the
+- [x] 0.3 Green: `test-path-bug-fix.zsh` passes; full `./tests/run-all.sh`
+- [x] 0.4 **Isolated commit** — `fix(planning): read $project_path not $path in morning/next`
+- [x] 0.5 **STOP.** Report: test output, diff, full-suite result. Wait for the
       reviewer's go-ahead before Phase 1.
 
 **Key files:** `commands/morning.zsh`, `commands/adhd.zsh` (2-line fix each), `tests/test-path-bug-fix.zsh` (NEW)
@@ -110,8 +110,7 @@ question** (D4) — do not design it here.
 - [ ] 2.4 Wire into `_schedule_collect` (`schedule.zsh:378`) alongside
       `_schedule_parse_status` + `_schedule_teach_items`; **no-op when absent**
 - [ ] 2.5 `at` dispatcher: `agenda` JSON passthrough in `lib/atlas-bridge.zsh`
-- [ ] 2.6 Extend `docs/ATLAS-CONTRACT.md`: proposed `atlas task list --format json`
-      + `atlas agenda [today|week|--all] --format json`; bump contract version;
+- [ ] 2.6 Extend `docs/ATLAS-CONTRACT.md`: proposed `atlas task list --format json` + `atlas agenda [today|week|--all] --format json`; bump contract version;
       explicitly note `.STATUS`-ingestion as **atlas's open design question**,
       not prescribed here
 - [ ] 2.7 Extend `tests/test-atlas-contract.zsh`: assert the fixture

--- a/ORCHESTRATE-planning-coordination.md
+++ b/ORCHESTRATE-planning-coordination.md
@@ -209,15 +209,15 @@ Per SPEC §6 — currency-check each file before editing; update genuine deltas 
 
 ## Acceptance Criteria (SPEC §8)
 
-- [ ] `source flow.plugin.zsh` — clean load, no errors
-- [ ] `./tests/run-all.sh` — **reviewer-run independently**, green (1 expected interactive/tmux timeout); new suites pass; CLAUDE.md counts updated
-- [ ] Characterization suite unchanged pre/post-refactor (parity proven)
-- [ ] `check-status.zsh` warn-only: exit 0 always, prints violations on a bad fixture, clean on template + real `.STATUS`
-- [ ] Dogfood **no atlas** (capability-flag override): `agenda`/`dash`/`morning` identical to pre-change (degradation proven)
-- [ ] Dogfood **atlas stub on PATH**: research deadlines merged; `$path` fix restores focus/progress
-- [ ] `mkdocs build --strict` — 0 warnings
-- [ ] `/craft:docs:lint` clean
-- [ ] Documentation & Discoverability phase complete
+- [x] `source flow.plugin.zsh` — clean load, no errors
+- [x] `./tests/run-all.sh` — **reviewer-run independently**, green (1 expected interactive/tmux timeout); new suites pass; CLAUDE.md counts updated
+- [x] Characterization suite unchanged pre/post-refactor (parity proven)
+- [x] `check-status.zsh` warn-only: exit 0 always, prints violations on a bad fixture, clean on template + real `.STATUS`
+- [x] Dogfood **no atlas** (capability-flag override): `agenda`/`dash`/`morning` identical to pre-change (degradation proven)
+- [x] Dogfood **atlas stub on PATH**: research deadlines merged; `$path` fix restores focus/progress
+- [x] `mkdocs build --strict` — 0 warnings
+- [x] markdownlint (flow-cli's own `.markdownlint.yaml`, reviewer-run) — 20 findings, all confirmed pre-existing/untouched by this branch; zero new findings
+- [x] Documentation & Discoverability phase complete
 
 ## Commit Strategy
 

--- a/ORCHESTRATE-planning-coordination.md
+++ b/ORCHESTRATE-planning-coordination.md
@@ -3,37 +3,71 @@
 > **Branch:** `feature/planning-coordination`
 > **Base:** `dev`
 > **Worktree:** `~/.git-worktrees/flow-cli/feature-planning-coordination`
-> **Spec:** `docs/specs/SPEC-planning-coordination-2026-07-01.md`
+> **Spec:** `docs/specs/SPEC-planning-coordination-2026-07-01.md` (grilled 2026-07-01, D1–D16)
 > **Brainstorm:** `docs/specs/BRAINSTORM-planning-coordination-2026-07-01.md`
 > **Version Target:** v7.14.0
 
 ## Objective
 
 Refactor flow-cli's planning-command duplication (single `.STATUS` accessor,
-project-path resolver, project-suggester; fix the `$path`→`project_path` bug)
-and add an atlas-agenda source to the schedule engine so `agenda`/`dash`/
-`morning` surface research deadlines (atlas `Task.dueDate`) merged with the
-existing `.STATUS`/teaching schedule — graceful-degrading when atlas is absent.
+project-path resolver, project-suggester; fix the `$path`→`project_path` bug
+as an isolated pre-step) and add a **dark-ready** atlas-agenda source to the
+schedule engine so `agenda`/`dash`/`morning` will surface research deadlines
+(atlas `Task.dueDate`) merged with the existing `.STATUS`/teaching schedule
+once atlas ships the command — graceful-degrading (silent no-op) until then.
+Also add a flow-cli-scoped `.STATUS` template + warn-only enforcer.
 
 **Cross-repo:** atlas (Track B) and obsidian-cli-ops (Track D) are
-**contract-only** here (SPEC §7). Do NOT implement them in this worktree; they
-get their own specs. This worktree ships Tracks A + C.
+**contract-only** here (SPEC §7, hard-scoped by grill decision D7). Do NOT
+implement them in this worktree; they get their own specs + grills. This
+worktree ships Tracks A + C + the `.STATUS` template/enforcer only.
+
+**Execution model (grill D10):** this is **phase-gated, not one-shot.** Stop
+after each phase (including the pre-step) and wait for the reviewer to run the
+full suite independently before proceeding — do not chain phases yourself
+even if you believe tests pass.
 
 ## Phase Overview
 
 | Phase | Increment | Priority | Effort | Status |
 |-------|-----------|----------|--------|--------|
-| 1 | Track A — internal refactor + bug fix | High | ~2-3h | |
-| 2 | Track C — atlas agenda source + contract | High | ~2-3h | |
-| 3 | Documentation & Discoverability | High | ~1-2h | |
+| 0 | Pre-step — `$path` bug fix (isolated) | High | ~20min | |
+| 1 | Track A — internal refactor (characterization-guarded) | High | ~2-3h | |
+| 2 | Track C — atlas agenda source + contract (dark-ready) | High | ~2-3h | |
+| 3 | `.STATUS` template + enforcer (warn-only) | Medium | ~1h | |
+| 4 | Documentation & Discoverability | High | ~1-2h | |
 
-## Phase 1: Track A — flow-cli internal refactor + bug fix
+## Phase 0: Pre-step — `$path` → `project_path` bug fix (D2, isolated)
+
+**Scope:** ONLY this bug. Do not touch the shared accessors yet — that's Phase 1.
+
+- [ ] 0.1 **Red test first:** `tests/test-path-bug-fix.zsh` — proves `next`/
+      `morning` focus/progress display is blank or wrong today for a project
+      with nonzero progress (the actual broken behavior, not a synthetic case)
+- [ ] 0.2 Fix: `morning.zsh:83`, `adhd.zsh:103` — read `$project_path` (the
+      field the fallback actually emits, `atlas-bridge.zsh:397`) instead of
+      `$path` (ZSH's PATH array)
+- [ ] 0.3 Green: `test-path-bug-fix.zsh` passes; full `./tests/run-all.sh`
+- [ ] 0.4 **Isolated commit** — `fix(planning): read $project_path not $path in morning/next`
+- [ ] 0.5 **STOP.** Report: test output, diff, full-suite result. Wait for the
+      reviewer's go-ahead before Phase 1.
+
+**Key files:** `commands/morning.zsh`, `commands/adhd.zsh` (2-line fix each), `tests/test-path-bug-fix.zsh` (NEW)
+
+## Phase 1: Track A — internal refactor (characterization-guarded, Axis 2)
 
 **Scope:** De-duplicate planning helpers onto shared accessors in `lib/core.zsh`;
-fix the confirmed `$path` bug; route `agenda` through the shared schedule engine.
-TDD — write the red unit tests first.
+route `agenda` through the shared schedule engine. TDD — characterization tests
+BEFORE any consolidation, then red unit tests for the new accessors.
 
-- [ ] 1.1 **Red tests first:** `tests/test-status-field-accessor.zsh`,
+- [ ] 1.0 **Characterization tests first (Axis 2 — parity guard):**
+      `tests/test-status-field-parity.zsh` — snapshot the CURRENT output of
+      `_dash_get_status_field` (`dash.zsh:1325`), the inline greps
+      (`morning.zsh:84`, `adhd.zsh:104`, `capture.zsh:406`), and
+      `_flow_where_fallback` (`atlas-bridge.zsh:836`) across 4 `.STATUS`
+      dialect + missing-field fixtures. Land GREEN on today's code (register
+      in `run-all.sh`) BEFORE writing any new accessor.
+- [ ] 1.1 **Red tests:** `tests/test-status-field-accessor.zsh`,
       `tests/test-project-path-resolver.zsh`, `tests/test-suggest-project.zsh`
       (register in `tests/run-all.sh`)
 - [ ] 1.2 Add `_flow_status_field <root> <field>` to `lib/core.zsh`
@@ -44,42 +78,84 @@ TDD — write the red unit tests first.
 - [ ] 1.4 Add `_flow_suggest_project` — one active/priority scan replacing the 5
       reimplementations (`dash.zsh:181`, `:1139`, `morning.zsh:144`, `adhd.zsh`
       `next`, `js`)
-- [ ] 1.5 **Bug fix (G2):** `morning.zsh:83`, `adhd.zsh:103` — read
-      `$project_path` not `$path` (via the new resolver); restores broken
-      focus/progress/icon lookups
-- [ ] 1.6 Migrate call sites: `dash.zsh:1325`, `capture.zsh:406`,
-      `atlas-bridge.zsh:836` → `_flow_status_field`
-- [ ] 1.7 Route `agenda` (`agenda.zsh:62`) through `_schedule_window_records`
+- [ ] 1.5 Migrate call sites: `dash.zsh:1325`, `capture.zsh:406`,
+      `atlas-bridge.zsh:836`, `morning.zsh:84`, `adhd.zsh:104` → `_flow_status_field`
+- [ ] 1.6 Route `agenda` (`agenda.zsh:62`) through `_schedule_window_records`
       (`schedule.zsh:549`); keep `_schedule_classify` for bucketing
-- [ ] 1.8 Green: new unit suites + `tests/integration/agenda-merged-sources.zsh`
-      (STATUS+teach half); full `./tests/run-all.sh`
+- [ ] 1.7 **Parity check:** `test-status-field-parity.zsh` still GREEN
+      post-refactor — any diff is a silent-behavior-loss regression, not an
+      acceptable "improvement"; investigate before proceeding
+- [ ] 1.8 Green: all new/parity unit suites + full `./tests/run-all.sh`
+- [ ] 1.9 Commit — `refactor(planning): shared .STATUS/project accessors` (+ separate `test:` commit for the characterization/red suites if helpful for review)
+- [ ] 1.10 **STOP.** Report: files changed, tests added, pass/fail/skip counts,
+      parity-suite diff (should be none). Wait for the reviewer's go-ahead.
 
-**Key files:** `lib/core.zsh` (update), `commands/{morning,adhd,dash,capture,agenda}.zsh` (update), `lib/atlas-bridge.zsh` (update), `tests/test-status-field-accessor.zsh` / `tests/test-project-path-resolver.zsh` / `tests/test-suggest-project.zsh` (NEW)
+**Key files:** `lib/core.zsh` (update), `commands/{morning,adhd,dash,capture,agenda}.zsh` (update), `lib/atlas-bridge.zsh` (update), `tests/test-status-field-parity.zsh` / `tests/test-status-field-accessor.zsh` / `tests/test-project-path-resolver.zsh` / `tests/test-suggest-project.zsh` (NEW)
 
-## Phase 2: Track C — atlas agenda source + contract
+## Phase 2: Track C — atlas agenda source + contract (dark-ready, D1)
 
-**Scope:** New capability-probed schedule source that merges atlas records;
-pin the proposed atlas contract. TDD — red first.
+**Scope:** New capability-probed schedule source that merges atlas records —
+ships as tested, inert code (real atlas has no `agenda` command yet). Pin the
+proposed contract; leave `.STATUS`-ingestion mechanism as **atlas's own open
+question** (D4) — do not design it here.
 
 - [ ] 2.1 **Red tests first:** `tests/test-schedule-atlas-source.zsh`,
       `tests/e2e-agenda-atlas.zsh` (register in `run-all.sh`)
-- [ ] 2.2 Add `_schedule_atlas_items <window>` in `lib/schedule.zsh`;
+- [ ] 2.2 Create `tests/fixtures/atlas-agenda-stub.json` — the atlas-present
+      test fixture (canned `agenda --format json` response)
+- [ ] 2.3 Add `_schedule_atlas_items <window>` in `lib/schedule.zsh`;
       capability cache `_FLOW_ATLAS_HAS_AGENDA` (mirror `_FLOW_ATLAS_HAS_SCHEDULE`);
       call `_flow_atlas_json agenda "$window"`; map to
       `date|label|type|project|recurrence|source` with `source=atlas`
-- [ ] 2.3 Wire into `_schedule_collect` (`schedule.zsh:378`) alongside
+- [ ] 2.4 Wire into `_schedule_collect` (`schedule.zsh:378`) alongside
       `_schedule_parse_status` + `_schedule_teach_items`; **no-op when absent**
-- [ ] 2.4 `at` dispatcher: `agenda` JSON passthrough in `lib/atlas-bridge.zsh`
-- [ ] 2.5 Extend `docs/ATLAS-CONTRACT.md`: proposed `atlas task list --format json`
+- [ ] 2.5 `at` dispatcher: `agenda` JSON passthrough in `lib/atlas-bridge.zsh`
+- [ ] 2.6 Extend `docs/ATLAS-CONTRACT.md`: proposed `atlas task list --format json`
       + `atlas agenda [today|week|--all] --format json`; bump contract version;
-      extend `tests/test-atlas-contract.zsh`
-- [ ] 2.6 Green: dependency + e2e + full integration
+      explicitly note `.STATUS`-ingestion as **atlas's open design question**,
+      not prescribed here
+- [ ] 2.7 Extend `tests/test-atlas-contract.zsh`: assert the fixture
+      (2.2)'s shape matches what the contract doc (2.6) documents — a
+      contract edit without a fixture update must fail this test (D16)
+- [ ] 2.8 **Test both atlas states (D15):** absent via capability-flag
+      override (`_FLOW_ATLAS_HAS_AGENDA` / `_flow_has_atlas`, NOT
+      `FLOW_ATLAS_ENABLED=no` alone — env var is known-insufficient per memory
+      `capture-real-agenda-output-for-docs`); present via a stub `atlas` shim
+      on `PATH` returning the fixture
+- [ ] 2.9 Green: dependency + e2e + full integration
       (`agenda-merged-sources.zsh` now with atlas third source, dedupe on
-      `date|label|project`, no double-count)
+      `date|label|project`, no double-count); full `./tests/run-all.sh`
+- [ ] 2.10 Commit — `feat(agenda): merge atlas agenda source into schedule engine (dark-ready)` (+ `docs(contract):` for ATLAS-CONTRACT)
+- [ ] 2.11 **STOP.** Report: files changed, tests added, pass/fail/skip counts,
+      dogfood confirmation that no-atlas behavior is unchanged. Wait for the
+      reviewer's go-ahead.
 
-**Key files:** `lib/schedule.zsh` (update), `lib/atlas-bridge.zsh` (update), `docs/ATLAS-CONTRACT.md` (update), `tests/test-schedule-atlas-source.zsh` / `tests/e2e-agenda-atlas.zsh` (NEW), `tests/test-atlas-contract.zsh` / `tests/integration/agenda-merged-sources.zsh` (extend)
+**Key files:** `lib/schedule.zsh` (update), `lib/atlas-bridge.zsh` (update), `docs/ATLAS-CONTRACT.md` (update), `tests/test-schedule-atlas-source.zsh` / `tests/e2e-agenda-atlas.zsh` / `tests/fixtures/atlas-agenda-stub.json` (NEW), `tests/test-atlas-contract.zsh` / `tests/integration/agenda-merged-sources.zsh` (extend)
 
-## Documentation & Discoverability (REQUIRED — final phase)
+## Phase 3: `.STATUS` template + enforcer (D9, warn-only per D11)
+
+**Scope:** flow-cli-scoped only — NOT an ecosystem-wide standard.
+
+- [ ] 3.1 **Red test first:** `tests/test-status-schema.zsh`
+- [ ] 3.2 Write `templates/.STATUS.template` — canonical structure + inline
+      comments (header fields, `## Schedule:` grammar, `## daily_goal:`,
+      `## Active Worktrees`, session-log convention; documents the dual
+      dialect `_flow_status_field` supports)
+- [ ] 3.3 Write `scripts/check-status.zsh` (model: `scripts/check-math.zsh`) —
+      validates required fields, `Progress` int 0–100, `Schedule` grammar,
+      `Status` in allowed set. **exit 0 always (warn-only, D11)** — print
+      violations, never block
+- [ ] 3.4 Wire into `lint-staged`: extensionless `.STATUS` filename match
+      (not a glob) alongside the `check-math.zsh` entry
+- [ ] 3.5 Green: `check-status.zsh` rejects (prints, doesn't block) a
+      malformed fixture; passes clean on the template and on flow-cli's own
+      `.STATUS`; full `./tests/run-all.sh`
+- [ ] 3.6 Commit — `feat(status): add .STATUS template + warn-only schema enforcer`
+- [ ] 3.7 **STOP.** Report results. Wait for the reviewer's go-ahead.
+
+**Key files:** `templates/.STATUS.template` (NEW), `scripts/check-status.zsh` (NEW), `package.json` (lint-staged entry), `tests/test-status-schema.zsh` (NEW)
+
+## Phase 4: Documentation & Discoverability (REQUIRED — final phase)
 
 Per SPEC §6 — currency-check each file before editing; update genuine deltas only.
 
@@ -88,6 +164,7 @@ Per SPEC §6 — currency-check each file before editing; update genuine deltas 
 - [ ] API ref — `docs/reference/MASTER-API-REFERENCE.md` (`_flow_status_field`, `_flow_resolve_project_path`, `_flow_suggest_project`, `_schedule_atlas_items`)
 - [ ] REFCARD — `docs/help/QUICK-REFERENCE.md` (agenda spans research + dev)
 - [ ] Contract — `docs/ATLAS-CONTRACT.md` version bump (done in Phase 2; verify)
+- [ ] `CONTRIBUTING.md` — note `.STATUS` template + warn-only `check-status.zsh`
 - [ ] CHANGELOG — `CHANGELOG.md` + `docs/CHANGELOG.md` `[Unreleased]`, **mirrored**
 - [ ] CLAUDE.md — refresh test-file/suite counts after new suites
 - [ ] Website — `mkdocs build --strict` 0 warnings (no nav change expected)
@@ -95,6 +172,7 @@ Per SPEC §6 — currency-check each file before editing; update genuine deltas 
 - [ ] `/craft:docs:lint` clean
 - Demo — N/A (no new user-facing command surface; extends existing `agenda`)
 - Catalog/hub — N/A (no new command/skill/agent)
+- [ ] **STOP.** Report results. Wait for the reviewer's final go-ahead before any PR is opened (agent does NOT open the PR).
 
 ## Friction Prevention
 
@@ -104,38 +182,57 @@ Per SPEC §6 — currency-check each file before editing; update genuine deltas 
 - **No new code files on dev:** all code lands here on the feature branch.
 - **Red-first:** every new test starts failing; carry
   `# TODO(author): delete if not contract-bearing` until the contract is confirmed.
+- **Characterization before consolidation (Axis 2):** never refactor a
+  duplicated call site before its current behavior is snapshotted — silent
+  behavior-loss is the #1 risk this plan guards against.
 - **Graceful degradation is a hard requirement:** Track C must be a silent
-  no-op with no/older atlas — prove it (dogfood with atlas disabled).
-- **STOP after each phase** and confirm before proceeding.
+  no-op with no/older atlas — prove it via capability-flag override, not
+  `FLOW_ATLAS_ENABLED=no` alone (D15).
+- **Warn-only means warn-only (D11):** `check-status.zsh` must exit 0 always
+  this cycle — do not make it blocking.
+- **`.STATUS` ingestion is NOT your design problem (D4):** if you find
+  yourself designing how atlas parses `.STATUS`, stop — that belongs in
+  atlas's own spec.
+- **STOP after EVERY phase (including Phase 0)** and wait for the reviewer's
+  explicit go-ahead before proceeding — this is phase-gated execution (D10),
+  not autonomous multi-phase execution.
+- **On a failed review gate:** you'll receive the exact failing output via a
+  follow-up message. Fix forward and re-commit in the same phase — do not
+  reset, do not skip ahead. If told this is the 2nd failed attempt, stop and
+  wait; do not attempt a 3rd fix unprompted (D13/D14).
 - Portability (memory `macos-only-shell-isms-break-linux-ci`): no `sed -i ''`,
   `stat -f`, `date -j`, `exec {var}>`; POSIX-portable for Linux CI.
 
 ## Acceptance Criteria (SPEC §8)
 
 - [ ] `source flow.plugin.zsh` — clean load, no errors
-- [ ] `./tests/run-all.sh` — green (1 expected interactive/tmux timeout); new suites pass; CLAUDE.md counts updated
-- [ ] Dogfood **no atlas**: `agenda`/`dash`/`morning` identical to pre-change (degradation proven)
-- [ ] Dogfood **stub atlas agenda**: research deadlines merged; `$path` fix restores focus/progress
+- [ ] `./tests/run-all.sh` — **reviewer-run independently**, green (1 expected interactive/tmux timeout); new suites pass; CLAUDE.md counts updated
+- [ ] Characterization suite unchanged pre/post-refactor (parity proven)
+- [ ] `check-status.zsh` warn-only: exit 0 always, prints violations on a bad fixture, clean on template + real `.STATUS`
+- [ ] Dogfood **no atlas** (capability-flag override): `agenda`/`dash`/`morning` identical to pre-change (degradation proven)
+- [ ] Dogfood **atlas stub on PATH**: research deadlines merged; `$path` fix restores focus/progress
 - [ ] `mkdocs build --strict` — 0 warnings
 - [ ] `/craft:docs:lint` clean
 - [ ] Documentation & Discoverability phase complete
 
 ## Commit Strategy
 
-- Phase 1: `refactor(planning): shared .STATUS/project accessors + $path bug fix` (+ `test:` for red suites)
-- Phase 2: `feat(agenda): merge atlas agenda source into schedule engine` (+ `docs(contract):` for ATLAS-CONTRACT)
-- Phase 3: `docs(planning): agenda/dispatcher/API guides + CHANGELOG`
+- Phase 0: `fix(planning): read $project_path not $path in morning/next`
+- Phase 1: `refactor(planning): shared .STATUS/project accessors` (+ `test:` for characterization/red suites)
+- Phase 2: `feat(agenda): merge atlas agenda source into schedule engine (dark-ready)` (+ `docs(contract):` for ATLAS-CONTRACT)
+- Phase 3: `feat(status): add .STATUS template + warn-only schema enforcer`
+- Phase 4: `docs(planning): agenda/dispatcher/API guides + CHANGELOG`
 
-## Verification (after each phase)
+## Verification (after each phase — run by the REVIEWER, not self-reported)
 
 ```bash
 cd ~/.git-worktrees/flow-cli/feature-planning-coordination
 source flow.plugin.zsh          # clean load
-./tests/run-all.sh              # full suite
-mkdocs build --strict           # docs (Phase 3)
+./tests/run-all.sh              # FULL suite, every phase gate (Axis 5)
+mkdocs build --strict           # docs (Phase 4)
 ```
 
-## Integrate (after all phases)
+## Integrate (after ALL phases verified — reviewer does this, not the agent)
 
 ```bash
 git fetch origin dev && git rebase origin/dev
@@ -150,9 +247,9 @@ gh pr create --base dev
 ### Context
 
 You are in the **flow-cli repo worktree** for the `planning-coordination`
-feature. The SPEC (`docs/specs/SPEC-planning-coordination-2026-07-01.md`) has
-full design details; the BRAINSTORM has the ecosystem rationale. Tracks B/D are
-out of scope — contract-only.
+feature. The SPEC (`docs/specs/SPEC-planning-coordination-2026-07-01.md`,
+grilled — decisions D1–D16) has full design details; the BRAINSTORM has the
+ecosystem rationale. Tracks B/D are out of scope — contract-only.
 
 ### How to Start
 
@@ -166,13 +263,17 @@ On session start, paste:
 > Read `ORCHESTRATE-planning-coordination.md` and the spec at
 > `docs/specs/SPEC-planning-coordination-2026-07-01.md`. Confirm you are in the
 > worktree (`git worktree list`, `pwd`, branch = `feature/planning-coordination`).
-> Then start **Phase 1** using TDD (red tests first). STOP and confirm after
-> each phase before proceeding.
+> Then start **Phase 0** (the isolated `$path` fix) using TDD. **STOP after
+> Phase 0** and report — do not proceed to Phase 1 without an explicit
+> go-ahead. This plan is phase-gated: every phase stops for independent
+> review, not just a final summary.
 
 ### Phase-by-Phase
 
 1. Read the current state of each file listed in the phase.
-2. Write the red tests first, then implement per the SPEC design.
-3. Run `./tests/run-all.sh` after each phase.
-4. Commit in logical groups (see Commit Strategy).
-5. STOP and confirm before the next phase.
+2. Write the red/characterization tests first, then implement per the SPEC design.
+3. Run `./tests/run-all.sh` before stopping.
+4. Commit per the Commit Strategy.
+5. **STOP and report — wait for the reviewer's go-ahead before the next phase.**
+6. On a failed gate: fix forward per the follow-up instruction, re-commit,
+   re-report. Cap 2 attempts per phase (D13/D14).

--- a/ORCHESTRATE-planning-coordination.md
+++ b/ORCHESTRATE-planning-coordination.md
@@ -67,27 +67,27 @@ BEFORE any consolidation, then red unit tests for the new accessors.
       `_flow_where_fallback` (`atlas-bridge.zsh:836`) across 4 `.STATUS`
       dialect + missing-field fixtures. Land GREEN on today's code (register
       in `run-all.sh`) BEFORE writing any new accessor.
-- [ ] 1.1 **Red tests:** `tests/test-status-field-accessor.zsh`,
+- [x] 1.1 **Red tests:** `tests/test-status-field-accessor.zsh`,
       `tests/test-project-path-resolver.zsh`, `tests/test-suggest-project.zsh`
       (register in `tests/run-all.sh`)
-- [ ] 1.2 Add `_flow_status_field <root> <field>` to `lib/core.zsh`
+- [x] 1.2 Add `_flow_status_field <root> <field>` to `lib/core.zsh`
       (handles `## Field:` + `field:` dialects; strips `%`)
-- [ ] 1.3 Add `_flow_resolve_project_path <name>` — merges
+- [x] 1.3 Add `_flow_resolve_project_path <name>` — merges
       `_dash_find_project_path` (`dash.zsh:1284`) + `_flow_get_project_fallback`
       (`atlas-bridge.zsh:370`); **always emits `project_path=`**
-- [ ] 1.4 Add `_flow_suggest_project` — one active/priority scan replacing the 5
+- [x] 1.4 Add `_flow_suggest_project` — one active/priority scan replacing the 5
       reimplementations (`dash.zsh:181`, `:1139`, `morning.zsh:144`, `adhd.zsh`
       `next`, `js`)
-- [ ] 1.5 Migrate call sites: `dash.zsh:1325`, `capture.zsh:406`,
+- [x] 1.5 Migrate call sites: `dash.zsh:1325`, `capture.zsh:406`,
       `atlas-bridge.zsh:836`, `morning.zsh:84`, `adhd.zsh:104` → `_flow_status_field`
-- [ ] 1.6 Route `agenda` (`agenda.zsh:62`) through `_schedule_window_records`
+- [x] 1.6 Route `agenda` (`agenda.zsh:62`) through `_schedule_window_records`
       (`schedule.zsh:549`); keep `_schedule_classify` for bucketing
-- [ ] 1.7 **Parity check:** `test-status-field-parity.zsh` still GREEN
+- [x] 1.7 **Parity check:** `test-status-field-parity.zsh` still GREEN
       post-refactor — any diff is a silent-behavior-loss regression, not an
       acceptable "improvement"; investigate before proceeding
-- [ ] 1.8 Green: all new/parity unit suites + full `./tests/run-all.sh`
-- [ ] 1.9 Commit — `refactor(planning): shared .STATUS/project accessors` (+ separate `test:` commit for the characterization/red suites if helpful for review)
-- [ ] 1.10 **STOP.** Report: files changed, tests added, pass/fail/skip counts,
+- [x] 1.8 Green: all new/parity unit suites + full `./tests/run-all.sh`
+- [x] 1.9 Commit — `refactor(planning): shared .STATUS/project accessors` (+ separate `test:` commit for the characterization/red suites if helpful for review)
+- [x] 1.10 **STOP.** Report: files changed, tests added, pass/fail/skip counts,
       parity-suite diff (should be none). Wait for the reviewer's go-ahead.
 
 **Key files:** `lib/core.zsh` (update), `commands/{morning,adhd,dash,capture,agenda}.zsh` (update), `lib/atlas-bridge.zsh` (update), `tests/test-status-field-parity.zsh` / `tests/test-status-field-accessor.zsh` / `tests/test-project-path-resolver.zsh` / `tests/test-suggest-project.zsh` (NEW)

--- a/ORCHESTRATE-planning-coordination.md
+++ b/ORCHESTRATE-planning-coordination.md
@@ -99,33 +99,38 @@ ships as tested, inert code (real atlas has no `agenda` command yet). Pin the
 proposed contract; leave `.STATUS`-ingestion mechanism as **atlas's own open
 question** (D4) — do not design it here.
 
-- [ ] 2.1 **Red tests first:** `tests/test-schedule-atlas-source.zsh`,
+- [x] 2.1 **Red tests first:** `tests/test-schedule-atlas-source.zsh`,
       `tests/e2e-agenda-atlas.zsh` (register in `run-all.sh`)
-- [ ] 2.2 Create `tests/fixtures/atlas-agenda-stub.json` — the atlas-present
+- [x] 2.2 Create `tests/fixtures/atlas-agenda-stub.json` — the atlas-present
       test fixture (canned `agenda --format json` response)
-- [ ] 2.3 Add `_schedule_atlas_items <window>` in `lib/schedule.zsh`;
+- [x] 2.3 Add `_schedule_atlas_items <window>` in `lib/schedule.zsh`;
       capability cache `_FLOW_ATLAS_HAS_AGENDA` (mirror `_FLOW_ATLAS_HAS_SCHEDULE`);
       call `_flow_atlas_json agenda "$window"`; map to
       `date|label|type|project|recurrence|source` with `source=atlas`
-- [ ] 2.4 Wire into `_schedule_collect` (`schedule.zsh:378`) alongside
+- [x] 2.4 Wire into `_schedule_collect` (`schedule.zsh:378`) alongside
       `_schedule_parse_status` + `_schedule_teach_items`; **no-op when absent**
-- [ ] 2.5 `at` dispatcher: `agenda` JSON passthrough in `lib/atlas-bridge.zsh`
-- [ ] 2.6 Extend `docs/ATLAS-CONTRACT.md`: proposed `atlas task list --format json` + `atlas agenda [today|week|--all] --format json`; bump contract version;
+- [x] 2.5 `at` dispatcher: `agenda` JSON passthrough in `lib/atlas-bridge.zsh`
+      — verified the generic `atlas "$@"` passthrough (already existing)
+      already handles `at agenda ... --format=json` correctly; no code change
+      needed, confirmed via a stub-atlas dogfood check
+- [x] 2.6 Extend `docs/ATLAS-CONTRACT.md`: proposed
+      `atlas agenda <window-days> --format json`; bump contract version;
       explicitly note `.STATUS`-ingestion as **atlas's open design question**,
       not prescribed here
-- [ ] 2.7 Extend `tests/test-atlas-contract.zsh`: assert the fixture
+- [x] 2.7 Extend `tests/test-atlas-contract.zsh`: assert the fixture
       (2.2)'s shape matches what the contract doc (2.6) documents — a
       contract edit without a fixture update must fail this test (D16)
-- [ ] 2.8 **Test both atlas states (D15):** absent via capability-flag
+- [x] 2.8 **Test both atlas states (D15):** absent via capability-flag
       override (`_FLOW_ATLAS_HAS_AGENDA` / `_flow_has_atlas`, NOT
       `FLOW_ATLAS_ENABLED=no` alone — env var is known-insufficient per memory
       `capture-real-agenda-output-for-docs`); present via a stub `atlas` shim
       on `PATH` returning the fixture
-- [ ] 2.9 Green: dependency + e2e + full integration
-      (`agenda-merged-sources.zsh` now with atlas third source, dedupe on
-      `date|label|project`, no double-count); full `./tests/run-all.sh`
-- [ ] 2.10 Commit — `feat(agenda): merge atlas agenda source into schedule engine (dark-ready)` (+ `docs(contract):` for ATLAS-CONTRACT)
-- [ ] 2.11 **STOP.** Report: files changed, tests added, pass/fail/skip counts,
+- [x] 2.9 Green: dependency + e2e + full integration (dedupe on
+      `date|label|project`, no double-count — new: `tests/integration/
+    agenda-merged-sources.zsh` didn't exist yet, so dedup coverage was
+      added as e2e-agenda-atlas.zsh Section 3 instead); full `./tests/run-all.sh`
+- [x] 2.10 Commit — `feat(agenda): merge atlas agenda source into schedule engine (dark-ready)` (+ `docs(contract):` for ATLAS-CONTRACT)
+- [x] 2.11 **STOP.** Report: files changed, tests added, pass/fail/skip counts,
       dogfood confirmation that no-atlas behavior is unchanged. Wait for the
       reviewer's go-ahead.
 

--- a/ORCHESTRATE-planning-coordination.md
+++ b/ORCHESTRATE-planning-coordination.md
@@ -127,7 +127,7 @@ question** (D4) — do not design it here.
       on `PATH` returning the fixture
 - [x] 2.9 Green: dependency + e2e + full integration (dedupe on
       `date|label|project`, no double-count — new: `tests/integration/
-  agenda-merged-sources.zsh` didn't exist yet, so dedup coverage was
+agenda-merged-sources.zsh` didn't exist yet, so dedup coverage was
       added as e2e-agenda-atlas.zsh Section 3 instead); full `./tests/run-all.sh`
 - [x] 2.10 Commit — `feat(agenda): merge atlas agenda source into schedule engine (dark-ready)` (+ `docs(contract):` for ATLAS-CONTRACT)
 - [x] 2.11 **STOP.** Report: files changed, tests added, pass/fail/skip counts,
@@ -163,20 +163,20 @@ question** (D4) — do not design it here.
 
 Per SPEC §6 — currency-check each file before editing; update genuine deltas only.
 
-- [ ] Guide — `docs/reference/MASTER-DISPATCHER-GUIDE.md` (atlas source + degradation)
-- [ ] Guide — `docs/guides/AGENDA-SCHEDULE-GUIDE.md` (data-source diagram + merged example w/ real captured output — memory `capture-real-agenda-output-for-docs`)
-- [ ] API ref — `docs/reference/MASTER-API-REFERENCE.md` (`_flow_status_field`, `_flow_resolve_project_path`, `_flow_suggest_project`, `_schedule_atlas_items`)
-- [ ] REFCARD — `docs/help/QUICK-REFERENCE.md` (agenda spans research + dev)
-- [ ] Contract — `docs/ATLAS-CONTRACT.md` version bump (done in Phase 2; verify)
-- [ ] `CONTRIBUTING.md` — note `.STATUS` template + warn-only `check-status.zsh`
-- [ ] CHANGELOG — `CHANGELOG.md` + `docs/CHANGELOG.md` `[Unreleased]`, **mirrored**
-- [ ] CLAUDE.md — refresh test-file/suite counts after new suites
-- [ ] Website — `mkdocs build --strict` 0 warnings (no nav change expected)
-- [ ] Hygiene — mark `docs/specs/SPEC-agenda-schedule-2026-06-13.md` **Implemented**
-- [ ] `/craft:docs:lint` clean
+- [x] Guide — `docs/reference/MASTER-DISPATCHER-GUIDE.md` (atlas source + degradation)
+- [x] Guide — `docs/guides/AGENDA-SCHEDULE-GUIDE.md` (data-source diagram + merged example w/ real captured output — memory `capture-real-agenda-output-for-docs`)
+- [x] API ref — `docs/reference/MASTER-API-REFERENCE.md` (`_flow_status_field`, `_flow_resolve_project_path`, `_flow_suggest_project`, `_schedule_atlas_items`)
+- [x] REFCARD — `docs/help/QUICK-REFERENCE.md` (agenda spans research + dev)
+- [x] Contract — `docs/ATLAS-CONTRACT.md` version bump (done in Phase 2; verified — v1.2.0, `atlas agenda` documented)
+- [x] `CONTRIBUTING.md` — note `.STATUS` template + warn-only `check-status.zsh`
+- [x] CHANGELOG — `CHANGELOG.md` + `docs/CHANGELOG.md` `[Unreleased]`, **mirrored**
+- [x] CLAUDE.md — refresh test-file/suite counts after new suites
+- [x] Website — `mkdocs build --strict` 0 warnings (no nav change expected)
+- [x] Hygiene — mark `docs/specs/SPEC-agenda-schedule-2026-06-13.md` **Implemented**
+- [x] `/craft:docs:lint` clean (scoped to files touched this phase — see report)
 - Demo — N/A (no new user-facing command surface; extends existing `agenda`)
 - Catalog/hub — N/A (no new command/skill/agent)
-- [ ] **STOP.** Report results. Wait for the reviewer's final go-ahead before any PR is opened (agent does NOT open the PR).
+- [x] **STOP.** Report results. Wait for the reviewer's final go-ahead before any PR is opened (agent does NOT open the PR).
 
 ## Friction Prevention
 

--- a/ORCHESTRATE-planning-coordination.md
+++ b/ORCHESTRATE-planning-coordination.md
@@ -1,0 +1,178 @@
+# planning-coordination — Orchestration Plan
+
+> **Branch:** `feature/planning-coordination`
+> **Base:** `dev`
+> **Worktree:** `~/.git-worktrees/flow-cli/feature-planning-coordination`
+> **Spec:** `docs/specs/SPEC-planning-coordination-2026-07-01.md`
+> **Brainstorm:** `docs/specs/BRAINSTORM-planning-coordination-2026-07-01.md`
+> **Version Target:** v7.14.0
+
+## Objective
+
+Refactor flow-cli's planning-command duplication (single `.STATUS` accessor,
+project-path resolver, project-suggester; fix the `$path`→`project_path` bug)
+and add an atlas-agenda source to the schedule engine so `agenda`/`dash`/
+`morning` surface research deadlines (atlas `Task.dueDate`) merged with the
+existing `.STATUS`/teaching schedule — graceful-degrading when atlas is absent.
+
+**Cross-repo:** atlas (Track B) and obsidian-cli-ops (Track D) are
+**contract-only** here (SPEC §7). Do NOT implement them in this worktree; they
+get their own specs. This worktree ships Tracks A + C.
+
+## Phase Overview
+
+| Phase | Increment | Priority | Effort | Status |
+|-------|-----------|----------|--------|--------|
+| 1 | Track A — internal refactor + bug fix | High | ~2-3h | |
+| 2 | Track C — atlas agenda source + contract | High | ~2-3h | |
+| 3 | Documentation & Discoverability | High | ~1-2h | |
+
+## Phase 1: Track A — flow-cli internal refactor + bug fix
+
+**Scope:** De-duplicate planning helpers onto shared accessors in `lib/core.zsh`;
+fix the confirmed `$path` bug; route `agenda` through the shared schedule engine.
+TDD — write the red unit tests first.
+
+- [ ] 1.1 **Red tests first:** `tests/test-status-field-accessor.zsh`,
+      `tests/test-project-path-resolver.zsh`, `tests/test-suggest-project.zsh`
+      (register in `tests/run-all.sh`)
+- [ ] 1.2 Add `_flow_status_field <root> <field>` to `lib/core.zsh`
+      (handles `## Field:` + `field:` dialects; strips `%`)
+- [ ] 1.3 Add `_flow_resolve_project_path <name>` — merges
+      `_dash_find_project_path` (`dash.zsh:1284`) + `_flow_get_project_fallback`
+      (`atlas-bridge.zsh:370`); **always emits `project_path=`**
+- [ ] 1.4 Add `_flow_suggest_project` — one active/priority scan replacing the 5
+      reimplementations (`dash.zsh:181`, `:1139`, `morning.zsh:144`, `adhd.zsh`
+      `next`, `js`)
+- [ ] 1.5 **Bug fix (G2):** `morning.zsh:83`, `adhd.zsh:103` — read
+      `$project_path` not `$path` (via the new resolver); restores broken
+      focus/progress/icon lookups
+- [ ] 1.6 Migrate call sites: `dash.zsh:1325`, `capture.zsh:406`,
+      `atlas-bridge.zsh:836` → `_flow_status_field`
+- [ ] 1.7 Route `agenda` (`agenda.zsh:62`) through `_schedule_window_records`
+      (`schedule.zsh:549`); keep `_schedule_classify` for bucketing
+- [ ] 1.8 Green: new unit suites + `tests/integration/agenda-merged-sources.zsh`
+      (STATUS+teach half); full `./tests/run-all.sh`
+
+**Key files:** `lib/core.zsh` (update), `commands/{morning,adhd,dash,capture,agenda}.zsh` (update), `lib/atlas-bridge.zsh` (update), `tests/test-status-field-accessor.zsh` / `tests/test-project-path-resolver.zsh` / `tests/test-suggest-project.zsh` (NEW)
+
+## Phase 2: Track C — atlas agenda source + contract
+
+**Scope:** New capability-probed schedule source that merges atlas records;
+pin the proposed atlas contract. TDD — red first.
+
+- [ ] 2.1 **Red tests first:** `tests/test-schedule-atlas-source.zsh`,
+      `tests/e2e-agenda-atlas.zsh` (register in `run-all.sh`)
+- [ ] 2.2 Add `_schedule_atlas_items <window>` in `lib/schedule.zsh`;
+      capability cache `_FLOW_ATLAS_HAS_AGENDA` (mirror `_FLOW_ATLAS_HAS_SCHEDULE`);
+      call `_flow_atlas_json agenda "$window"`; map to
+      `date|label|type|project|recurrence|source` with `source=atlas`
+- [ ] 2.3 Wire into `_schedule_collect` (`schedule.zsh:378`) alongside
+      `_schedule_parse_status` + `_schedule_teach_items`; **no-op when absent**
+- [ ] 2.4 `at` dispatcher: `agenda` JSON passthrough in `lib/atlas-bridge.zsh`
+- [ ] 2.5 Extend `docs/ATLAS-CONTRACT.md`: proposed `atlas task list --format json`
+      + `atlas agenda [today|week|--all] --format json`; bump contract version;
+      extend `tests/test-atlas-contract.zsh`
+- [ ] 2.6 Green: dependency + e2e + full integration
+      (`agenda-merged-sources.zsh` now with atlas third source, dedupe on
+      `date|label|project`, no double-count)
+
+**Key files:** `lib/schedule.zsh` (update), `lib/atlas-bridge.zsh` (update), `docs/ATLAS-CONTRACT.md` (update), `tests/test-schedule-atlas-source.zsh` / `tests/e2e-agenda-atlas.zsh` (NEW), `tests/test-atlas-contract.zsh` / `tests/integration/agenda-merged-sources.zsh` (extend)
+
+## Documentation & Discoverability (REQUIRED — final phase)
+
+Per SPEC §6 — currency-check each file before editing; update genuine deltas only.
+
+- [ ] Guide — `docs/reference/MASTER-DISPATCHER-GUIDE.md` (atlas source + degradation)
+- [ ] Guide — `docs/guides/AGENDA-SCHEDULE-GUIDE.md` (data-source diagram + merged example w/ real captured output — memory `capture-real-agenda-output-for-docs`)
+- [ ] API ref — `docs/reference/MASTER-API-REFERENCE.md` (`_flow_status_field`, `_flow_resolve_project_path`, `_flow_suggest_project`, `_schedule_atlas_items`)
+- [ ] REFCARD — `docs/help/QUICK-REFERENCE.md` (agenda spans research + dev)
+- [ ] Contract — `docs/ATLAS-CONTRACT.md` version bump (done in Phase 2; verify)
+- [ ] CHANGELOG — `CHANGELOG.md` + `docs/CHANGELOG.md` `[Unreleased]`, **mirrored**
+- [ ] CLAUDE.md — refresh test-file/suite counts after new suites
+- [ ] Website — `mkdocs build --strict` 0 warnings (no nav change expected)
+- [ ] Hygiene — mark `docs/specs/SPEC-agenda-schedule-2026-06-13.md` **Implemented**
+- [ ] `/craft:docs:lint` clean
+- Demo — N/A (no new user-facing command surface; extends existing `agenda`)
+- Catalog/hub — N/A (no new command/skill/agent)
+
+## Friction Prevention
+
+- **Context first:** read this ORCHESTRATE file + the SPEC before any edit.
+- **Verify location:** `git worktree list` + `pwd` — confirm you are in the
+  worktree, not the main repo. Branch must be `feature/planning-coordination`.
+- **No new code files on dev:** all code lands here on the feature branch.
+- **Red-first:** every new test starts failing; carry
+  `# TODO(author): delete if not contract-bearing` until the contract is confirmed.
+- **Graceful degradation is a hard requirement:** Track C must be a silent
+  no-op with no/older atlas — prove it (dogfood with atlas disabled).
+- **STOP after each phase** and confirm before proceeding.
+- Portability (memory `macos-only-shell-isms-break-linux-ci`): no `sed -i ''`,
+  `stat -f`, `date -j`, `exec {var}>`; POSIX-portable for Linux CI.
+
+## Acceptance Criteria (SPEC §8)
+
+- [ ] `source flow.plugin.zsh` — clean load, no errors
+- [ ] `./tests/run-all.sh` — green (1 expected interactive/tmux timeout); new suites pass; CLAUDE.md counts updated
+- [ ] Dogfood **no atlas**: `agenda`/`dash`/`morning` identical to pre-change (degradation proven)
+- [ ] Dogfood **stub atlas agenda**: research deadlines merged; `$path` fix restores focus/progress
+- [ ] `mkdocs build --strict` — 0 warnings
+- [ ] `/craft:docs:lint` clean
+- [ ] Documentation & Discoverability phase complete
+
+## Commit Strategy
+
+- Phase 1: `refactor(planning): shared .STATUS/project accessors + $path bug fix` (+ `test:` for red suites)
+- Phase 2: `feat(agenda): merge atlas agenda source into schedule engine` (+ `docs(contract):` for ATLAS-CONTRACT)
+- Phase 3: `docs(planning): agenda/dispatcher/API guides + CHANGELOG`
+
+## Verification (after each phase)
+
+```bash
+cd ~/.git-worktrees/flow-cli/feature-planning-coordination
+source flow.plugin.zsh          # clean load
+./tests/run-all.sh              # full suite
+mkdocs build --strict           # docs (Phase 3)
+```
+
+## Integrate (after all phases)
+
+```bash
+git fetch origin dev && git rebase origin/dev
+./tests/run-all.sh
+gh pr create --base dev
+# after merge: git worktree remove ~/.git-worktrees/flow-cli/feature-planning-coordination
+# delete ORCHESTRATE-planning-coordination.md as part of merge cleanup
+```
+
+## Session Instructions
+
+### Context
+
+You are in the **flow-cli repo worktree** for the `planning-coordination`
+feature. The SPEC (`docs/specs/SPEC-planning-coordination-2026-07-01.md`) has
+full design details; the BRAINSTORM has the ecosystem rationale. Tracks B/D are
+out of scope — contract-only.
+
+### How to Start
+
+```bash
+cd ~/.git-worktrees/flow-cli/feature-planning-coordination
+claude
+```
+
+On session start, paste:
+
+> Read `ORCHESTRATE-planning-coordination.md` and the spec at
+> `docs/specs/SPEC-planning-coordination-2026-07-01.md`. Confirm you are in the
+> worktree (`git worktree list`, `pwd`, branch = `feature/planning-coordination`).
+> Then start **Phase 1** using TDD (red tests first). STOP and confirm after
+> each phase before proceeding.
+
+### Phase-by-Phase
+
+1. Read the current state of each file listed in the phase.
+2. Write the red tests first, then implement per the SPEC design.
+3. Run `./tests/run-all.sh` after each phase.
+4. Commit in logical groups (see Commit Strategy).
+5. STOP and confirm before the next phase.

--- a/ORCHESTRATE-planning-coordination.md
+++ b/ORCHESTRATE-planning-coordination.md
@@ -60,7 +60,7 @@ even if you believe tests pass.
 route `agenda` through the shared schedule engine. TDD — characterization tests
 BEFORE any consolidation, then red unit tests for the new accessors.
 
-- [ ] 1.0 **Characterization tests first (Axis 2 — parity guard):**
+- [x] 1.0 **Characterization tests first (Axis 2 — parity guard):**
       `tests/test-status-field-parity.zsh` — snapshot the CURRENT output of
       `_dash_get_status_field` (`dash.zsh:1325`), the inline greps
       (`morning.zsh:84`, `adhd.zsh:104`, `capture.zsh:406`), and

--- a/ORCHESTRATE-planning-coordination.md
+++ b/ORCHESTRATE-planning-coordination.md
@@ -127,7 +127,7 @@ question** (D4) — do not design it here.
       on `PATH` returning the fixture
 - [x] 2.9 Green: dependency + e2e + full integration (dedupe on
       `date|label|project`, no double-count — new: `tests/integration/
-    agenda-merged-sources.zsh` didn't exist yet, so dedup coverage was
+  agenda-merged-sources.zsh` didn't exist yet, so dedup coverage was
       added as e2e-agenda-atlas.zsh Section 3 instead); full `./tests/run-all.sh`
 - [x] 2.10 Commit — `feat(agenda): merge atlas agenda source into schedule engine (dark-ready)` (+ `docs(contract):` for ATLAS-CONTRACT)
 - [x] 2.11 **STOP.** Report: files changed, tests added, pass/fail/skip counts,
@@ -140,22 +140,22 @@ question** (D4) — do not design it here.
 
 **Scope:** flow-cli-scoped only — NOT an ecosystem-wide standard.
 
-- [ ] 3.1 **Red test first:** `tests/test-status-schema.zsh`
-- [ ] 3.2 Write `templates/.STATUS.template` — canonical structure + inline
+- [x] 3.1 **Red test first:** `tests/test-status-schema.zsh`
+- [x] 3.2 Write `templates/.STATUS.template` — canonical structure + inline
       comments (header fields, `## Schedule:` grammar, `## daily_goal:`,
       `## Active Worktrees`, session-log convention; documents the dual
       dialect `_flow_status_field` supports)
-- [ ] 3.3 Write `scripts/check-status.zsh` (model: `scripts/check-math.zsh`) —
+- [x] 3.3 Write `scripts/check-status.zsh` (model: `scripts/check-math.zsh`) —
       validates required fields, `Progress` int 0–100, `Schedule` grammar,
       `Status` in allowed set. **exit 0 always (warn-only, D11)** — print
       violations, never block
-- [ ] 3.4 Wire into `lint-staged`: extensionless `.STATUS` filename match
+- [x] 3.4 Wire into `lint-staged`: extensionless `.STATUS` filename match
       (not a glob) alongside the `check-math.zsh` entry
-- [ ] 3.5 Green: `check-status.zsh` rejects (prints, doesn't block) a
+- [x] 3.5 Green: `check-status.zsh` rejects (prints, doesn't block) a
       malformed fixture; passes clean on the template and on flow-cli's own
       `.STATUS`; full `./tests/run-all.sh`
-- [ ] 3.6 Commit — `feat(status): add .STATUS template + warn-only schema enforcer`
-- [ ] 3.7 **STOP.** Report results. Wait for the reviewer's go-ahead.
+- [x] 3.6 Commit — `feat(status): add .STATUS template + warn-only schema enforcer`
+- [x] 3.7 **STOP.** Report results. Wait for the reviewer's go-ahead.
 
 **Key files:** `templates/.STATUS.template` (NEW), `scripts/check-status.zsh` (NEW), `package.json` (lint-staged entry), `tests/test-status-schema.zsh` (NEW)
 

--- a/commands/adhd.zsh
+++ b/commands/adhd.zsh
@@ -100,12 +100,12 @@ next() {
 
     if [[ -n "$info" ]]; then
       eval "$info"
-      if [[ -n "$path" ]] && [[ -f "$path/.STATUS" ]]; then
-        focus=$(command grep -m1 "^## Focus:" "$path/.STATUS" 2>/dev/null | command cut -d: -f2- | sed 's/^ *//')
+      if [[ -n "$project_path" ]] && [[ -f "$project_path/.STATUS" ]]; then
+        focus=$(command grep -m1 "^## Focus:" "$project_path/.STATUS" 2>/dev/null | command cut -d: -f2- | sed 's/^ *//')
       fi
     fi
 
-    local icon=$(_flow_project_icon "$(_flow_detect_project_type "$path" 2>/dev/null)")
+    local icon=$(_flow_project_icon "$(_flow_detect_project_type "$project_path" 2>/dev/null)")
     printf "  %s %-15s" "$icon" "$project"
     [[ -n "$focus" ]] && printf " → %s" "$focus"
     echo ""

--- a/commands/adhd.zsh
+++ b/commands/adhd.zsh
@@ -33,8 +33,8 @@ js() {
     fi
     
     if [[ -z "$project" ]]; then
-      # Fallback: pick randomly from active projects
-      project=$(echo "$projects" | sort -R | head -1)
+      # Fallback: pick randomly from active projects (shared scan, lib/core.zsh)
+      project=$(_flow_suggest_project random-active)
     fi
   fi
   
@@ -101,7 +101,7 @@ next() {
     if [[ -n "$info" ]]; then
       eval "$info"
       if [[ -n "$project_path" ]] && [[ -f "$project_path/.STATUS" ]]; then
-        focus=$(command grep -m1 "^## Focus:" "$project_path/.STATUS" 2>/dev/null | command cut -d: -f2- | sed 's/^ *//')
+        focus=$(_flow_status_field "$project_path" "Focus")
       fi
     fi
 

--- a/commands/agenda.zsh
+++ b/commands/agenda.zsh
@@ -57,14 +57,11 @@ agenda() {
       ;;
   esac
 
-  # Pipeline: collect -> window filter -> sort
+  # Pipeline: routed through the shared surface pipeline (_schedule_window_records,
+  # schedule.zsh) so collect -> window-filter -> sort -> holiday-drop logic
+  # lives once (SPEC §3.3). Holidays are noise unless explicitly requested (--all).
   local records
-  records=$(_schedule_collect "$window" "$category" | _schedule_filter_window "$window" | _schedule_sort)
-
-  # Holidays are noise unless explicitly requested (--all)
-  if (( ! show_all )) && [[ -n "$records" ]]; then
-    records=$(print -r -- "$records" | _schedule_drop_holidays)
-  fi
+  records=$(_schedule_window_records "$window" "$category" "$show_all")
 
   # Bucketize (THIS WEEK vs LATER split on the fixed 7-day horizon)
   local -a b_overdue=() b_today=() b_week=() b_later=()

--- a/commands/capture.zsh
+++ b/commands/capture.zsh
@@ -399,11 +399,13 @@ _flow_read_goal() {
   local today=$(_flow_today)
 
   # First: Check project .STATUS for daily_goal (v3.5.0)
+  # Reads via the shared accessor (_flow_status_field, lib/core.zsh); note
+  # this drops the old case-insensitive grep -i — every real .STATUS uses
+  # lowercase "## daily_goal:" (templates/docs), so this is not load-bearing.
   if _flow_in_project; then
     local root=$(_flow_find_project_root)
-    local status_file="$root/.STATUS"
-    if [[ -f "$status_file" ]]; then
-      local project_goal=$(command grep -i "^## daily_goal:" "$status_file" 2>/dev/null | head -1 | sed 's/^## [^:]*: *//')
+    if [[ -f "$root/.STATUS" ]]; then
+      local project_goal=$(_flow_status_field "$root" "daily_goal")
       if [[ -n "$project_goal" ]] && [[ "$project_goal" =~ ^[0-9]+$ ]]; then
         echo "$project_goal"
         return

--- a/commands/dash.zsh
+++ b/commands/dash.zsh
@@ -228,51 +228,30 @@ _dash_right_now() {
     suggestion="Keep going on"
     suggested_project="$current_project"
   else
-    # Not working - suggest starting
-    # Find first active project with a focus/next item
-    local projects=$(_flow_list_projects)
+    # Not working - suggest starting. Shared scan (_flow_suggest_project,
+    # lib/core.zsh): prefer an active project that has a Focus, falling back
+    # to any active project.
     local found=0
-    
-    while IFS= read -r project; do
-      [[ -z "$project" ]] && continue
-      
-      local proj_path=$(_dash_find_project_path "$project")
-      if [[ -n "$proj_path" ]] && [[ -f "$proj_path/.STATUS" ]]; then
-        local proj_status=$(_dash_get_project_status "$proj_path/.STATUS")
-        if [[ "$proj_status" == "active" ]]; then
-          local focus=$(_dash_get_project_focus "$proj_path/.STATUS")
-          if [[ -n "$focus" ]]; then
-            suggested_project="$project"
-            next_action="$focus"
-            found=1
-            break
-          fi
-        fi
+    local suggested=$(_flow_suggest_project active-with-focus)
+    if [[ -n "$suggested" ]]; then
+      suggested_project="$suggested"
+      local resolved project_path
+      resolved=$(_flow_resolve_project_path "$suggested_project")
+      eval "$resolved"
+      next_action=$(_dash_get_project_focus "$project_path/.STATUS")
+      found=1
+    else
+      suggested=$(_flow_suggest_project active)
+      if [[ -n "$suggested" ]]; then
+        suggested_project="$suggested"
+        found=1
       fi
-    done <<< "$projects"
-    
+    fi
+
     if (( found )); then
       suggestion="Start work on"
     else
-      # No active project with focus - suggest first active
-      while IFS= read -r project; do
-        [[ -z "$project" ]] && continue
-        local proj_path=$(_dash_find_project_path "$project")
-        if [[ -n "$proj_path" ]] && [[ -f "$proj_path/.STATUS" ]]; then
-          local proj_status=$(_dash_get_project_status "$proj_path/.STATUS")
-          if [[ "$proj_status" == "active" ]]; then
-            suggested_project="$project"
-            found=1
-            break
-          fi
-        fi
-      done <<< "$projects"
-      
-      if (( found )); then
-        suggestion="Start work on"
-      else
-        suggestion="No active projects"
-      fi
+      suggestion="No active projects"
     fi
   fi
   
@@ -1170,21 +1149,9 @@ _dash_footer() {
   if [[ -n "$current_project" ]]; then
     suggestion="💡 Type 'finish' when done  •  'dash -i' to switch  •  'h' for help"
   else
-    # Find first active project to suggest
-    local projects=$(_flow_list_projects)
-    local suggested=""
-    while IFS= read -r project; do
-      [[ -z "$project" ]] && continue
-      local proj_path=$(_dash_find_project_path "$project")
-      if [[ -n "$proj_path" ]] && [[ -f "$proj_path/.STATUS" ]]; then
-        local proj_status=$(_dash_get_project_status "$proj_path/.STATUS")
-        if [[ "$proj_status" == "active" ]]; then
-          suggested="$project"
-          break
-        fi
-      fi
-    done <<< "$projects"
-    
+    # Find first active project to suggest (shared scan, lib/core.zsh)
+    local suggested=$(_flow_suggest_project active)
+
     if [[ -n "$suggested" ]]; then
       suggestion="💡 Try: 'work $suggested' to start  •  'dash -i' for picker  •  'h' for help"
     else
@@ -1280,29 +1247,16 @@ ${_C_DIM}See also:${_C_NC} work help, status help, pick help
 # HELPERS
 # ============================================================================
 
-# Find project path by name
+# Find project path by name — delegates to the shared resolver
+# (_flow_resolve_project_path, lib/core.zsh) which merges this function's
+# original taxonomy with _flow_get_project_fallback's. Kept as a thin
+# wrapper so the ~10 internal callers in this file don't need to change.
 _dash_find_project_path() {
   local name="$1"
-  local search_dirs=(
-    "$FLOW_PROJECTS_ROOT/dev-tools"
-    "$FLOW_PROJECTS_ROOT/apps"
-    "$FLOW_PROJECTS_ROOT/r-packages/active"
-    "$FLOW_PROJECTS_ROOT/r-packages/stable"
-    "$FLOW_PROJECTS_ROOT/research"
-    "$FLOW_PROJECTS_ROOT/teaching"
-    "$FLOW_PROJECTS_ROOT/quarto/manuscripts"
-    "$FLOW_PROJECTS_ROOT/quarto/presentations"
-    "$FLOW_PROJECTS_ROOT"
-  )
-
-  for dir in "${search_dirs[@]}"; do
-    if [[ -d "$dir/$name" ]]; then
-      echo "$dir/$name"
-      return 0
-    fi
-  done
-
-  return 1
+  local resolved project_path
+  resolved=$(_flow_resolve_project_path "$name") || return 1
+  eval "$resolved"
+  echo "$project_path"
 }
 
 # Detect category from path
@@ -1320,45 +1274,15 @@ _dash_detect_category() {
   esac
 }
 
-# Parse .STATUS field (supports both "## Field:" and "field:" formats)
-# Uses ZSH builtins only - no external commands
+# Parse .STATUS field (supports both "## Field:" and "field:" formats).
+# Delegates to the shared accessor (_flow_status_field, lib/core.zsh), which
+# takes a project ROOT rather than a full file path — this wrapper adapts so
+# the ~15 internal callers passing "$proj_path/.STATUS" don't need to change.
 _dash_get_status_field() {
   local file="$1"
   local field="$2"
-  local value="" line
-
-  [[ ! -f "$file" ]] && return 1
-
-  # Read file and find matching line
-  while IFS= read -r line; do
-    # Try markdown format (## Field:)
-    if [[ "$line" == "## ${field}:"* ]]; then
-      value="${line#*: }"  # Remove everything up to ": "
-      value="${value#"${value%%[![:space:]]*}"}"  # Trim leading whitespace
-      break
-    fi
-    # Try YAML format (field:)
-    if [[ "$line" == "${field}:"* ]]; then
-      value="${line#*: }"
-      value="${value#"${value%%[![:space:]]*}"}"
-      break
-    fi
-  done < "$file"
-
-  # Normalize status values
-  if [[ "$field" == "Status" || "$field" == "status" ]]; then
-    value="${value:l}"      # ZSH: lowercase
-    value="${value// /}"    # ZSH: remove spaces
-    # Map variations
-    case "$value" in
-      underreview) value="active" ;;
-      inprogress) value="active" ;;
-      wip) value="active" ;;
-      onhold) value="paused" ;;
-    esac
-  fi
-
-  echo "$value"
+  local root="${file%/.STATUS}"
+  _flow_status_field "$root" "$field"
 }
 
 # Get project status

--- a/commands/morning.zsh
+++ b/commands/morning.zsh
@@ -81,8 +81,8 @@ _flow_morning_projects() {
     if [[ -n "$info" ]]; then
       eval "$info"
       if [[ -n "$project_path" ]] && [[ -f "$project_path/.STATUS" ]]; then
-        focus=$(grep -m1 "^## Focus:" "$project_path/.STATUS" 2>/dev/null | cut -d: -f2- | sed 's/^ *//')
-        progress=$(grep -m1 "^## Progress:" "$project_path/.STATUS" 2>/dev/null | cut -d: -f2- | sed 's/^ *//' | tr -d '%')
+        focus=$(_flow_status_field "$project_path" "Focus")
+        progress=$(_flow_status_field "$project_path" "Progress" | tr -d '%')
       fi
     fi
 
@@ -151,17 +151,8 @@ _flow_morning_suggest() {
   if _flow_has_atlas; then
     suggestion=$(_flow_atlas project list --status=active --format=names 2>/dev/null | head -1)
   else
-    # Find priority project from filesystem
-    for status_file in "$FLOW_PROJECTS_ROOT"/**/.STATUS(N); do
-      local status=$(grep -m1 "^## Status:" "$status_file" | cut -d: -f2 | tr -d ' ' | tr '[:upper:]' '[:lower:]')
-      local priority=$(grep -m1 "^## Priority:" "$status_file" | cut -d: -f2 | tr -d ' ')
-      
-      if [[ "$status" == "active" ]] && [[ "$priority" == "1" || "$priority" == "P1" ]]; then
-        local dir="${status_file:h}"
-        suggestion="${dir:t}"
-        break
-      fi
-    done
+    # Find priority project (shared scan, lib/core.zsh — P1/priority 1)
+    suggestion=$(_flow_suggest_project priority)
   fi
   
   if [[ -n "$suggestion" ]]; then

--- a/commands/morning.zsh
+++ b/commands/morning.zsh
@@ -80,13 +80,13 @@ _flow_morning_projects() {
     
     if [[ -n "$info" ]]; then
       eval "$info"
-      if [[ -n "$path" ]] && [[ -f "$path/.STATUS" ]]; then
-        focus=$(grep -m1 "^## Focus:" "$path/.STATUS" 2>/dev/null | cut -d: -f2- | sed 's/^ *//')
-        progress=$(grep -m1 "^## Progress:" "$path/.STATUS" 2>/dev/null | cut -d: -f2- | sed 's/^ *//' | tr -d '%')
+      if [[ -n "$project_path" ]] && [[ -f "$project_path/.STATUS" ]]; then
+        focus=$(grep -m1 "^## Focus:" "$project_path/.STATUS" 2>/dev/null | cut -d: -f2- | sed 's/^ *//')
+        progress=$(grep -m1 "^## Progress:" "$project_path/.STATUS" 2>/dev/null | cut -d: -f2- | sed 's/^ *//' | tr -d '%')
       fi
     fi
-    
-    local icon=$(_flow_project_icon "$(_flow_detect_project_type "$path" 2>/dev/null)")
+
+    local icon=$(_flow_project_icon "$(_flow_detect_project_type "$project_path" 2>/dev/null)")
     
     printf "     %s %-15s" "$icon" "$project"
     [[ -n "$progress" ]] && printf " [%3d%%]" "$progress"

--- a/docs/ATLAS-CONTRACT.md
+++ b/docs/ATLAS-CONTRACT.md
@@ -1,7 +1,7 @@
 # Atlas CLI API Contract
 
-**Version:** 1.1.0
-**Parties:** flow-cli (v7.10.x) <-> Atlas CLI `@data-wise/atlas` (v0.9.3)
+**Version:** 1.2.0
+**Parties:** flow-cli (v7.14.x) <-> Atlas CLI `@data-wise/atlas` (v0.9.3+, `agenda` proposed)
 **Status:** Active
 
 ---
@@ -10,6 +10,7 @@
 
 | flow-cli | Atlas CLI | Notes |
 |----------|-----------|-------|
+| v7.14.x  | v0.9.3+   | Contract v1.2 — adds the *proposed* `atlas agenda` opportunistic read source (Track C, dark-ready — see below). No atlas release implements it yet; flow-cli ships this as tested, capability-probed, inert code. |
 | v7.10.x  | v0.9.3    | Contract v1.1 — 5 new integration flags (`session status --format`, `project list --count`, `project list --suggest`, `inbox --count`, `trail --limit`) |
 | v7.4.x   | v0.9.x    | Contract v1.0 — original contract |
 | v7.3.x   | v0.8.x    | Legacy — no `crumb` command |
@@ -63,6 +64,63 @@ the data model and degrades fully without atlas.
 | Command | Description | Direction |
 |---------|-------------|-----------|
 | `atlas schedule push --format=json --data=<json>` | Ingest forward-looking dated items | flow-cli → atlas |
+| `atlas agenda <window-days> --format=json` | Read atlas-tracked deadlines (`Task.dueDate`) for a window | atlas → flow-cli |
+
+### `atlas agenda` (proposed, dark this cycle — Track C)
+
+The schedule engine (`lib/schedule.zsh`) merges a third source into
+`_schedule_collect` alongside `.STATUS` `## Schedule:` blocks and
+`.flow/teach-config.yml`: atlas-tracked deadlines (research tasks, grant
+reports, anything atlas's own `Task.dueDate` model tracks) that don't live in
+a project's `.STATUS` file at all.
+
+**Capability probe.** flow-cli runs `atlas agenda --help` once per session and
+caches the result (`_FLOW_ATLAS_HAS_AGENDA`, mirroring `_FLOW_ATLAS_HAS_SCHEDULE`).
+If atlas is absent, or present but lacks an `agenda` subcommand,
+`_schedule_atlas_items` returns nothing and the engine falls back to
+`.STATUS` + teach-config only — **no behavior change without atlas**.
+
+**Call.** `_flow_atlas_json agenda "$window"` — `$window` is the same
+look-ahead window (in days) the engine itself uses (`SCHEDULE_DEFAULT_WINDOW`,
+0/7/30/3650), passed positionally. `_flow_atlas_json` appends `--format=json`.
+
+**Response.** A JSON array of records — atlas does NOT include a `source`
+field; flow-cli's mapping (`_schedule_atlas_items`) stamps `source=atlas` on
+every record it ingests, same idea as `status`/`teach-config` tagging their
+own origin:
+
+```json
+[
+  {"date":"2026-07-05","label":"Submit grant report","type":"research","project":"grant-writing","recurrence":"none"},
+  {"date":"2026-07-12","label":"NIH progress report","type":"research","project":"grant-writing","recurrence":"none"}
+]
+```
+
+| Field | Meaning |
+|-------|---------|
+| `date` | ISO `YYYY-MM-DD` |
+| `label` | Human text |
+| `type` | `teaching` · `research` · `general` · `recurring` · `holiday` |
+| `project` | Project name (flow-cli maps this to a local path the same way as any other project) |
+| `recurrence` | `none` or `weekly:<dow>` |
+
+Mapped into the engine's internal `date\|label\|type\|project\|recurrence\|source`
+record shape with `source` hardcoded to `atlas` during mapping (not read from
+the JSON). Deduped against `.STATUS`/teach-config records downstream on
+`(date, label, project)` like any other source — no special-casing.
+
+**Out of scope here (atlas's own open question).** How atlas populates
+`Task.dueDate` in the first place — whether it ever reads `.STATUS`
+`## Schedule:` blocks itself, imports from somewhere else, or is purely
+user-entered — is entirely atlas's design space. This contract only pins the
+**read interface** flow-cli calls; it does not prescribe atlas's ingestion
+mechanism.
+
+**Deliberately dark this cycle.** No atlas release implements `agenda` yet
+(Track B, tracked separately). flow-cli ships this as tested, capability-
+probed, inert code — same posture `schedule push` shipped with. Zero user-
+visible payoff until atlas's `agenda` command exists; zero rework required
+when it does, beyond flipping the capability probe to "yes".
 
 ### `atlas schedule push` (proposed)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
   org installation, and exchanges for a `ghs_` token. Supports `--org`,
   `--dry-run`, and `--verbose` flags. Interactive `tok mint setup` wizard for
   one-time credential storage ([#479](https://github.com/Data-Wise/flow-cli/issues/479)).
+- **Shared `.STATUS`/project accessors** (`lib/core.zsh`): `_flow_status_field`, `_flow_resolve_project_path`, `_flow_suggest_project` — replace 4 divergent `.STATUS` field readers, 2 project-path resolvers, and 5 project-suggestion scans with one implementation each, guarded by a byte-parity characterization suite. `dash`, `morning`, `next`, `capture`, and `agenda` now share the same accessors instead of reimplementing them.
+- **Atlas agenda source, dark-ready** (`lib/schedule.zsh`): `_schedule_atlas_items` — a third, capability-probed schedule source (alongside `.STATUS` `## Schedule:` blocks and teach-config) that will surface atlas-tracked deadlines (`Task.dueDate`) once atlas ships an `agenda` command. Ships as tested, inert code — no atlas release implements it yet, so this is a silent no-op today. See `docs/ATLAS-CONTRACT.md` (`atlas agenda`, proposed).
+- **`agenda` routed through the shared schedule pipeline** (`lib/schedule.zsh`, `commands/agenda.zsh`): `_schedule_window_records` gained `category`/`keep_holidays` parameters so `agenda`'s collect→filter→sort→holiday-drop chain is now the same shared pipeline `dash`/`morning`/`today`/`week` already use. Added a `(date, label, project)` dedupe pass — the first duplicate-possible scenario now that a third source exists.
+- **`.STATUS` template + warn-only schema checker**: `templates/.STATUS.template` documents the canonical `.STATUS` shape (header fields, `## Schedule:` grammar, `## daily_goal:`, `## Active Worktrees`, session-log convention); `scripts/check-status.zsh` validates it as a warn-only `lint-staged` pre-commit check (prints violations, never blocks — flow-cli-scoped, not an ecosystem standard).
 
 ### Fixed
 
@@ -27,6 +31,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 - **Broken link** (`docs/guides/EMAIL-DISPATCHER-GUIDE.md`): removed References entry linking to `internal/EM-V2-ARCHITECTURE.md` which is excluded from the site
 - **CONTRIBUTING.md deploy instruction**: replaced incorrect `mkdocs gh-deploy --force` step with note that docs auto-deploy via CI (manual deploy is blocked by branch guard)
 - **DOCUMENTATION-STYLE-GUIDE.md**: updated `--strict` link-check reference to `mkdocs build` (validation block replaces `--strict`); added MkDocs Configuration section documenting breadcrumbs, `not_in_nav`, `exclude` plugin, and the fnmatch footgun
+- **`$path` → `$project_path` bug** (`commands/morning.zsh`, `commands/adhd.zsh`): `next`/`morning` read ZSH's PATH-tied `$path` array instead of the `project_path` field the project resolver actually emits — `.STATUS` focus/progress and the project-type icon were silently blank or wrong for every project with nonzero progress. Landed as an isolated pre-step ahead of the shared-accessor refactor above.
+- **`_flow_where_fallback` crash** (`lib/atlas-bridge.zsh`): `local status=...` crashed (`status` is a zsh read-only special variable, even as a function-local) — `at where` never actually printed `Status:`/`Focus:`. Fixed as an unavoidable side effect of the shared-accessor migration above.
+
 ## [7.13.0] — 2026-06-19 — flow claude: C7-C11 checks + watch daemon
 
 ### Added

--- a/docs/guides/AGENDA-SCHEDULE-GUIDE.md
+++ b/docs/guides/AGENDA-SCHEDULE-GUIDE.md
@@ -83,6 +83,23 @@ is due:
 
 ## Where items come from
 
+Three sources feed the same engine and are merged, deduped, and rendered
+identically no matter which surface you're looking at:
+
+```mermaid
+flowchart LR
+    A["📄 .STATUS<br/>## Schedule: blocks<br/>(no yq needed)"] --> E
+    B["🎓 .flow/teach-config.yml<br/>teaching dates<br/>(needs yq)"] --> E
+    C["☁️ atlas agenda<br/>Task.dueDate<br/>(dark-ready — no atlas<br/>release implements it yet)"] -.->|"silent no-op<br/>without atlas"| E
+    E["_schedule_collect<br/>(lib/schedule.zsh)"] --> F["dedupe on<br/>(date, label, project)"]
+    F --> G["agenda / dash UPCOMING /<br/>morning / today / week"]
+```
+
+The dotted line marks the atlas source as **optional and currently inert** —
+see [Atlas integration](#atlas-integration-optional-dark-ready) below. The
+other two sources work fully without atlas and without `yq` (the teaching
+path is the only one that needs `yq`; it's skipped gracefully when absent).
+
 ### 1. `## Schedule:` in a project's `.STATUS` (no `yq` needed)
 
 Add a `## Schedule:` section to any project's `.STATUS` file:
@@ -126,6 +143,16 @@ agenda still works, the teaching items are just skipped.
     that only has `weeks[].date` yields no week items.
 
 Holidays are typed `holiday` and hidden unless you pass `--all`.
+
+### 3. Atlas-tracked deadlines (dark-ready, optional)
+
+A third source, `_schedule_atlas_items` (`lib/schedule.zsh`), reads
+atlas-tracked deadlines (`Task.dueDate`) — things you track in atlas rather
+than in a project's `.STATUS`. See
+[Atlas integration](#atlas-integration-optional-dark-ready) below for details
+and a real merged example. **No atlas release implements this yet** — until
+it does, this source is a silent no-op and changes nothing about the two
+sources above.
 
 ---
 
@@ -192,13 +219,64 @@ each command answers.
 
 ---
 
-## Atlas integration (optional)
+## Atlas integration (optional, dark-ready)
+
+Atlas integration is two independent, opportunistic paths — a push (flow-cli
+→ atlas, shipped) and a read (atlas → flow-cli, dark-ready as of v7.14.0).
+Both degrade to a silent no-op without atlas; neither is required for
+`agenda` to work.
+
+### Push: flow-cli → atlas (shipped)
 
 When atlas is installed **and** exposes a `schedule` subcommand, `agenda` pushes
 the collected items opportunistically and asynchronously
 (`atlas schedule push --format=json`). When atlas is absent — or present but
 without that subcommand — the push is a silent no-op. flow-cli owns the model;
-atlas is just a sync target. See [ATLAS-CONTRACT](../ATLAS-CONTRACT.md).
+atlas is just a sync target.
+
+### Read: atlas → flow-cli (dark-ready, v7.14.0)
+
+`_schedule_atlas_items` (source #3 above) reads atlas-tracked deadlines back
+into the engine via `atlas agenda <window-days> --format=json`, probed once per
+session (`atlas agenda --help`) and cached. **No atlas release implements
+`agenda` yet** — real atlas doesn't have the command, so this ships as tested,
+capability-probed, inert code. Zero user-visible change until atlas ships it;
+zero rework required here when it does.
+
+Below is a real captured run (not a fabricated transcript) against a stub
+`atlas` returning one deadline, merged alongside a `.STATUS` Schedule item and
+a teaching week — this is what it looks like once atlas *does* implement
+`agenda`:
+
+```text
+$ agenda -m
+
+  📅 AGENDA (next 30 days)
+
+  THIS WEEK (4)
+  🔁 in 2d       Grading window (manuscript-x)
+  🔬 in 4d       Submit JRSS-B revision (manuscript-x)
+  🎓 in 5d       Week 1 (stat-101)
+  🔬 in 7d       NIH progress report (manuscript-x)
+
+  LATER (4)
+  🔁 in 9d       Grading window (manuscript-x)
+  🔁 in 16d      Grading window (manuscript-x)
+  🔁 in 23d      Grading window (manuscript-x)
+  🔁 in 30d      Grading window (manuscript-x)
+
+  8 items • 'agenda -h' for options
+```
+
+"NIH progress report" is the only atlas-sourced item (`🔬`, same research
+icon as any other research-typed record — the source is invisible to the
+rendered output, by design). "Submit JRSS-B revision" and the weekly
+"Grading window" come from `.STATUS`; "Week 1" comes from teach-config. If an
+atlas record matches a local one exactly on `(date, label, project)`, it's
+deduped — the local `.STATUS` record always wins.
+
+See [ATLAS-CONTRACT](../ATLAS-CONTRACT.md) for the full `atlas agenda`
+contract (request/response shape, capability probe).
 
 ---
 

--- a/docs/help/QUICK-REFERENCE.md
+++ b/docs/help/QUICK-REFERENCE.md
@@ -157,6 +157,12 @@ agenda -h
 Add dated items to any project's `.STATUS` (no `yq` needed). Teaching dates come
 from `.flow/teach-config.yml` automatically.
 
+!!! tip "Not just for research/teaching"
+    `agenda` spans every project category — `dev`, `r`, `quarto`, `apps` — not
+    only `research`/`teach`. A plain `## Schedule:` block with `general` or
+    `recurring` items works the same way on any project; filter by category
+    (`agenda dev`, `agenda apps`, …) exactly like `agenda research`/`agenda teach`.
+
 ```markdown
 ## Schedule:
 - 2026-06-20 | Submit JRSS-B revision | research

--- a/docs/reference/MASTER-API-REFERENCE.md
+++ b/docs/reference/MASTER-API-REFERENCE.md
@@ -20,7 +20,7 @@ This document provides complete API documentation for all flow-cli library funct
 ### Coverage Status
 
 **Total Functions:** 880
-**Documented:** 178 (20.2%)
+**Documented:** 182 (20.7%)
 **Auto-Generated:** Will be updated by `scripts/generate-api-docs.sh`
 
 ### Library Organization
@@ -114,6 +114,7 @@ When adding new functions:
 
 - [Core Library](#core-library) - Essential utilities
 - [Atlas Integration](#atlas-integration) - State engine
+- [Schedule Engine](#schedule-engine) - Forward-looking schedule layer (`agenda`)
 - [Project Detection](#project-detection) - Project type detection
 - [Terminal UI](#terminal-ui) - TUI components
 - [Tool Inventory](#tool-inventory) - Dependency tracking
@@ -523,6 +524,144 @@ type=$(_flow_detect_project_type "$PWD")
 echo "Project type: $type"
 # Output: Project type: node
 ```
+
+---
+
+#### `_flow_status_field`
+
+Read one field from a project's `.STATUS` file (shared accessor — replaces 4
+divergent field readers that used to exist across `dash`/`morning`/`next`/`capture`).
+
+**Signature:**
+
+```zsh
+_flow_status_field <project-root-dir> <field>
+```
+
+**Parameters:**
+
+- `$1` - Project root directory (NOT the `.STATUS` file path itself — this
+  function appends `/.STATUS`)
+- `$2` - Field name, e.g. `Focus`, `Progress`, `Status`
+
+**Returns:**
+
+- 0 - `.STATUS` file found (value may still be empty if the field is absent)
+- 1 - `.STATUS` file not found
+
+**Output:**
+
+- Field's value with leading whitespace trimmed, or empty
+
+**Example:**
+
+```zsh
+_flow_status_field "$project_path" "Focus"
+_flow_status_field "$project_path" "Progress" | tr -d '%'   # site strips %
+```
+
+**Notes:**
+
+- Handles both the `## Field:` markdown dialect and the plain `field:`
+  YAML-ish dialect (case-sensitive field-name match in both)
+- Does NOT strip `%` — callers that need a bare number (e.g. Progress) strip
+  it themselves. A universal strip here would corrupt any other field that
+  legitimately contains `%` (e.g. `## Focus: hit 80% coverage`)
+- `Status`/`status` gets synonym normalization (lowercase, spaces removed;
+  `underreview`/`inprogress`/`wip` → `active`, `onhold` → `paused`)
+- `_dash_get_status_field` (`commands/dash.zsh`) is now a thin delegating
+  wrapper around this function
+
+---
+
+#### `_flow_resolve_project_path`
+
+Find a project's absolute path by name (shared resolver — merges
+`_dash_find_project_path`'s taxonomy with `_flow_get_project_fallback`'s).
+
+**Signature:**
+
+```zsh
+_flow_resolve_project_path <name>
+```
+
+**Parameters:**
+
+- `$1` - Project name
+
+**Returns:**
+
+- 0 - Project found
+- 1 - Project not found
+
+**Output:**
+
+- A single shell-evaluable line: `project_path="/abs/path"` (never `path=` —
+  that collides with ZSH's PATH-tied array)
+
+**Example:**
+
+```zsh
+local out project_path
+if out=$(_flow_resolve_project_path "flow-cli"); then
+    eval "$out"
+    echo "Found at: $project_path"
+fi
+```
+
+**Notes:**
+
+- Search order: `dev-tools`, `apps`, `r-packages/active`, `r-packages/stable`,
+  `research`, `teaching`, `quarto/manuscripts`, `quarto/presentations`, then
+  an exact match directly under `$FLOW_PROJECTS_ROOT`, then a generic
+  `quarto/` fallback
+- `_dash_find_project_path` and `_flow_get_project_fallback` are now thin
+  delegating wrappers around this function
+
+---
+
+#### `_flow_suggest_project`
+
+Suggest a project to work on (shared active/priority/random scan — replaces
+5 separate reimplementations in `dash`, `morning`, and `adhd.zsh`).
+
+**Signature:**
+
+```zsh
+_flow_suggest_project [strategy]
+```
+
+**Parameters:**
+
+- `$1` (optional) - Strategy [default: `active`]:
+  - `active` - first active project
+  - `active-with-focus` - first active project with a non-empty Focus
+  - `priority` - first active project with Priority `1`/`P1`
+  - `random-active` - random pick from the active list (or the first 5 of
+    all projects if none are active)
+
+**Returns:**
+
+- 0 - A project was found
+- 1 - No qualifying project found
+
+**Output:**
+
+- The suggested project name, or empty
+
+**Example:**
+
+```zsh
+suggested=$(_flow_suggest_project active-with-focus)
+suggested=$(_flow_suggest_project priority)
+```
+
+**Notes:**
+
+- Not byte-parity guarded like `_flow_status_field` — the 5 call sites this
+  replaces (dash "right now"/footer, morning priority scan, adhd `next`/`js`)
+  genuinely differ in selection logic; each strategy is pinned by its own
+  unit test instead
 
 ---
 
@@ -1485,6 +1624,65 @@ at crumb "Debugging auth flow"
 - Provides essential fallback commands without Atlas
 - 'at' chosen for easy typing (2 characters)
 - Shows helpful error message if Atlas not available and unknown command used
+
+---
+
+## Schedule Engine
+
+**File:** `lib/schedule.zsh`
+**Purpose:** Forward-looking schedule layer powering `agenda`, the dash UPCOMING
+section, and dated enrichment of `morning`/`today`/`week`
+**Note:** This section is not yet exhaustive — only the atlas-source addition
+below is documented here so far; `_schedule_collect`, `_schedule_window_records`,
+`_schedule_classify`, and the rest of the pipeline are documented inline in
+`lib/schedule.zsh` itself and in `docs/guides/AGENDA-SCHEDULE-GUIDE.md`.
+
+#### `_schedule_atlas_items`
+
+Read atlas-tracked deadlines (`Task.dueDate`) for a window — a third,
+capability-probed schedule source (alongside `.STATUS` `## Schedule:` blocks
+and teach-config). **Dark-ready:** no atlas release implements the `agenda`
+command yet, so this ships as tested, inert code — a silent no-op today. See
+`docs/ATLAS-CONTRACT.md` (`atlas agenda`, proposed).
+
+**Signature:**
+
+```zsh
+_schedule_atlas_items <window>
+```
+
+**Parameters:**
+
+- `$1` - Window in days (the same look-ahead window the engine itself uses)
+
+**Returns:**
+
+- 0 - Always (silent no-op on any absence: atlas, `agenda` capability, `jq`)
+
+**Output:**
+
+- Record stream in the engine's `date|label|type|project|recurrence|source`
+  shape, with `source` hardcoded to `atlas` (not read from the JSON)
+
+**Example:**
+
+```zsh
+_schedule_atlas_items 7
+# (empty today — no atlas release implements `agenda` yet)
+```
+
+**Notes:**
+
+- Capability probe (`atlas agenda --help`) is cached per session in
+  `_FLOW_ATLAS_HAS_AGENDA`, mirroring `_FLOW_ATLAS_HAS_SCHEDULE`
+- Requires `jq` to parse the JSON array response; absence of `jq` is just
+  another silent-no-op path, same as atlas absence — no hard dependency
+  added to the engine
+- Wired into `_schedule_collect` as a third source, called once per collect
+  (not once per project — atlas returns cross-project results in one call)
+- How atlas populates `Task.dueDate` (including whether it ever reads
+  `.STATUS` itself) is explicitly out of scope here — atlas's own open
+  design question
 
 ---
 

--- a/docs/reference/MASTER-DISPATCHER-GUIDE.md
+++ b/docs/reference/MASTER-DISPATCHER-GUIDE.md
@@ -66,6 +66,14 @@ The same schedule engine (`lib/schedule.zsh`) also enriches other surfaces:
 `week` show dated blocks. See the
 [Agenda & Schedule guide](../guides/AGENDA-SCHEDULE-GUIDE.md).
 
+The engine merges three sources: `.STATUS` `## Schedule:` blocks, teaching
+config dates, and — dark-ready as of v7.14.0 — atlas-tracked deadlines
+(`Task.dueDate`), once atlas ships an `agenda` command (see
+[`docs/ATLAS-CONTRACT.md`](../ATLAS-CONTRACT.md)). Without atlas, or with an
+atlas that doesn't implement `agenda` yet, the atlas source is a **silent
+no-op** — `agenda`/`dash`/`morning` behave identically to today, driven by
+`.STATUS` + teach-config alone.
+
 ---
 
 ## How to Use This Guide

--- a/docs/specs/SPEC-agenda-schedule-2026-06-13.md
+++ b/docs/specs/SPEC-agenda-schedule-2026-06-13.md
@@ -2,8 +2,9 @@
 
 | | |
 |---|---|
-| **Status** | draft |
+| **Status** | Implemented |
 | **Created** | 2026-06-13 |
+| **Implemented** | v7.10.0 (`agenda` + dash UPCOMING + schedule engine); atlas agenda source (dark-ready) added in v7.14.0 — see `SPEC-planning-coordination-2026-07-01.md` §3.4 |
 | **Author** | dt + Claude (brainstorm) |
 | **From brainstorm** | `/workflow:brainstorm -d -s` session, 2026-06-13 |
 | **Plan file** | `~/.claude/plans/eventual-bouncing-phoenix.md` |

--- a/docs/specs/SPEC-planning-coordination-2026-07-01.md
+++ b/docs/specs/SPEC-planning-coordination-2026-07-01.md
@@ -1,9 +1,9 @@
 # SPEC — flow-cli planning-command refactor + atlas-agenda coordination
 
-**Status:** Draft (awaiting approval)
+**Status:** Approved (grilled 2026-07-01 — see `GRILL-planning-coordination-2026-07-01` decisions D1–D16 in `~/.claude/plans/fuzzy-conjuring-milner.md`)
 **Date:** 2026-07-01 · **Target version:** v7.14.0 · **Focus:** architecture / ops
 **Companion:** [`BRAINSTORM-planning-coordination-2026-07-01.md`](BRAINSTORM-planning-coordination-2026-07-01.md)
-**Scope in this repo:** Track A (flow-cli internal refactor) + Track C (consume atlas agenda). Tracks B (atlas `task`/`agenda` CLI) and D (obs render/seed) are cross-repo dependencies, documented here as contract only.
+**Scope in this repo — hard boundary (D7):** Track A (flow-cli internal refactor) + Track C (consume atlas agenda, shipped **dark-ready**, D1) + a new flow-cli-scoped `.STATUS` template/enforcer (D9). Tracks B (atlas `task`/`agenda` CLI) and D (obs render/seed) are cross-repo dependencies, documented here as contract only — **not designed or built in this cycle**; each gets its own spec + grill.
 
 ---
 
@@ -14,54 +14,83 @@ flow-cli's planning surface (`agenda`, `dash`, `morning`, `next`, `js`) works bu
 ## 2. Goals / non-goals
 
 **Goals**
-- G1 — Single accessor for `.STATUS` fields, project-path resolution, and project suggestion (kill 4×/2×/5× duplication).
-- G2 — Fix the `$path` → `project_path` bug in `morning.zsh` + `adhd.zsh`.
+- G0 — **(Pre-step, isolated — D2)** Fix the `$path` → `project_path` bug in `morning.zsh` + `adhd.zsh`, red-test-first, landed **before** any refactor so it's independently bisectable/revertable.
+- G1 — Single accessor for `.STATUS` fields, project-path resolution, and project suggestion (kill 4×/2×/5× duplication), **guarded by characterization/snapshot tests of every call site's CURRENT output, landed green before consolidation** (Axis 2 — the unification must not silently change what a call site sees).
+- G2 — *(superseded by G0 — kept as the design record of the bug; the fix itself ships as the pre-step)*.
 - G3 — Route `agenda` through the shared `_schedule_window_records` engine (no inlined pipeline).
-- G4 — New `_schedule_atlas_items` source: merge `atlas agenda`/`atlas task` records into the schedule engine, capability-probed, graceful-degrading.
-- G5 — Pin `atlas task list --format json` + `atlas agenda --format json` in `docs/ATLAS-CONTRACT.md` as proposed contract.
+- G4 — New `_schedule_atlas_items` source: merge `atlas agenda`/`atlas task` records into the schedule engine, capability-probed, graceful-degrading, **shipped dark-ready (D1)** — mirrors the existing `schedule push` no-op-until-atlas-ships pattern.
+- G5 — Pin `atlas task list --format json` + `atlas agenda --format json` in `docs/ATLAS-CONTRACT.md` as proposed contract. **`.STATUS`-ingestion mechanism is explicitly left as atlas's own open design question (D4) — this SPEC does not prescribe it.**
+- G6 — **(D9)** flow-cli-scoped `.STATUS` template (`templates/.STATUS.template`) + a **warn-only** enforcer (`scripts/check-status.zsh`, D11) documenting the dialects `_flow_status_field` supports.
 
 **Non-goals**
-- Implementing the atlas CLI (Track B) or obs rendering (Track D) — separate repos/specs.
+- Implementing the atlas CLI (Track B), its `.STATUS`-ingestion design, or obs rendering (Track D) — separate repos/specs (D4, D7).
 - Changing the `.STATUS ## Schedule:` grammar or teach-config parsing.
 - New top-level command (extends existing `agenda`; no count-cascade).
+- An ecosystem-wide `.STATUS` standard — flow-cli-scoped only this cycle (deferred per the follow-up to D7).
+- Blocking `.STATUS` commits anywhere — the enforcer is warn-only until a follow-up proves the template against real files (D11).
 
 ## 3. Design
 
-### 3.1 Shared accessors (`lib/core.zsh`)
+### 3.0 Pre-step: `$path` bug fix (G0, D2 — isolated, ahead of everything)
+`morning.zsh:83` and `adhd.zsh:103` do `eval "$info"` then read `$path`. The fallback emits `project_path=` (`atlas-bridge.zsh:397` — deliberately, per its comment "Avoid 'path' — conflicts with ZSH's PATH-tied variable"). Result: `$path` = the shell's PATH array, so `.STATUS` focus/progress + `_flow_detect_project_type "$path"` operate on garbage. **This lands as its own commit before Phase 1's refactor**, so it's bisectable independent of the larger change:
+1. Red test proving the *current* broken output (focus/progress blank or wrong in `next`/`morning` for a project with nonzero progress).
+2. Fix: read `$project_path` directly (not yet through the new resolver — that consolidation is Phase 1 proper).
+3. Green — isolated commit.
+
+### 3.1 Shared accessors (`lib/core.zsh`) — guarded by characterization tests (Axis 2)
+**Before writing any of these**, snapshot each call site's CURRENT output against fixtures (four `.STATUS` dialect variants + missing-field cases) and land those characterization tests green on **today's** code. Only then refactor; the same tests must stay green after (parity, not just new-behavior coverage) — this is the guard against silently changing what a call site sees when unifying 4 divergent readers / 2 resolvers / 5 suggesters into one each.
 - `_flow_status_field <root> <field>` — replaces `_dash_get_status_field` (`dash.zsh:1325`), the inline `grep`s in `morning.zsh:84` / `adhd.zsh:104` / `capture.zsh:406`, and `_flow_where_fallback` field reads (`atlas-bridge.zsh:836`). Handles both `## Field:` and `field:` dialects (superset of current behavior).
 - `_flow_resolve_project_path <name>` — single resolver merging `_dash_find_project_path` (`dash.zsh:1284`, has apps + quarto/manuscripts + presentations) and `_flow_get_project_fallback` (`atlas-bridge.zsh:370`). **Always emits `project_path=` never `path=`.**
 - `_flow_suggest_project` — single active/priority scan replacing the 5 reimplementations (`dash.zsh:181`, `:1139`, `morning.zsh:144`, `adhd.zsh` `next`, `js`).
 
-### 3.2 Bug fix (G2)
-`morning.zsh:83` and `adhd.zsh:103` do `eval "$info"` then read `$path`. The fallback emits `project_path=` (`atlas-bridge.zsh:397` — deliberately, per its comment "Avoid 'path' — conflicts with ZSH's PATH-tied variable"). Result: `$path` = the shell's PATH array, so `.STATUS` focus/progress + `_flow_detect_project_type "$path"` operate on garbage. Fix: read `$project_path` (routed through `_flow_resolve_project_path`).
+### 3.2 *(bug fix moved to §3.0 as an isolated pre-step — D2)*
 
 ### 3.3 agenda unification (G3)
 `agenda.zsh:62` runs an inline collect→filter→classify variant. Re-point it at `_schedule_window_records` (`schedule.zsh:549`) so bucketing + holiday-drop logic lives once. `_schedule_classify` stays for OVERDUE/TODAY/THIS-WEEK/LATER labelling.
 
-### 3.4 atlas agenda source (G4)
+### 3.4 atlas agenda source (G4 — shipped dark-ready, D1)
 New `_schedule_atlas_items <window>` invoked inside `_schedule_collect` (`schedule.zsh:378`, alongside `_schedule_parse_status` + `_schedule_teach_items`):
 - Probe capability once (session-cached, e.g. `_FLOW_ATLAS_HAS_AGENDA`), mirroring `_FLOW_ATLAS_HAS_SCHEDULE`.
 - Call `_flow_atlas_json agenda "$window"`; map each record to the engine's `date|label|type|project|recurrence|source` shape (`source=atlas`).
 - **Absent/older atlas → silent no-op**, engine falls back to `.STATUS` + teach only. No behavior change without atlas.
+- **Deliberately dark this cycle:** real atlas has no `agenda` command yet (Track B unbuilt) — this ships as tested, capability-probed, inert code, same posture as `schedule push` today. Zero user-visible payoff until atlas B ships; zero rework required when it does.
+
+**Test simulation of both atlas states (D15/D16):**
+- **Absent:** override the capability flag (`_FLOW_ATLAS_HAS_AGENDA` / `_flow_has_atlas`) directly — `FLOW_ATLAS_ENABLED=no` alone is insufficient (memory `capture-real-agenda-output-for-docs`).
+- **Present:** a stub `atlas` shim placed on `PATH` returning `tests/fixtures/atlas-agenda-stub.json` (real atlas can't be used — it lacks the command). The fixture's shape is asserted against what `docs/ATLAS-CONTRACT.md` documents inside `test-atlas-contract.zsh`, so a contract edit without a fixture update fails loudly instead of drifting silently.
 
 ### 3.5 Contract (G5)
-Add to `docs/ATLAS-CONTRACT.md` (bump contract version): `atlas task list --format json`, `atlas agenda [today|week|--all] --format json`, marked **proposed** until atlas ships them (same status `schedule push` carries today).
+Add to `docs/ATLAS-CONTRACT.md` (bump contract version): `atlas task list --format json`, `atlas agenda [today|week|--all] --format json`, marked **proposed** until atlas ships them (same status `schedule push` carries today). **The `.STATUS`-ingestion mechanism is explicitly recorded as atlas's own open question (D4) — not designed here**, to respect the §7/D7 scope boundary.
+
+### 3.6 `.STATUS` template + enforcer (G6, D9/D11)
+flow-cli-scoped only (not an ecosystem standard — that's deferred). Reuses the `scripts/check-math.zsh` pattern:
+- **Template** `templates/.STATUS.template` — canonical structure with inline comments: header fields (`## Project/Type/Status/Phase/Focus/Priority/Progress`), the `## Schedule:` grammar, `## daily_goal:`, `## Active Worktrees`, session-log convention. Documents the dual dialect (`## Field:` and `field:`) that `_flow_status_field` (§3.1) supports.
+- **Enforcer** `scripts/check-status.zsh` — validates required fields present, `Progress` is int 0–100, `Schedule` lines match grammar, `Status` in the allowed set. **Warn-only (D11): exit 0, prints violations** — does NOT block commits. Flip to blocking only in a follow-up once flow-cli's own `.STATUS` + the template are confirmed compliant.
+- **Wiring:** add a `.STATUS`-keyed entry to `lint-staged` (extensionless filename match, not a glob) alongside `check-math.zsh`'s existing entry; new `tests/test-status-schema.zsh` (schema validity + template-parses-clean).
 
 ## 4. Files touched
 
 - `lib/core.zsh` — new shared accessors.
 - `lib/schedule.zsh` — `_schedule_atlas_items` + call site in `_schedule_collect`.
 - `commands/agenda.zsh` — route through shared engine.
-- `commands/morning.zsh`, `commands/adhd.zsh` — bug fix + use shared accessors.
+- `commands/morning.zsh`, `commands/adhd.zsh` — `$path` pre-step fix + use shared accessors.
 - `commands/dash.zsh`, `commands/capture.zsh` — migrate to shared accessors.
 - `lib/atlas-bridge.zsh` — capability probe + `agenda` JSON passthrough for `at`.
-- `docs/ATLAS-CONTRACT.md` — proposed contract entries.
+- `docs/ATLAS-CONTRACT.md` — proposed contract entries (`.STATUS` ingestion left open).
+- `templates/.STATUS.template` (NEW) — canonical `.STATUS` structure.
+- `scripts/check-status.zsh` (NEW) — warn-only schema enforcer.
+- `tests/fixtures/atlas-agenda-stub.json` (NEW) — atlas-present test fixture, shape-asserted against the contract.
 
 ---
 
 ## 5. Testing plan *(refined — first-class, red-first, in-tree)*
 
-Run everything in the worktree via `./tests/run-all.sh`; new suites registered there. Judge failures against the `dev` baseline.
+Run everything in the worktree via `./tests/run-all.sh`; new suites registered there. Judge failures against the `dev` baseline. **Verification bar (Axis 5): the FULL suite, run independently by the reviewer, at every phase gate and before merge — never a sampled subset, never the agent's self-reported summary.**
+
+### 5.0 Characterization (parity guard, Axis 2 — precedes 5.1)
+| Suite | Asserts |
+|---|---|
+| `tests/test-status-field-parity.zsh` (new, RED against current code until it captures it, then GREEN pre-refactor) | Snapshots each existing call site's CURRENT output (`_dash_get_status_field`, the 3 inline greps, `_flow_where_fallback`) across 4 `.STATUS` dialect + missing-field fixtures; **must stay green after §3.1's consolidation** — a diff here means silent behavior change, not a passing refactor |
 
 ### 5.1 Unit
 | Suite (new/extended) | Asserts |
@@ -70,6 +99,8 @@ Run everything in the worktree via `./tests/run-all.sh`; new suites registered t
 | `tests/test-project-path-resolver.zsh` (new) | `_flow_resolve_project_path` finds apps, quarto/manuscripts, presentations; emits `project_path=` never `path=`; unknown project → empty |
 | `tests/test-suggest-project.zsh` (new) | `_flow_suggest_project` prefers active + high-priority; deterministic tie-break; empty registry → graceful |
 | `tests/test-schedule-atlas-source.zsh` (new) | `_schedule_atlas_items` maps stub JSON → normalized records; malformed JSON → no-op not crash; capability-absent → 0 records |
+| `tests/test-path-bug-fix.zsh` (new, pre-step §3.0) | RED first: proves `next`/`morning` focus/progress is blank/wrong today; GREEN after the isolated fix |
+| `tests/test-status-schema.zsh` (new, §3.6) | `check-status.zsh` schema validity; `templates/.STATUS.template` parses clean; warn-only (exit 0) on a malformed fixture, prints violations |
 
 ### 5.2 Integration (cross-command data flow)
 | Suite | Asserts |
@@ -80,12 +111,12 @@ Run everything in the worktree via `./tests/run-all.sh`; new suites registered t
 ### 5.3 Dependency / contract
 | Suite | Asserts |
 |---|---|
-| `tests/test-atlas-contract.zsh` (extend) | `atlas task list --format json` + `atlas agenda --format json` shapes pinned; flow-cli degrades to no-op when atlas lacks them (proven against a stub that omits the commands) |
+| `tests/test-atlas-contract.zsh` (extend) | `atlas task list --format json` + `atlas agenda --format json` shapes pinned; flow-cli degrades to no-op when atlas lacks them (proven against a stub that omits the commands); **`tests/fixtures/atlas-agenda-stub.json` shape asserted against the documented contract (D16) — a contract edit without a fixture update fails this test** |
 
 ### 5.4 E2E + dogfood
 | Suite | Asserts |
 |---|---|
-| `tests/e2e-agenda-atlas.zsh` (new) | sandbox + stub `atlas agenda` returning 2 tasks + `_flow_has_atlas` override → merged view shows research deadlines alongside `.STATUS` schedule (capture real output per memory `capture-real-agenda-output-for-docs`) |
+| `tests/e2e-agenda-atlas.zsh` (new) | sandbox + **capability-flag override** for atlas-absent (not `FLOW_ATLAS_ENABLED=no` alone, D15) + a **stub `atlas` shim on PATH** for atlas-present returning the shared fixture → merged view shows research deadlines alongside `.STATUS` schedule (capture real output per memory `capture-real-agenda-output-for-docs`) |
 | dogfood (manual, quoted in PR) | run `agenda` / `dash` / `morning` against the real repo set; confirm the `$path` fix restores focus/progress; confirm no regression when atlas agenda unavailable |
 
 ### 5.5 Regression guards
@@ -106,7 +137,9 @@ Inventory current state before editing (per doc-currency rule); update only genu
 | `docs/guides/AGENDA-SCHEDULE-GUIDE.md` | new data source diagram; merged research+dev example with real captured output |
 | `docs/reference/MASTER-API-REFERENCE.md` | document `_flow_status_field`, `_flow_resolve_project_path`, `_flow_suggest_project`, `_schedule_atlas_items` |
 | `docs/help/QUICK-REFERENCE.md` | one-line: agenda spans research + dev |
-| `docs/ATLAS-CONTRACT.md` | proposed `atlas task`/`atlas agenda` entries + contract version bump |
+| `docs/ATLAS-CONTRACT.md` | proposed `atlas task`/`atlas agenda` entries + contract version bump; `.STATUS` ingestion noted as atlas's open question (D4) |
+| `templates/.STATUS.template` inline comments (new) | canonical structure + dialect documentation (§3.6) |
+| `CONTRIBUTING.md` | note the `.STATUS` template + `check-status.zsh` (warn-only, D11) in the contributor checklist |
 | `CHANGELOG.md` + `docs/CHANGELOG.md` | `[Unreleased]` — mirrored (both files) |
 | `CLAUDE.md` | refresh test-file/suite counts after new suites land |
 | `mkdocs.yml` | no nav change (extends existing pages); `mkdocs build --strict` must pass |
@@ -124,15 +157,19 @@ Doc-scorer (`commands/docs/sync.md`, threshold ≥3): guide ✅, refcard ✅, co
 ## 8. Verification (end-to-end)
 
 1. `source flow.plugin.zsh` — clean load, no errors.
-2. `./tests/run-all.sh` — all suites green (1 expected interactive/tmux timeout); new suites pass; counts updated in CLAUDE.md.
-3. Dogfood with **no atlas**: `agenda`, `dash`, `morning` identical to pre-change (graceful degradation proven).
-4. Dogfood with **stub atlas agenda**: research deadlines appear merged; `$path` fix restores focus/progress in `morning`/`next`.
-5. `mkdocs build --strict` — 0 warnings.
-6. `/craft:docs:lint` — clean.
+2. `./tests/run-all.sh` — **run independently by the reviewer** (Axis 5, not the agent's self-report), all suites green (1 expected interactive/tmux timeout); new suites pass; counts updated in CLAUDE.md.
+3. Characterization suite (`test-status-field-parity.zsh`) unchanged pre/post-refactor — parity proven, not just new-behavior coverage.
+4. `check-status.zsh` — warn-only (exit 0) on a malformed `.STATUS` fixture, prints violations; clean (no violations) on the template and on flow-cli's own `.STATUS`.
+5. Dogfood with **no atlas** (capability-flag override, D15): `agenda`, `dash`, `morning` identical to pre-change (graceful degradation proven).
+6. Dogfood with **stub atlas shim on PATH** (D15): research deadlines appear merged; `$path` fix restores focus/progress in `morning`/`next`.
+7. `mkdocs build --strict` — 0 warnings.
+8. `/craft:docs:lint` — clean.
 
-## 9. Rollout
+## 9. Rollout & execution model
 
-- Branch: `feature/planning-coordination` (worktree off `dev`).
+- Branch: `feature/planning-coordination` (worktree off `dev`); `npm install` run in the worktree first so husky/lint-staged (prettier, `check-math.zsh`, the new `check-status.zsh`) fire on every commit (D12 — the worktree has no `node_modules` by default).
+- **Execution is phase-gated (D10), not one-shot:** pre-step ($path fix) → Phase 1 (characterization + refactor) → Phase 2 (atlas source + contract) → Phase 3 (`.STATUS` template + enforcer) → Phase 4 (docs). Each phase stops for an independent full-suite review before the next proceeds.
+- **Failure recovery (D13/D14):** a phase that fails review gets fixed forward via follow-up instruction to the same agent (context retained), re-verified; capped at 2 attempts. On a 2nd failure, execution stops and the finding is reported directly — no silent retry, no skip-ahead to the next phase.
 - Ship Track A independently if Track C's atlas dependency isn't ready — the refactor + bug fix stand alone.
 - Release as v7.14.0 once C's contract is pinned (C degrades safely even before atlas ships).
 

--- a/lib/atlas-bridge.zsh
+++ b/lib/atlas-bridge.zsh
@@ -367,38 +367,23 @@ _flow_get_project() {
 #   - Search order: root, dev-tools, r-packages/*, research, teaching, quarto
 #   - Uses project_path/proj_status to avoid ZSH reserved names
 # =============================================================================
+# Delegates to the shared resolver (_flow_resolve_project_path, lib/core.zsh)
+# which merges this function's original search dirs with
+# _dash_find_project_path's fuller taxonomy (adds apps + quarto/manuscripts +
+# quarto/presentations). Kept as a thin wrapper so _flow_get_project's output
+# contract (name=/project_path=/proj_status=) is unchanged for callers.
 _flow_get_project_fallback() {
   local name="$1"
-  local path
+  local resolved project_path
 
-  # Try exact match first
-  if [[ -d "$FLOW_PROJECTS_ROOT/$name" ]]; then
-    path="$FLOW_PROJECTS_ROOT/$name"
-  else
-    # Search in common subdirectories
-    local search_dirs=(
-      "$FLOW_PROJECTS_ROOT/dev-tools"
-      "$FLOW_PROJECTS_ROOT/r-packages/active"
-      "$FLOW_PROJECTS_ROOT/r-packages/stable"
-      "$FLOW_PROJECTS_ROOT/research"
-      "$FLOW_PROJECTS_ROOT/teaching"
-      "$FLOW_PROJECTS_ROOT/quarto"
-    )
-    for dir in "${search_dirs[@]}"; do
-      if [[ -d "$dir/$name" ]]; then
-        path="$dir/$name"
-        break
-      fi
-    done
-  fi
+  resolved=$(_flow_resolve_project_path "$name") || return 1
+  eval "$resolved"
+  [[ -z "$project_path" ]] && return 1
 
-  if [[ -n "$path" ]]; then
-    echo "name=\"$name\""
-    echo "project_path=\"$path\""  # Avoid 'path' - conflicts with ZSH's PATH-tied variable
-    echo "proj_status=\"active\""  # Avoid 'status' - conflicts with ZSH builtin
-    return 0
-  fi
-  return 1
+  echo "name=\"$name\""
+  echo "project_path=\"$project_path\""  # Avoid 'path' - conflicts with ZSH's PATH-tied variable
+  echo "proj_status=\"active\""  # Avoid 'status' - conflicts with ZSH builtin
+  return 0
 }
 
 # =============================================================================
@@ -849,20 +834,26 @@ _flow_where_fallback() {
 
   echo "📁 Project: $project"
 
-  # Show status if available
-  local status_file
+  # Show status if available. Reads via the shared accessor
+  # (_flow_status_field, lib/core.zsh) — NOTE: this also fixes a pre-existing
+  # crash. The prior inline version declared `local status=...`, but `status`
+  # is a zsh read-only special variable even as a function-local, so this
+  # line always errored and Status:/Focus: never actually printed. Found
+  # while characterizing (tests/test-status-field-parity.zsh) ahead of this
+  # migration; fixed as an unavoidable side effect of touching this line.
+  local status_dir
   for search_dir in "$PWD" "$FLOW_PROJECTS_ROOT/$project"; do
     if [[ -f "$search_dir/.STATUS" ]]; then
-      status_file="$search_dir/.STATUS"
+      status_dir="$search_dir"
       break
     fi
   done
 
-  if [[ -f "$status_file" ]]; then
-    local status=$(command grep -m1 "^## Status:" "$status_file" | command cut -d: -f2 | tr -d ' ')
-    local focus=$(command grep -m1 "^## Focus:" "$status_file" | command cut -d: -f2-)
+  if [[ -n "$status_dir" ]]; then
+    local proj_status=$(_flow_status_field "$status_dir" "Status" | tr -d ' ')
+    local focus=$(_flow_status_field "$status_dir" "Focus")
 
-    [[ -n "$status" ]] && echo "   Status: $status"
+    [[ -n "$proj_status" ]] && echo "   Status: $proj_status"
     [[ -n "$focus" ]] && echo "   Focus: $focus"
   fi
 }

--- a/lib/core.zsh
+++ b/lib/core.zsh
@@ -839,3 +839,235 @@ _flow_tty_handoff_cleanup() {
     printf '\e[?1004l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l' > /dev/tty
     while read -t 0.05 -k 1 _flow_discard 2>/dev/null; do : ; done < /dev/tty
 }
+
+# ============================================================================
+# PLANNING ACCESSORS (shared .STATUS/project helpers — SPEC-planning-
+# coordination-2026-07-01 §3.1)
+# ============================================================================
+# Consolidates 4 divergent .STATUS field readers, 2 project-path resolvers,
+# and 5 project-suggestion scans into one implementation each. Existing
+# per-file wrappers (_dash_get_status_field, _dash_find_project_path,
+# _flow_get_project_fallback) now delegate here to avoid touching their many
+# internal call sites; see tests/test-status-field-parity.zsh for the
+# byte-parity guard on the field reader.
+
+# =============================================================================
+# Function: _flow_status_field
+# Purpose: Read one field from a project's .STATUS file (shared accessor)
+# =============================================================================
+# Arguments:
+#   $1 - (required) Project root directory (NOT the .STATUS file path itself —
+#        this function appends /.STATUS)
+#   $2 - (required) Field name, e.g. "Focus", "Progress", "Status"
+#
+# Returns:
+#   0 - .STATUS file found (value may still be empty if the field is absent)
+#   1 - .STATUS file not found
+#
+# Output:
+#   stdout - the field's value (leading whitespace trimmed), or empty
+#
+# Example:
+#   _flow_status_field "$project_path" "Focus"
+#   _flow_status_field "$project_path" "Progress" | tr -d '%'   # site strips %
+#
+# Notes:
+#   - Handles both the "## Field:" markdown dialect and the plain "field:"
+#     YAML-ish dialect (matches field name case-sensitively in both).
+#   - Does NOT strip '%' — callers that need a bare number (e.g. Progress)
+#     strip it themselves, same as today (_dash_get_project_progress,
+#     morning.zsh). A universal strip here would corrupt any other field
+#     that legitimately contains '%' (e.g. "## Focus: hit 80% coverage").
+#   - "Status"/"status" gets the same synonym normalization
+#     _dash_get_status_field has always applied (lowercase, spaces removed,
+#     underreview/inprogress/wip -> active, onhold -> paused) — required so
+#     _dash_get_status_field can delegate here without changing behavior.
+# =============================================================================
+_flow_status_field() {
+  local root="$1"
+  local field="$2"
+  local file="$root/.STATUS"
+  local value="" line
+
+  [[ ! -f "$file" ]] && return 1
+
+  while IFS= read -r line; do
+    if [[ "$line" == "## ${field}:"* ]]; then
+      value="${line#*: }"
+      value="${value#"${value%%[![:space:]]*}"}"
+      break
+    fi
+    if [[ "$line" == "${field}:"* ]]; then
+      value="${line#*: }"
+      value="${value#"${value%%[![:space:]]*}"}"
+      break
+    fi
+  done < "$file"
+
+  if [[ "$field" == "Status" || "$field" == "status" ]]; then
+    value="${value:l}"
+    value="${value// /}"
+    case "$value" in
+      underreview) value="active" ;;
+      inprogress) value="active" ;;
+      wip) value="active" ;;
+      onhold) value="paused" ;;
+    esac
+  fi
+
+  echo "$value"
+  return 0
+}
+
+# =============================================================================
+# Function: _flow_resolve_project_path
+# Purpose: Find a project's absolute path by name (shared resolver)
+# =============================================================================
+# Arguments:
+#   $1 - (required) Project name
+#
+# Returns:
+#   0 - Project found
+#   1 - Project not found
+#
+# Output:
+#   stdout - a single shell-evaluable line: project_path="/abs/path"
+#            (never `path=` — that collides with ZSH's PATH-tied array)
+#
+# Example:
+#   local out project_path
+#   if out=$(_flow_resolve_project_path "flow-cli"); then
+#       eval "$out"
+#       echo "Found at: $project_path"
+#   fi
+#
+# Environment:
+#   FLOW_PROJECTS_ROOT - Base directory for projects
+#
+# Notes:
+#   - Merges _dash_find_project_path's category taxonomy (dev-tools, apps,
+#     r-packages/active|stable, research, teaching, quarto/manuscripts,
+#     quarto/presentations) with _flow_get_project_fallback's exact-root-match
+#     and generic quarto/ fallback.
+#   - Search order matches _dash_find_project_path's original order (root
+#     checked last, after the category subdirs) since that is the
+#     better-tested, more complete taxonomy; the generic "quarto/" fallback
+#     is appended at the very end as a pure superset for projects that live
+#     directly under quarto/ rather than manuscripts/ or presentations/.
+# =============================================================================
+_flow_resolve_project_path() {
+  local name="$1"
+  local dir
+
+  local -a search_dirs=(
+    "$FLOW_PROJECTS_ROOT/dev-tools"
+    "$FLOW_PROJECTS_ROOT/apps"
+    "$FLOW_PROJECTS_ROOT/r-packages/active"
+    "$FLOW_PROJECTS_ROOT/r-packages/stable"
+    "$FLOW_PROJECTS_ROOT/research"
+    "$FLOW_PROJECTS_ROOT/teaching"
+    "$FLOW_PROJECTS_ROOT/quarto/manuscripts"
+    "$FLOW_PROJECTS_ROOT/quarto/presentations"
+    "$FLOW_PROJECTS_ROOT"
+    "$FLOW_PROJECTS_ROOT/quarto"
+  )
+
+  for dir in "${search_dirs[@]}"; do
+    if [[ -d "$dir/$name" ]]; then
+      echo "project_path=\"$dir/$name\""
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# =============================================================================
+# Function: _flow_suggest_project
+# Purpose: Suggest a project to work on (shared active/priority/random scan)
+# =============================================================================
+# Arguments:
+#   $1 - (optional) Strategy [default: "active"]:
+#          active             - first active project
+#          active-with-focus  - first active project with a non-empty Focus
+#          priority           - first active project with Priority 1/P1
+#          random-active      - random pick from the active list (or the
+#                                first 5 of all projects if none are active)
+#
+# Returns:
+#   0 - A project was found
+#   1 - No qualifying project found
+#
+# Output:
+#   stdout - the suggested project name, or empty
+#
+# Example:
+#   suggested=$(_flow_suggest_project active-with-focus)
+#   suggested=$(_flow_suggest_project priority)
+#
+# Notes:
+#   - NOT byte-parity guarded like _flow_status_field — the 5 call sites this
+#     replaces (dash.zsh:181/:1139, morning.zsh:144, adhd.zsh next/js)
+#     genuinely differ in selection logic; each strategy is pinned by its own
+#     unit test in tests/test-suggest-project.zsh instead.
+#   - Uses _flow_list_projects("active") when available, falling back to the
+#     unfiltered list (matching existing callers' fallback pattern) since the
+#     filesystem fallback ignores the status filter param.
+# =============================================================================
+_flow_suggest_project() {
+  local strategy="${1:-active}"
+  local projects
+  projects=$(_flow_list_projects "active" 2>/dev/null)
+  [[ -z "$projects" ]] && projects=$(_flow_list_projects 2>/dev/null)
+  [[ -z "$projects" ]] && return 1
+
+  if [[ "$strategy" == "random-active" ]]; then
+    local pick
+    pick=$(echo "$projects" | sort -R | head -1)
+    [[ -z "$pick" ]] && return 1
+    echo "$pick"
+    return 0
+  fi
+
+  # NOTE: resolved/project_path/pstatus/focus/priority are declared ONCE
+  # here, outside the loop — redeclaring `local` on an already-local
+  # variable on every iteration of a `while ... done <<< ...` loop triggers
+  # a reproducible zsh quirk where the PREVIOUS iteration's value gets
+  # echoed to stdout when the variable is redeclared. See
+  # tests/test-suggest-project.zsh discovery notes / MEMORY zsh-gotchas.
+  local project resolved project_path pstatus focus priority
+  while IFS= read -r project; do
+    [[ -z "$project" ]] && continue
+
+    resolved=$(_flow_resolve_project_path "$project") || continue
+    eval "$resolved"
+    [[ -z "$project_path" || ! -f "$project_path/.STATUS" ]] && continue
+
+    pstatus=$(_flow_status_field "$project_path" "Status")
+    [[ "$pstatus" != "active" ]] && continue
+
+    case "$strategy" in
+      active)
+        echo "$project"
+        return 0
+        ;;
+      active-with-focus)
+        focus=$(_flow_status_field "$project_path" "Focus")
+        if [[ -n "$focus" ]]; then
+          echo "$project"
+          return 0
+        fi
+        ;;
+      priority)
+        priority=$(_flow_status_field "$project_path" "Priority")
+        priority="${priority// /}"
+        if [[ "$priority" == "1" || "$priority" == "P1" ]]; then
+          echo "$project"
+          return 0
+        fi
+        ;;
+    esac
+  done <<< "$projects"
+
+  return 1
+}

--- a/lib/schedule.zsh
+++ b/lib/schedule.zsh
@@ -51,6 +51,10 @@ typeset -g _SCHEDULE_CACHE_TIME=0
 # Atlas `schedule` subcommand capability probe (cached per session).
 typeset -g _FLOW_ATLAS_HAS_SCHEDULE=""
 
+# Atlas `agenda` subcommand capability probe (cached per session) — dark-ready
+# read source, SPEC-planning-coordination-2026-07-01 §3.4.
+typeset -g _FLOW_ATLAS_HAS_AGENDA=""
+
 # ============================================================================
 # DATE HELPERS
 # ============================================================================
@@ -443,8 +447,42 @@ _schedule_collect() {
     fi
   done < <(_flow_list_projects)
 
+  # 3. Atlas agenda source (dark-ready; silent no-op without atlas — SPEC §3.4)
+  while IFS= read -r rec; do
+    [[ -z "$rec" ]] && continue
+    local -a af=("${(@s:|:)rec}")
+    rtype="${af[3]}"
+    if [[ -n "$category" ]]; then
+      local aproj_path aproj_cat=""
+      aproj_path=$(_dash_find_project_path "${af[4]}")
+      [[ -n "$aproj_path" ]] && aproj_cat=$(_dash_detect_category "$aproj_path")
+      _schedule_category_match "$category" "$rtype" "$aproj_cat" || continue
+    fi
+    out+=("$rec")
+  done < <(_schedule_atlas_items "$window")
+
+  # Dedupe on (date, label, project) — fields 1/2/4. With only .STATUS +
+  # teach-config as sources, duplicates were structurally impossible; the
+  # atlas source (3.) makes them possible for the first time (the same
+  # deadline tracked both locally and in atlas), so this is new with Track C.
+  # First occurrence wins — .STATUS/teach-config are collected before atlas,
+  # so a local record always takes priority over an atlas duplicate.
   local records=""
-  (( ${#out[@]} > 0 )) && records=$(print -rl -- "${out[@]}")
+  if (( ${#out[@]} > 0 )); then
+    local -A seen_keys=()
+    local -a deduped=()
+    local dkey
+    local -a df
+    for rec in "${out[@]}"; do
+      df=("${(@s:|:)rec}")
+      dkey="${df[1]}|${df[2]}|${df[4]}"
+      if (( ! ${+seen_keys[$dkey]} )); then
+        seen_keys[$dkey]=1
+        deduped+=("$rec")
+      fi
+    done
+    records=$(print -rl -- "${deduped[@]}")
+  fi
 
   _SCHEDULE_CACHE_RECORDS="$records"
   _SCHEDULE_CACHE_KEY="$cache_key"
@@ -672,5 +710,59 @@ _flow_schedule_to_atlas() {
   local json=$(_schedule_records_to_json "${records[@]}")
 
   _flow_atlas_async schedule push --format=json --data="$json"
+  return 0
+}
+
+# =============================================================================
+# Function: _schedule_atlas_items
+# Purpose: Read atlas-tracked deadlines (Task.dueDate) for a window (dark-ready
+#          read source, opportunistic + capability-detected). See
+#          docs/ATLAS-CONTRACT.md's `atlas agenda` section.
+# =============================================================================
+# Arguments:
+#   $1 - window in days (same look-ahead window the engine itself uses)
+#
+# Returns:
+#   0 - Always (silent no-op on any absence: atlas, `agenda` capability, jq)
+#
+# Output:
+#   stdout - record stream in the engine's date|label|type|project|recurrence|source
+#            shape, with `source` hardcoded to `atlas` (not read from the JSON)
+#
+# Notes:
+#   - DARK THIS CYCLE: no atlas release implements `agenda` yet (Track B,
+#     tracked separately). This is tested, inert code — same posture as
+#     `atlas schedule push` before it shipped.
+#   - Capability probe (`atlas agenda --help`) is cached in
+#     _FLOW_ATLAS_HAS_AGENDA, mirroring _FLOW_ATLAS_HAS_SCHEDULE.
+#   - Requires `jq` to parse the JSON array response; absence of jq is just
+#     another silent-no-op path, same as atlas absence — no hard dependency
+#     added to the engine (lib/schedule.zsh stays "pure ZSH, works fully
+#     without atlas" for everyone who doesn't have jq either).
+#   - How atlas populates Task.dueDate (including whether it ever reads
+#     .STATUS itself) is NOT this function's concern — that is atlas's own
+#     open design question (D4), documented as such in ATLAS-CONTRACT.md.
+# =============================================================================
+_schedule_atlas_items() {
+  local window="$1"
+
+  _flow_has_atlas || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  if [[ -z "$_FLOW_ATLAS_HAS_AGENDA" ]]; then
+    if atlas agenda --help >/dev/null 2>&1; then
+      _FLOW_ATLAS_HAS_AGENDA="yes"
+    else
+      _FLOW_ATLAS_HAS_AGENDA="no"
+    fi
+  fi
+  [[ "$_FLOW_ATLAS_HAS_AGENDA" == "yes" ]] || return 0
+
+  local json
+  json=$(_flow_atlas_json agenda "$window")
+  [[ -z "$json" ]] && return 0
+
+  print -r -- "$json" \
+    | jq -r '.[]? | "\(.date)|\(.label)|\(.type)|\(.project)|\(.recurrence)|atlas"' 2>/dev/null
   return 0
 }

--- a/lib/schedule.zsh
+++ b/lib/schedule.zsh
@@ -537,22 +537,37 @@ _schedule_render_line() {
 # =============================================================================
 # Function: _schedule_window_records
 # Purpose: The shared surface pipeline — collect, window-filter, sort, and drop
-#          holidays — in one place (dash UPCOMING, morning/today/week, counts).
+#          holidays — in one place (dash UPCOMING, morning/today/week, counts,
+#          and `agenda` — SPEC-planning-coordination-2026-07-01 §3.3).
 # Arguments:
 #   $1 - window in days [default: SCHEDULE_DEFAULT_WINDOW]
+#   $2 - category filter [default: "" (none)] — forwarded to _schedule_collect
+#   $3 - keep_holidays (0|1) [default: 0 — drop holidays, existing behavior]
 # Output:
 #   stdout - the resulting record stream (empty when nothing is due)
 # Notes:
 #   - Returns 0 with no output when the engine is unavailable or nothing matches,
 #     so callers can `records=$(_schedule_window_records …); [[ -z … ]] && return`.
+#   - $2/$3 are additive: every pre-existing caller passes only $1, so
+#     category defaults to none and holidays are still dropped — unchanged
+#     behavior for dash/morning/today/week/counts. `agenda --all` is the one
+#     caller that passes keep_holidays=1.
 # =============================================================================
 _schedule_window_records() {
   local window="${1:-$SCHEDULE_DEFAULT_WINDOW}"
+  local category="${2:-}"
+  local keep_holidays="${3:-0}"
   typeset -f _schedule_collect >/dev/null 2>&1 || return 0
-  _schedule_collect "$window" \
-    | _schedule_filter_window "$window" \
-    | _schedule_sort \
-    | _schedule_drop_holidays
+  if (( keep_holidays )); then
+    _schedule_collect "$window" "$category" \
+      | _schedule_filter_window "$window" \
+      | _schedule_sort
+  else
+    _schedule_collect "$window" "$category" \
+      | _schedule_filter_window "$window" \
+      | _schedule_sort \
+      | _schedule_drop_holidays
+  fi
 }
 
 # =============================================================================

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     ],
     "*.qmd": [
       "zsh scripts/check-math.zsh"
+    ],
+    ".STATUS": [
+      "zsh scripts/check-status.zsh"
     ]
   }
 }

--- a/scripts/check-status.zsh
+++ b/scripts/check-status.zsh
@@ -1,0 +1,164 @@
+#!/usr/bin/env zsh
+# scripts/check-status.zsh — Standalone .STATUS schema validator (WARN-ONLY)
+# Used by lint-staged (pre-commit) and callable standalone. Model:
+# scripts/check-math.zsh — same shape, different exit-code contract.
+#
+# SPEC-planning-coordination-2026-07-01 §3.6 (D9/D11): flow-cli-scoped only
+# (not an ecosystem-wide standard). Validates required header fields,
+# Progress (integer 0-100), Status (allowed set), and ## Schedule: grammar.
+#
+# D11 — HARD CONSTRAINT: this script ALWAYS exits 0. It prints violations,
+# it never blocks a commit. Flip to blocking only in a future follow-up once
+# flow-cli's own .STATUS + the template are confirmed compliant across the
+# ecosystem — not this cycle.
+#
+# Usage: zsh scripts/check-status.zsh file1/.STATUS file2/.STATUS ...
+# Exit:  ALWAYS 0
+
+setopt LOCAL_OPTIONS EXTENDED_GLOB
+
+local script_dir="${0:A:h}"
+local project_root="${script_dir:h}"
+
+# Only need _flow_status_field — lib/core.zsh is self-contained (no module
+# guard, no dependency on other lib/*.zsh files), same lightweight-source
+# pattern check-math.zsh uses for teach-deploy-enhanced.zsh.
+source "${project_root}/lib/core.zsh" 2>/dev/null
+
+if ! typeset -f _flow_status_field >/dev/null 2>&1; then
+    print -P "%F{red}ERROR:%f Could not load _flow_status_field from lib/core.zsh"
+    print -P "%F{yellow}(warn-only: not blocking despite the internal error)%f"
+    exit 0
+fi
+
+if (( $# == 0 )); then
+    print -P "%F{yellow}Usage:%f zsh scripts/check-status.zsh <.STATUS file> ..."
+    exit 0
+fi
+
+typeset -a REQUIRED_FIELDS=(Project Type Status Focus Phase Priority Progress)
+typeset -a ALLOWED_STATUS=(active paused archived blocked)
+typeset -gi TOTAL_ISSUES=0
+
+# Normalize a Status value the same way _flow_status_field does internally,
+# so a synonym it already accepts ("In Progress", "WIP", ...) is not flagged
+# as a violation here.
+_check_status_normalize() {
+    local v="${1:l}"
+    v="${v// /}"
+    case "$v" in
+        underreview|inprogress|wip) v="active" ;;
+        onhold) v="paused" ;;
+    esac
+    print -r -- "$v"
+}
+
+_check_status_file() {
+    local file="$1"
+    local root="${file:h}"
+    local tmp_status_dir=""
+
+    # _flow_status_field expects a ROOT dir and always reads "<root>/.STATUS"
+    # (lib/core.zsh's established contract — do not special-case it here,
+    # that would risk the Phase 1 parity guard for every other caller).
+    # Real .STATUS files satisfy this directly. But this script is also
+    # asked to validate templates/.STATUS.template — a file that documents
+    # the shape without being named ".STATUS" itself. For any file NOT
+    # literally named ".STATUS", stage a throwaway copy under that exact
+    # name so _flow_status_field's contract is met without duplicating its
+    # parsing logic here.
+    if [[ "${file:t}" != ".STATUS" ]]; then
+        tmp_status_dir=$(mktemp -d)
+        cp "$file" "$tmp_status_dir/.STATUS"
+        root="$tmp_status_dir"
+    fi
+
+    # NOTE: all locals used inside the loops below are declared ONCE here,
+    # not redeclared per iteration — redeclaring `local` on an already-local
+    # variable inside a loop is a reproducible zsh quirk that echoes the
+    # previous iteration's value to stdout (see lib/core.zsh's
+    # _flow_suggest_project for the first discovery of this). `status` is
+    # additionally a zsh READ-ONLY special variable (even function-local —
+    # see lib/atlas-bridge.zsh's _flow_where_fallback fix in Phase 1), hence
+    # `proj_status` instead.
+    local field val progress pnum proj_status norm
+
+    # ---- Required fields present ----
+    for field in "${REQUIRED_FIELDS[@]}"; do
+        val=$(_flow_status_field "$root" "$field")
+        if [[ -z "$val" ]]; then
+            print -P "%F{yellow}WARN%f  $file — missing required field: ## ${field}:"
+            (( TOTAL_ISSUES++ ))
+        fi
+    done
+
+    # ---- Progress: integer 0-100 ----
+    progress=$(_flow_status_field "$root" "Progress")
+    if [[ -n "$progress" ]]; then
+        pnum="${progress//%/}"
+        if [[ ! "$pnum" == <-> ]] || (( pnum < 0 || pnum > 100 )); then
+            print -P "%F{yellow}WARN%f  $file — Progress not an integer 0-100: '$progress'"
+            (( TOTAL_ISSUES++ ))
+        fi
+    fi
+
+    # ---- Status: allowed set (synonym-tolerant) ----
+    proj_status=$(_flow_status_field "$root" "Status")
+    if [[ -n "$proj_status" ]]; then
+        norm=$(_check_status_normalize "$proj_status")
+        if (( ! ${ALLOWED_STATUS[(Ie)$norm]} )); then
+            print -P "%F{yellow}WARN%f  $file — Status '$proj_status' not in allowed set (active|paused|archived|blocked, or a recognized synonym)"
+            (( TOTAL_ISSUES++ ))
+        fi
+    fi
+
+    # ---- ## Schedule: grammar ----
+    # Mirrors _schedule_parse_status's grammar (lib/schedule.zsh): a line the
+    # real parser can't match is silently skipped there (invisible, not
+    # fatal) — this is exactly the class of mistake worth flagging here.
+    local in_section=0 line body when label
+    local -a parts
+    local -i lineno=0
+    while IFS= read -r line; do
+        (( lineno++ ))
+        if [[ "$line" == "## Schedule:"* ]]; then
+            in_section=1
+            continue
+        fi
+        if (( in_section )) && [[ "$line" == "## "* ]]; then
+            in_section=0
+            continue
+        fi
+        (( in_section )) || continue
+
+        [[ "$line" == "-"* ]] || continue
+        body="${line#-}"
+        body="${body#"${body%%[![:space:]]*}"}"
+        [[ -z "$body" ]] && continue
+
+        parts=("${(@s:|:)body}")
+        when="${parts[1]//[[:space:]]/}"
+        label="${parts[2]:-}"
+        label="${label#"${label%%[![:space:]]*}"}"
+
+        if [[ -z "$when" || -z "$label" ]] \
+           || { [[ "$when" != [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]] && [[ "$when" != weekly:* ]] ; }; then
+            print -P "%F{yellow}WARN%f  $file:$lineno — Schedule line doesn't match grammar (expected '- YYYY-MM-DD | label | type' or '- weekly:<dow> | label | type'): '$line'"
+            (( TOTAL_ISSUES++ ))
+        fi
+    done < "$file"
+
+    [[ -n "$tmp_status_dir" ]] && rm -rf "$tmp_status_dir"
+}
+
+local file
+for file in "$@"; do
+    [[ -f "$file" ]] || continue
+    _check_status_file "$file"
+done
+
+if (( TOTAL_ISSUES > 0 )); then
+    print -P "\n%F{yellow}${TOTAL_ISSUES} .STATUS schema issue(s) found (warn-only — not blocking, D11).%f"
+fi
+
+exit 0

--- a/templates/.STATUS.template
+++ b/templates/.STATUS.template
@@ -1,0 +1,70 @@
+# <project-name> - <one-line description>
+#
+# This is a flow-cli .STATUS file. It drives `dash`, `morning`, `next`,
+# `agenda`, and `flow goal` — keep the header fields below accurate; flow-cli
+# reads them directly (no external tools required).
+#
+# Dual dialect: every field below may be written either as markdown
+# ("## Field: value", shown here) or as plain YAML-ish ("field: value", no
+# "## " prefix, lowercase). _flow_status_field (lib/core.zsh) reads both —
+# pick whichever your project already uses and stay consistent within a file.
+#
+# flow-cli-scoped convention (SPEC-planning-coordination-2026-07-01 §3.6) —
+# this is NOT an ecosystem-wide standard. scripts/check-status.zsh validates
+# this shape as a warn-only pre-commit check (D11): it prints violations, it
+# never blocks a commit.
+
+## Project: <project-name>
+## Type: <e.g. zsh-plugin | node-cli | r-package | quarto-site>
+## Status: active
+## Focus: <what you're doing right now, one line>
+## Phase: Planning
+## Priority: 2
+## Progress: 0
+
+# --- Optional fields --------------------------------------------------------
+
+# Per-project daily win goal (flow-cli's dopamine features — `win`/`yay`).
+# Overrides the global default when present. Must be a bare integer.
+## daily_goal: 3
+
+# --- Schedule (optional) -----------------------------------------------------
+# Forward-looking dated items surfaced by `agenda` / the dash UPCOMING
+# section. One list item per line:
+#
+#   - <when> | <label> [| <type>]
+#
+#   when  = YYYY-MM-DD                (concrete date)
+#         | weekly:<dow>              (recurring, e.g. weekly:fri)
+#   label = free text (must not itself contain " | "; a literal "|" inside
+#           the label is sanitized to "/" downstream)
+#   type  = teaching | research | general | recurring | holiday
+#           (optional — defaults to "general" for a dated entry, "recurring"
+#           for a weekly: entry)
+#
+# Lines that don't match this grammar are silently skipped by the schedule
+# engine (not fatal, just invisible) — check-status.zsh flags them so you
+# notice before they go missing from `agenda`.
+#
+## Schedule:
+# - 2026-08-15 | Submit conference abstract | research
+# - weekly:fri | Grading window | recurring
+
+# --- Active Worktrees (optional) --------------------------------------------
+# Free-form section some projects use to track open `git worktree`s. Not
+# machine-parsed by flow-cli today; documented here for convention only.
+#
+## Active Worktrees
+# - feature/some-branch -> ~/.git-worktrees/<project>/feature-some-branch
+
+# --- Session log (convention, append-only) ----------------------------------
+# Most-recent-first. Each entry is a "## Current Session (YYYY-MM-DD) —
+# <summary>" heading (rename the previous "Current Session" to "Previous
+# Session" when you start a new one) followed by a short bullet list. This is
+# read by humans and `dash`/`morning`'s Focus/Progress fields above — it is
+# NOT machine-parsed beyond the header fields at the top of this file.
+
+## Current Session (YYYY-MM-DD) — <short summary>
+
+**Session activity:**
+- <what happened>

--- a/tests/e2e-agenda-atlas.zsh
+++ b/tests/e2e-agenda-atlas.zsh
@@ -1,0 +1,211 @@
+#!/usr/bin/env zsh
+# e2e-agenda-atlas.zsh - End-to-end tests for the atlas agenda source
+# (SPEC-planning-coordination-2026-07-01 §3.4, ORCHESTRATE Phase 2)
+#
+# Drives the real `agenda` command against a seeded FLOW_PROJECTS_ROOT under
+# BOTH atlas states:
+#   - Absent (capability-flag override, D15) — output must be byte-identical
+#     to the no-atlas baseline (graceful degradation, no behavior change).
+#   - Present + capable (a stub `atlas` shim on PATH returning
+#     tests/fixtures/atlas-agenda-stub.json, D16 — real atlas has no `agenda`
+#     command yet, so it cannot be used for this).
+#
+# Also verifies the 3-source dedupe (date|label|project) added alongside this
+# feature — the atlas source is the first one that can produce a genuine
+# duplicate against a local .STATUS record.
+#
+# Usage: zsh tests/e2e-agenda-atlas.zsh
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    local test_func="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo -n "  ${CYAN}[$TESTS_RUN] $test_name...${RESET} "
+
+    local output
+    output=$(eval "$test_func" 2>&1)
+    local rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        echo "${GREEN}PASS${RESET}"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    elif [[ $rc -eq 77 ]]; then
+        echo "${YELLOW}SKIP${RESET}"
+    else
+        echo "${RED}FAIL${RESET}"
+        [[ -n "$output" ]] && echo "    ${DIM}${output:0:300}${RESET}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+echo ""
+echo "${CYAN}══════════════════════════════════════════════════════════════${RESET}"
+echo "${CYAN}  E2E: Agenda Atlas Source (dark-ready)${RESET}"
+echo "${CYAN}══════════════════════════════════════════════════════════════${RESET}"
+echo ""
+
+FLOW_QUIET=1
+FLOW_ATLAS_ENABLED=no
+FLOW_SCHEDULE_NO_CACHE=1
+FLOW_PLUGIN_DIR="$PROJECT_ROOT"
+source "$PROJECT_ROOT/flow.plugin.zsh" 2>/dev/null || {
+    echo "${RED}Failed to load plugin${RESET}"
+    exit 1
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "${YELLOW}jq not installed — skipping (atlas agenda source requires jq)${RESET}"
+    exit 77
+fi
+
+exec < /dev/null
+
+FIXTURE="$PROJECT_ROOT/tests/fixtures/atlas-agenda-stub.json"
+
+# Isolated project root. "grant-writing" matches the fixture's project field
+# so category-filter + dedupe tests resolve a real local path for it.
+TEST_ROOT=$(mktemp -d)
+STUB_BIN=$(mktemp -d)
+mkdir -p "$TEST_ROOT/research/grant-writing"
+cat > "$TEST_ROOT/research/grant-writing/.STATUS" <<'EOF'
+## Status: active
+
+## Schedule:
+- 2026-07-05 | Submit grant report | research
+EOF
+
+FLOW_PROJECTS_ROOT="$TEST_ROOT"
+
+ORIGINAL_DIR=$(pwd)
+ORIGINAL_PATH="$PATH"
+cleanup() {
+    cd "$ORIGINAL_DIR"
+    PATH="$ORIGINAL_PATH"
+    _FLOW_ATLAS_AVAILABLE=""
+    _FLOW_ATLAS_HAS_AGENDA=""
+    rm -rf "$TEST_ROOT" "$STUB_BIN"
+}
+trap cleanup EXIT
+
+_install_stub_atlas() {
+    cat > "$STUB_BIN/atlas" <<EOF
+#!/bin/sh
+if [ "\$1" = "agenda" ] && [ "\$2" = "--help" ]; then
+  exit 0
+fi
+if [ "\$1" = "agenda" ]; then
+  cat "$FIXTURE"
+  exit 0
+fi
+exit 1
+EOF
+    chmod +x "$STUB_BIN/atlas"
+}
+
+# ============================================================================
+# SECTION 1: atlas absent (D15) — degradation proven
+# ============================================================================
+
+echo "${CYAN}--- Section 1: Atlas absent (capability-flag override) ---${RESET}"
+
+run_test "agenda -m with atlas absent: only the local .STATUS record, no atlas items" '
+    _FLOW_ATLAS_AVAILABLE="no"
+    _FLOW_ATLAS_HAS_AGENDA=""
+    local output
+    output=$(agenda -m 2>&1)
+    [[ "$output" == *"Submit grant report"* ]] || { echo "local record missing"; return 1; }
+    [[ "$output" != *"NIH progress report"* ]] || { echo "atlas item leaked while atlas absent"; return 1; }
+'
+
+run_test "no atlas: output identical whether _schedule_atlas_items exists or not (no behavior change)" '
+    _FLOW_ATLAS_AVAILABLE="no"
+    _FLOW_ATLAS_HAS_AGENDA=""
+    local with_source=$(agenda -m 2>&1)
+    local direct=$(_schedule_atlas_items 30 2>&1)
+    [[ -z "$direct" ]] || { echo "atlas source not empty while absent: $direct"; return 1; }
+    [[ -n "$with_source" ]] || return 1
+'
+
+# ============================================================================
+# SECTION 2: atlas present + capable (D16) — items merge in
+# ============================================================================
+
+echo ""
+echo "${CYAN}--- Section 2: Atlas present (stub shim on PATH) ---${RESET}"
+
+run_test "agenda -m merges atlas fixture items alongside the local .STATUS record" '
+    _install_stub_atlas
+    PATH="$STUB_BIN:$ORIGINAL_PATH"
+    _FLOW_ATLAS_AVAILABLE=""
+    _FLOW_ATLAS_HAS_AGENDA=""
+    local output
+    output=$(agenda -m 2>&1)
+    PATH="$ORIGINAL_PATH"
+    [[ "$output" == *"Submit grant report"* ]] || { echo "local record missing"; return 1; }
+    [[ "$output" == *"NIH progress report"* ]] || { echo "atlas item missing"; return 1; }
+'
+
+run_test "atlas items pass through the category filter (_schedule_collect, wide window)" '
+    _install_stub_atlas
+    PATH="$STUB_BIN:$ORIGINAL_PATH"
+    _FLOW_ATLAS_AVAILABLE=""
+    _FLOW_ATLAS_HAS_AGENDA=""
+    # Direct _schedule_collect call (not the `agenda` CLI, which hardcodes
+    # window=7 for category filters) — a wide window avoids the fixture'"'"'s
+    # fixed dates going stale relative to "today" as real time passes.
+    local output
+    output=$(_schedule_collect 3650 research 2>&1)
+    PATH="$ORIGINAL_PATH"
+    [[ "$output" == *"NIH progress report"* ]] || { echo "atlas research item missing under category filter"; return 1; }
+'
+
+# ============================================================================
+# SECTION 3: dedupe (date|label|project) — atlas duplicate of a local record
+# ============================================================================
+
+echo ""
+echo "${CYAN}--- Section 3: Dedupe across sources ---${RESET}"
+
+run_test "a (date,label,project)-identical atlas record does not double-count the local one" '
+    _install_stub_atlas
+    PATH="$STUB_BIN:$ORIGINAL_PATH"
+    _FLOW_ATLAS_AVAILABLE=""
+    _FLOW_ATLAS_HAS_AGENDA=""
+    # The fixture'"'"'s first record (2026-07-05|Submit grant report|research|grant-writing)
+    # exactly matches the local .STATUS record above on (date,label,project).
+    local output
+    output=$(agenda -m 2>&1)
+    PATH="$ORIGINAL_PATH"
+    local count=$(print -r -- "$output" | grep -c "Submit grant report")
+    [[ "$count" -eq 1 ]] || { echo "expected exactly 1 occurrence, got $count"; return 1; }
+'
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+echo ""
+cd "$ORIGINAL_DIR"
+echo "${CYAN}══════════════════════════════════════════════════════════════${RESET}"
+if [[ $TESTS_FAILED -eq 0 ]]; then
+    echo "${GREEN}All $TESTS_PASSED/$TESTS_RUN e2e tests passed${RESET}"
+    exit 0
+else
+    echo "${RED}$TESTS_FAILED/$TESTS_RUN tests failed (${TESTS_PASSED} passed)${RESET}"
+    exit 1
+fi

--- a/tests/fixtures/atlas-agenda-stub.json
+++ b/tests/fixtures/atlas-agenda-stub.json
@@ -1,0 +1,16 @@
+[
+  {
+    "date": "2026-07-05",
+    "label": "Submit grant report",
+    "type": "research",
+    "project": "grant-writing",
+    "recurrence": "none"
+  },
+  {
+    "date": "2026-07-12",
+    "label": "NIH progress report",
+    "type": "research",
+    "project": "grant-writing",
+    "recurrence": "none"
+  }
+]

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -92,6 +92,7 @@ echo "Core command tests:"
 run_test ./tests/test-flow-claude.zsh
 run_test ./tests/test-dash.zsh
 run_test ./tests/test-schedule.zsh
+run_test ./tests/test-schedule-atlas-source.zsh
 run_test ./tests/test-agenda.zsh
 run_test ./tests/test-cadence-agenda.zsh
 run_test ./tests/test-work.zsh
@@ -162,6 +163,7 @@ run_test ./tests/e2e-atlas-bridge.zsh
 run_test ./tests/e2e-scholar-config-sync.zsh
 run_test ./tests/e2e-tok-sync.zsh
 run_test ./tests/e2e-agenda.zsh
+run_test ./tests/e2e-agenda-atlas.zsh
 
 echo ""
 echo "Atlas contract tests:"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -99,6 +99,7 @@ run_test ./tests/test-doctor.zsh 45
 run_test ./tests/test-capture.zsh
 run_test ./tests/test-pick-wt.zsh
 run_test ./tests/test-adhd.zsh
+run_test ./tests/test-path-bug-fix.zsh
 run_test ./tests/test-flow.zsh
 run_test ./tests/test-timer.zsh
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -100,6 +100,7 @@ run_test ./tests/test-capture.zsh
 run_test ./tests/test-pick-wt.zsh
 run_test ./tests/test-adhd.zsh
 run_test ./tests/test-path-bug-fix.zsh
+run_test ./tests/test-status-field-parity.zsh
 run_test ./tests/test-flow.zsh
 run_test ./tests/test-timer.zsh
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -173,6 +173,7 @@ run_test ./tests/test-doctor-atlas-calls.zsh
 echo ""
 echo "Additional unit tests:"
 run_test ./tests/test-status-fields.zsh
+run_test ./tests/test-status-schema.zsh
 run_test ./tests/test-lint-e2e.zsh
 run_test ./tests/test-teach-prompt-unit.zsh
 run_test ./tests/test-scholar-config-sync.zsh

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -101,6 +101,9 @@ run_test ./tests/test-pick-wt.zsh
 run_test ./tests/test-adhd.zsh
 run_test ./tests/test-path-bug-fix.zsh
 run_test ./tests/test-status-field-parity.zsh
+run_test ./tests/test-status-field-accessor.zsh
+run_test ./tests/test-project-path-resolver.zsh
+run_test ./tests/test-suggest-project.zsh
 run_test ./tests/test-flow.zsh
 run_test ./tests/test-timer.zsh
 

--- a/tests/test-atlas-contract.zsh
+++ b/tests/test-atlas-contract.zsh
@@ -233,6 +233,49 @@ if ! skip_without_warm_atlas; then
 fi
 
 # ============================================================================
+# ATLAS AGENDA SOURCE (Track C, dark-ready — SPEC-planning-coordination-2026-07-01 §3.4)
+# ============================================================================
+# Pins tests/fixtures/atlas-agenda-stub.json's shape to the `atlas agenda`
+# JSON example documented in ATLAS-CONTRACT.md — a contract edit without a
+# matching fixture update fails this test loudly instead of drifting silently
+# (D16). Always runs (doesn't need real atlas — the fixture stands in for it).
+
+test_case "atlas-agenda-stub.json fixture keys match the ATLAS-CONTRACT.md documented example"
+if ! command -v jq >/dev/null 2>&1; then
+  test_skip "jq not installed"
+else
+  local fixture="$PROJECT_ROOT/tests/fixtures/atlas-agenda-stub.json"
+  local contract_doc="$PROJECT_ROOT/docs/ATLAS-CONTRACT.md"
+
+  if [[ ! -f "$fixture" ]]; then
+    assert_exit_code 1 0 "fixture file missing: $fixture"
+  else
+    # Extract the fenced ```json block under the "### `atlas agenda`" heading.
+    local contract_json
+    contract_json=$(awk '/### `atlas agenda`/{found=1} found && /^```json/{incode=1; next} incode && /^```/{exit} incode' "$contract_doc")
+
+    local contract_keys fixture_keys
+    contract_keys=$(print -r -- "$contract_json" | jq -r '.[0] | keys | sort | join(",")' 2>/dev/null)
+    fixture_keys=$(jq -r '.[0] | keys | sort | join(",")' "$fixture" 2>/dev/null)
+
+    assert_not_empty "$contract_keys" "contract doc must have a parseable atlas agenda JSON example (got none — heading text or fence may have drifted)"
+    assert_not_empty "$fixture_keys" "fixture must be valid JSON with at least one object"
+    assert_equals "$fixture_keys" "$contract_keys" "fixture keys ($fixture_keys) must match the contract doc's documented example ($contract_keys)"
+  fi
+fi
+test_pass
+
+test_case "atlas-agenda-stub.json is a valid JSON array (jq-parseable)"
+if ! command -v jq >/dev/null 2>&1; then
+  test_skip "jq not installed"
+else
+  local fixture="$PROJECT_ROOT/tests/fixtures/atlas-agenda-stub.json"
+  jq -e 'type == "array" and length > 0' "$fixture" >/dev/null 2>&1
+  assert_exit_code $? 0 "fixture must be a non-empty JSON array"
+fi
+test_pass
+
+# ============================================================================
 # HELP BROWSER INTEGRATION
 # ============================================================================
 

--- a/tests/test-path-bug-fix.zsh
+++ b/tests/test-path-bug-fix.zsh
@@ -1,0 +1,139 @@
+#!/usr/bin/env zsh
+# tests/test-path-bug-fix.zsh
+# Regression test for the $path -> $project_path bug (SPEC-planning-coordination
+# §3.0, ORCHESTRATE-planning-coordination.md Phase 0).
+#
+# _flow_get_project_fallback (lib/atlas-bridge.zsh:397) deliberately emits
+# `project_path=` (never `path=`) to avoid colliding with ZSH's PATH-tied
+# `$path` array. But commands/morning.zsh:83-89 and commands/adhd.zsh:103-108
+# read `$path` after `eval "$info"` instead of `$project_path` — so `$path`
+# resolves to ZSH's PATH array (always non-empty), the `.STATUS` file lookup
+# silently fails, and focus/progress render blank while the project-type
+# icon falls back to generic even for a project with clear type markers.
+#
+# This suite proves that broken behavior is fixed, isolated from the Phase 1
+# shared-accessor refactor.
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh" || { echo "ERROR: Cannot source test-framework.zsh"; exit 1 }
+
+# ============================================================================
+# SETUP
+# ============================================================================
+
+setup() {
+    if [[ ! -f "$PROJECT_ROOT/flow.plugin.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root${RESET}"
+        exit 1
+    fi
+
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$PROJECT_ROOT"
+    source "$PROJECT_ROOT/flow.plugin.zsh" 2>/dev/null || {
+        echo "${RED}Plugin failed to load${RESET}"
+        exit 1
+    }
+
+    # Force filesystem fallback regardless of env (memory:
+    # capture-real-agenda-output-for-docs — FLOW_ATLAS_ENABLED=no alone is
+    # known-insufficient; override the capability probe directly).
+    _flow_has_atlas() { return 1 }
+
+    exec < /dev/null
+
+    # Isolated project root — a single project with nonzero progress, a
+    # focus line, and R-package markers (for the icon assertion) so the
+    # project-type default ("generic") can't accidentally look correct.
+    TEST_ROOT=$(mktemp -d)
+    PROJECT_NAME="pathbugtest"
+    PROJECT_DIR="$TEST_ROOT/$PROJECT_NAME"
+    mkdir -p "$PROJECT_DIR"
+    cat > "$PROJECT_DIR/.STATUS" <<'EOF'
+## Status: active
+## Focus: Ship the widget
+## Progress: 42
+EOF
+    # R-package markers so _flow_detect_project_type resolves to
+    # "r-package" (icon 📦) only when given the correct directory.
+    touch "$PROJECT_DIR/DESCRIPTION" "$PROJECT_DIR/NAMESPACE"
+
+    FLOW_PROJECTS_ROOT="$TEST_ROOT"
+}
+
+cleanup() {
+    reset_mocks
+    unset -f _flow_has_atlas 2>/dev/null
+    [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+# ============================================================================
+# TESTS: next (commands/adhd.zsh) reads project_path, not $path
+# ============================================================================
+
+test_next_shows_focus() {
+    test_case "next shows the project's Focus line (not blank)"
+    local output=$(next 2>&1)
+    assert_contains "$output" "Ship the widget" \
+        "next should render '## Focus:' from .STATUS via \$project_path" && test_pass
+}
+
+test_next_shows_correct_icon() {
+    test_case "next shows the r-package icon (project type resolved from real path)"
+    local output=$(next 2>&1)
+    assert_contains "$output" "📦" \
+        "next should detect r-package type via \$project_path, not the generic fallback" && test_pass
+}
+
+# ============================================================================
+# TESTS: morning (commands/morning.zsh) reads project_path, not $path
+# ============================================================================
+
+test_morning_shows_focus() {
+    test_case "morning shows the project's Focus line (not blank)"
+    local output=$(morning 2>&1)
+    assert_contains "$output" "Ship the widget" \
+        "morning should render '## Focus:' from .STATUS via \$project_path" && test_pass
+}
+
+test_morning_shows_progress() {
+    test_case "morning shows the project's Progress percentage (not blank)"
+    local output=$(morning 2>&1)
+    assert_contains "$output" "42%" \
+        "morning should render '## Progress:' from .STATUS via \$project_path" && test_pass
+}
+
+test_morning_shows_correct_icon() {
+    test_case "morning shows the r-package icon (project type resolved from real path)"
+    local output=$(morning 2>&1)
+    assert_contains "$output" "📦" \
+        "morning should detect r-package type via \$project_path, not the generic fallback" && test_pass
+}
+
+# ============================================================================
+# RUN TESTS
+# ============================================================================
+
+main() {
+    test_suite "Path Bug Fix Tests (\$path -> \$project_path)"
+
+    setup
+
+    echo "${CYAN}--- next (adhd.zsh) ---${RESET}"
+    test_next_shows_focus
+    test_next_shows_correct_icon
+
+    echo ""
+    echo "${CYAN}--- morning (morning.zsh) ---${RESET}"
+    test_morning_shows_focus
+    test_morning_shows_progress
+    test_morning_shows_correct_icon
+
+    cleanup
+    test_suite_end
+    exit $?
+}
+
+main "$@"

--- a/tests/test-project-path-resolver.zsh
+++ b/tests/test-project-path-resolver.zsh
@@ -1,0 +1,144 @@
+#!/usr/bin/env zsh
+# tests/test-project-path-resolver.zsh
+# Red-then-green unit tests for `_flow_resolve_project_path` (SPEC §3.1,
+# ORCHESTRATE task 1.1/1.3) — merges _dash_find_project_path (dash.zsh:1284,
+# has apps + quarto/manuscripts + presentations) and
+# _flow_get_project_fallback (atlas-bridge.zsh:370). Always emits
+# `project_path=`, never `path=`.
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh" || { echo "ERROR: Cannot source test-framework.zsh"; exit 1 }
+
+setup() {
+    if [[ ! -f "$PROJECT_ROOT/flow.plugin.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root${RESET}"
+        exit 1
+    fi
+
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$PROJECT_ROOT"
+    source "$PROJECT_ROOT/flow.plugin.zsh" 2>/dev/null || {
+        echo "${RED}Plugin failed to load${RESET}"
+        exit 1
+    }
+    exec < /dev/null
+
+    TEST_ROOT=$(mktemp -d)
+    mkdir -p "$TEST_ROOT/dev-tools/dt-proj"
+    mkdir -p "$TEST_ROOT/apps/app-proj"
+    mkdir -p "$TEST_ROOT/r-packages/active/rpkg-proj"
+    mkdir -p "$TEST_ROOT/r-packages/stable/rstable-proj"
+    mkdir -p "$TEST_ROOT/research/research-proj"
+    mkdir -p "$TEST_ROOT/teaching/teach-proj"
+    mkdir -p "$TEST_ROOT/quarto/manuscripts/ms-proj"
+    mkdir -p "$TEST_ROOT/quarto/presentations/pres-proj"
+    mkdir -p "$TEST_ROOT/root-proj"
+    FLOW_PROJECTS_ROOT="$TEST_ROOT"
+}
+
+cleanup() {
+    reset_mocks
+    [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+test_function_exists() {
+    test_case "_flow_resolve_project_path function exists"
+    assert_function_exists "_flow_resolve_project_path" && test_pass
+}
+
+_resolve() {
+    local out
+    out=$(FLOW_PROJECTS_ROOT="$TEST_ROOT" _flow_resolve_project_path "$1") || { echo ""; return 1; }
+    local project_path
+    eval "$out"
+    echo "$project_path"
+}
+
+test_finds_dev_tools() {
+    test_case "resolves a dev-tools project"
+    assert_equals "$(_resolve dt-proj)" "$TEST_ROOT/dev-tools/dt-proj" "dev-tools" && test_pass
+}
+
+test_finds_apps() {
+    test_case "resolves an apps project (dash's superset over atlas fallback)"
+    assert_equals "$(_resolve app-proj)" "$TEST_ROOT/apps/app-proj" "apps" && test_pass
+}
+
+test_finds_r_packages_active() {
+    test_case "resolves an r-packages/active project"
+    assert_equals "$(_resolve rpkg-proj)" "$TEST_ROOT/r-packages/active/rpkg-proj" "r-packages active" && test_pass
+}
+
+test_finds_r_packages_stable() {
+    test_case "resolves an r-packages/stable project"
+    assert_equals "$(_resolve rstable-proj)" "$TEST_ROOT/r-packages/stable/rstable-proj" "r-packages stable" && test_pass
+}
+
+test_finds_research() {
+    test_case "resolves a research project"
+    assert_equals "$(_resolve research-proj)" "$TEST_ROOT/research/research-proj" "research" && test_pass
+}
+
+test_finds_teaching() {
+    test_case "resolves a teaching project"
+    assert_equals "$(_resolve teach-proj)" "$TEST_ROOT/teaching/teach-proj" "teaching" && test_pass
+}
+
+test_finds_quarto_manuscripts() {
+    test_case "resolves a quarto/manuscripts project"
+    assert_equals "$(_resolve ms-proj)" "$TEST_ROOT/quarto/manuscripts/ms-proj" "quarto manuscripts" && test_pass
+}
+
+test_finds_quarto_presentations() {
+    test_case "resolves a quarto/presentations project"
+    assert_equals "$(_resolve pres-proj)" "$TEST_ROOT/quarto/presentations/pres-proj" "quarto presentations" && test_pass
+}
+
+test_finds_root_exact_match() {
+    test_case "resolves a project directly under FLOW_PROJECTS_ROOT"
+    assert_equals "$(_resolve root-proj)" "$TEST_ROOT/root-proj" "root exact match" && test_pass
+}
+
+test_unknown_project_empty() {
+    test_case "unknown project name resolves to empty and exit 1"
+    local out
+    out=$(FLOW_PROJECTS_ROOT="$TEST_ROOT" _flow_resolve_project_path "totally-unknown-xyz")
+    local rc=$?
+    assert_empty "$out" "unknown -> empty" && \
+    assert_exit_code $rc 1 "unknown -> exit 1" && test_pass
+}
+
+test_emits_project_path_key() {
+    test_case "output uses the key 'project_path=', never 'path='"
+    local out
+    out=$(FLOW_PROJECTS_ROOT="$TEST_ROOT" _flow_resolve_project_path "dt-proj")
+    assert_contains "$out" "project_path=" "has project_path=" && \
+    assert_not_contains "$out" $'\npath=' "never bare path=" && test_pass
+}
+
+main() {
+    test_suite "_flow_resolve_project_path resolver"
+    setup
+
+    test_function_exists
+    test_finds_dev_tools
+    test_finds_apps
+    test_finds_r_packages_active
+    test_finds_r_packages_stable
+    test_finds_research
+    test_finds_teaching
+    test_finds_quarto_manuscripts
+    test_finds_quarto_presentations
+    test_finds_root_exact_match
+    test_unknown_project_empty
+    test_emits_project_path_key
+
+    cleanup
+    test_suite_end
+    exit $?
+}
+
+main "$@"

--- a/tests/test-schedule-atlas-source.zsh
+++ b/tests/test-schedule-atlas-source.zsh
@@ -139,12 +139,23 @@ test_no_jq_is_graceful_noop() {
     _reset_atlas_caches
     local old_path="$PATH"
     _install_stub_atlas capable
-    # Minimal explicit PATH (stub atlas dir + /bin only) rather than trying to
-    # subtract jq's directory from $PATH — this box has jq on more than one
-    # PATH entry (e.g. both /opt/homebrew/bin and /usr/bin), so a single
-    # subtraction doesn't reliably hide it. /bin has no jq and covers the
-    # POSIX utilities the harness itself needs.
-    PATH="$STUB_BIN:/bin"
+    # PATH = $STUB_BIN only — no real system directory (no subtraction from
+    # $PATH, no "/bin should be jq-free" assumption). $STUB_BIN is a fresh
+    # mktemp dir under this test's exclusive control containing only the
+    # atlas stub, so it is guaranteed jq-free on every platform.
+    #
+    # This is deliberately NOT "$STUB_BIN:/bin": that assumption held on
+    # macOS (a real, separate /bin with no jq) but broke on Ubuntu's
+    # `ubuntu-latest` CI runner — Ubuntu has been usr-merged since 19.10, so
+    # /bin is a symlink to /usr/bin, which ships jq preinstalled. /bin/jq
+    # then resolved on CI, the no-op branch never triggered, and this test
+    # failed (same bug class as the documented macos-only-shell-isms-break-
+    # linux-ci gotcha — a PATH/filesystem assumption that only holds on
+    # macOS). Verified $STUB_BIN alone is sufficient: _schedule_atlas_items
+    # only needs `atlas` (found — the stub) and `jq` (not found, by
+    # construction) on PATH for this code path; nothing else is invoked
+    # before the early return.
+    PATH="$STUB_BIN"
     local out
     out=$(_schedule_atlas_items 7 2>&1)
     local rc=$?

--- a/tests/test-schedule-atlas-source.zsh
+++ b/tests/test-schedule-atlas-source.zsh
@@ -1,0 +1,172 @@
+#!/usr/bin/env zsh
+# tests/test-schedule-atlas-source.zsh
+# Red-then-green unit tests for `_schedule_atlas_items <window>` (SPEC
+# §3.4, ORCHESTRATE Phase 2, task 2.1) — the dark-ready atlas agenda source
+# merged into the schedule engine.
+#
+# D15: atlas-absent is simulated via the capability-flag override
+# (_flow_has_atlas / _FLOW_ATLAS_HAS_AGENDA), NOT `FLOW_ATLAS_ENABLED=no`
+# alone (memory: capture-real-agenda-output-for-docs).
+# D16: atlas-present is simulated via a stub `atlas` shim on PATH returning
+# tests/fixtures/atlas-agenda-stub.json (real atlas has no `agenda` command
+# yet, so it cannot be used for this).
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh" || { echo "ERROR: Cannot source test-framework.zsh"; exit 1 }
+
+FIXTURE="$PROJECT_ROOT/tests/fixtures/atlas-agenda-stub.json"
+
+setup() {
+    if [[ ! -f "$PROJECT_ROOT/flow.plugin.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root${RESET}"
+        exit 1
+    fi
+
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$PROJECT_ROOT"
+    source "$PROJECT_ROOT/flow.plugin.zsh" 2>/dev/null || {
+        echo "${RED}Plugin failed to load${RESET}"
+        exit 1
+    }
+    exec < /dev/null
+
+    STUB_BIN=$(mktemp -d)
+}
+
+cleanup() {
+    reset_mocks
+    _FLOW_ATLAS_AVAILABLE=""
+    _FLOW_ATLAS_HAS_AGENDA=""
+    [[ -n "$STUB_BIN" && -d "$STUB_BIN" ]] && rm -rf "$STUB_BIN"
+}
+trap cleanup EXIT
+
+# Reset the two session caches this function consults, so each test gets a
+# fresh capability probe regardless of what a prior test in this file did.
+_reset_atlas_caches() {
+    _FLOW_ATLAS_AVAILABLE=""
+    _FLOW_ATLAS_HAS_AGENDA=""
+}
+
+# Writes a stub `atlas` executable to $STUB_BIN and prepends it to PATH.
+# $1 - "capable"   -> agenda --help exits 0; agenda <window> --format=json cats the fixture
+#      "incapable" -> everything exits 1 (simulates an atlas without `agenda`)
+_install_stub_atlas() {
+    local mode="$1"
+    if [[ "$mode" == "capable" ]]; then
+        cat > "$STUB_BIN/atlas" <<EOF
+#!/bin/sh
+if [ "\$1" = "agenda" ] && [ "\$2" = "--help" ]; then
+  exit 0
+fi
+if [ "\$1" = "agenda" ]; then
+  cat "$FIXTURE"
+  exit 0
+fi
+exit 1
+EOF
+    else
+        cat > "$STUB_BIN/atlas" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+    fi
+    chmod +x "$STUB_BIN/atlas"
+    export PATH="$STUB_BIN:$PATH"
+}
+
+test_function_exists() {
+    test_case "_schedule_atlas_items function exists"
+    assert_function_exists "_schedule_atlas_items" && test_pass
+}
+
+test_absent_via_capability_flag_is_empty() {
+    test_case "atlas absent (capability-flag override): empty output, no crash"
+    _reset_atlas_caches
+    create_mock "_flow_has_atlas" "return 1"
+    local out=$(_schedule_atlas_items 7)
+    reset_mocks
+    assert_empty "$out" "no atlas -> empty" && test_pass
+}
+
+test_present_but_no_agenda_capability_is_empty() {
+    test_case "atlas present but lacks 'agenda' (older atlas): empty output"
+    if ! command -v jq >/dev/null 2>&1; then
+        test_skip "jq not installed"
+        return
+    fi
+    _reset_atlas_caches
+    local old_path="$PATH"
+    _install_stub_atlas incapable
+    local out=$(_schedule_atlas_items 7)
+    PATH="$old_path"
+    assert_empty "$out" "incapable atlas -> empty" && test_pass
+}
+
+test_capable_atlas_maps_fixture_to_records() {
+    test_case "atlas present + capable: fixture maps to date|label|type|project|recurrence|atlas"
+    if ! command -v jq >/dev/null 2>&1; then
+        test_skip "jq not installed"
+        return
+    fi
+    _reset_atlas_caches
+    local old_path="$PATH"
+    _install_stub_atlas capable
+    local out=$(_schedule_atlas_items 7)
+    PATH="$old_path"
+    assert_contains "$out" "2026-07-05|Submit grant report|research|grant-writing|none|atlas" "first fixture record mapped" && \
+    assert_contains "$out" "2026-07-12|NIH progress report|research|grant-writing|none|atlas" "second fixture record mapped" && test_pass
+}
+
+test_capability_probe_is_cached() {
+    test_case "capability probe result is cached in _FLOW_ATLAS_HAS_AGENDA"
+    if ! command -v jq >/dev/null 2>&1; then
+        test_skip "jq not installed"
+        return
+    fi
+    _reset_atlas_caches
+    local old_path="$PATH"
+    _install_stub_atlas capable
+    _schedule_atlas_items 7 >/dev/null
+    PATH="$old_path"
+    assert_equals "$_FLOW_ATLAS_HAS_AGENDA" "yes" "cached as yes after a capable probe" && test_pass
+}
+
+test_no_jq_is_graceful_noop() {
+    test_case "jq absent: graceful no-op, not a crash"
+    _reset_atlas_caches
+    local old_path="$PATH"
+    _install_stub_atlas capable
+    # Minimal explicit PATH (stub atlas dir + /bin only) rather than trying to
+    # subtract jq's directory from $PATH — this box has jq on more than one
+    # PATH entry (e.g. both /opt/homebrew/bin and /usr/bin), so a single
+    # subtraction doesn't reliably hide it. /bin has no jq and covers the
+    # POSIX utilities the harness itself needs.
+    PATH="$STUB_BIN:/bin"
+    local out
+    out=$(_schedule_atlas_items 7 2>&1)
+    local rc=$?
+    PATH="$old_path"
+    assert_empty "$out" "no jq -> empty, no crash" && \
+    assert_exit_code $rc 0 "no jq -> exit 0 (graceful)" && test_pass
+}
+
+main() {
+    test_suite "_schedule_atlas_items (dark-ready atlas agenda source)"
+    setup
+
+    test_function_exists
+    test_absent_via_capability_flag_is_empty
+    test_present_but_no_agenda_capability_is_empty
+    test_capable_atlas_maps_fixture_to_records
+    test_capability_probe_is_cached
+    test_no_jq_is_graceful_noop
+
+    cleanup
+    test_suite_end
+    exit $?
+}
+
+main "$@"

--- a/tests/test-status-field-accessor.zsh
+++ b/tests/test-status-field-accessor.zsh
@@ -1,0 +1,107 @@
+#!/usr/bin/env zsh
+# tests/test-status-field-accessor.zsh
+# Red-then-green unit tests for the new shared accessor `_flow_status_field`
+# (SPEC-planning-coordination-2026-07-01 §3.1, ORCHESTRATE task 1.1/1.2).
+#
+# Signature: _flow_status_field <project-root-dir> <field>
+# (unlike _dash_get_status_field, which takes the FULL .STATUS file path —
+# _flow_status_field takes the project ROOT and appends /.STATUS itself.)
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh" || { echo "ERROR: Cannot source test-framework.zsh"; exit 1 }
+
+setup() {
+    if [[ ! -f "$PROJECT_ROOT/flow.plugin.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root${RESET}"
+        exit 1
+    fi
+
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$PROJECT_ROOT"
+    source "$PROJECT_ROOT/flow.plugin.zsh" 2>/dev/null || {
+        echo "${RED}Plugin failed to load${RESET}"
+        exit 1
+    }
+    exec < /dev/null
+
+    TEST_ROOT=$(mktemp -d)
+    mkdir -p "$TEST_ROOT/md" "$TEST_ROOT/yaml" "$TEST_ROOT/synonym"
+    cat > "$TEST_ROOT/md/.STATUS" <<'EOF'
+## Status: active
+## Focus: Fix: the bug at 80% coverage
+## Progress: 42%
+EOF
+    printf "status: active\npriority: 2\n" > "$TEST_ROOT/yaml/.STATUS"
+    printf "## Status: In Progress\n" > "$TEST_ROOT/synonym/.STATUS"
+}
+
+cleanup() {
+    reset_mocks
+    [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+test_function_exists() {
+    test_case "_flow_status_field function exists"
+    assert_function_exists "_flow_status_field" && test_pass
+}
+
+test_markdown_dialect() {
+    test_case "_flow_status_field reads '## Field:' markdown dialect"
+    local v=$(_flow_status_field "$TEST_ROOT/md" "Focus")
+    assert_equals "$v" "Fix: the bug at 80% coverage" "markdown dialect" && test_pass
+}
+
+test_yaml_dialect() {
+    test_case "_flow_status_field reads 'field:' YAML-ish dialect"
+    local v=$(_flow_status_field "$TEST_ROOT/yaml" "status")
+    assert_equals "$v" "active" "yaml dialect" && test_pass
+}
+
+test_percent_not_stripped_by_default() {
+    test_case "_flow_status_field does NOT strip % (call sites do that themselves)"
+    local v=$(_flow_status_field "$TEST_ROOT/md" "Progress")
+    assert_equals "$v" "42%" "raw value keeps %" && test_pass
+}
+
+test_missing_field_returns_empty() {
+    test_case "_flow_status_field returns empty for a missing field"
+    local v=$(_flow_status_field "$TEST_ROOT/md" "NoSuchField")
+    assert_empty "$v" "missing field" && test_pass
+}
+
+test_missing_status_file_returns_empty() {
+    test_case "_flow_status_field returns empty (exit 1) when .STATUS is absent"
+    local v
+    v=$(_flow_status_field "$TEST_ROOT/does-not-exist" "Status")
+    local rc=$?
+    assert_empty "$v" "missing file -> empty" && \
+    assert_exit_code $rc 1 "missing file -> exit 1" && test_pass
+}
+
+test_status_synonym_mapping() {
+    test_case "_flow_status_field normalizes Status synonyms ('In Progress' -> 'active')"
+    local v=$(_flow_status_field "$TEST_ROOT/synonym" "Status")
+    assert_equals "$v" "active" "status synonym mapping preserved" && test_pass
+}
+
+main() {
+    test_suite "_flow_status_field accessor"
+    setup
+
+    test_function_exists
+    test_markdown_dialect
+    test_yaml_dialect
+    test_percent_not_stripped_by_default
+    test_missing_field_returns_empty
+    test_missing_status_file_returns_empty
+    test_status_synonym_mapping
+
+    cleanup
+    test_suite_end
+    exit $?
+}
+
+main "$@"

--- a/tests/test-status-field-parity.zsh
+++ b/tests/test-status-field-parity.zsh
@@ -1,0 +1,292 @@
+#!/usr/bin/env zsh
+# tests/test-status-field-parity.zsh
+# Characterization tests for the .STATUS field readers, SNAPSHOTTED BEFORE the
+# Phase 1 shared-accessor refactor (SPEC-planning-coordination-2026-07-01
+# §3.1, ORCHESTRATE-planning-coordination.md task 1.0).
+#
+# This suite locks down the CURRENT byte-exact output of:
+#   - _dash_get_status_field / _dash_get_project_status / _dash_get_project_focus
+#     / _dash_get_project_progress   (commands/dash.zsh)
+#   - the inline greps in `morning` (commands/morning.zsh) and `next`
+#     (commands/adhd.zsh)
+#   - _flow_read_goal's inline daily_goal grep (commands/capture.zsh)
+#   - _flow_where_fallback's inline Status/Focus greps (lib/atlas-bridge.zsh)
+#
+# It must be GREEN on today's code, before `_flow_status_field` exists. After
+# the refactor migrates these call sites onto the shared accessor, this same
+# suite must stay green (parity) — see task 1.7. The one sanctioned exception
+# is `_flow_where_fallback`: today it CRASHES on `local status=...` (`status`
+# is a zsh read-only special variable, even as a function-local) and never
+# prints Status:/Focus: at all. That crash is characterized explicitly below
+# (test_where_fallback_currently_crashes_on_status) and is EXPECTED to change
+# post-refactor — the migration renames the colliding local and fixes it as
+# an unavoidable side effect of touching that exact line. This is a discovered
+# bug fix, not a silent behavior-loss regression; flagged in the Phase 1
+# report per the "don't adjust the test to hide a diff" rule.
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh" || { echo "ERROR: Cannot source test-framework.zsh"; exit 1 }
+
+# ============================================================================
+# SETUP
+# ============================================================================
+
+setup() {
+    if [[ ! -f "$PROJECT_ROOT/flow.plugin.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root${RESET}"
+        exit 1
+    fi
+
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$PROJECT_ROOT"
+    source "$PROJECT_ROOT/flow.plugin.zsh" 2>/dev/null || {
+        echo "${RED}Plugin failed to load${RESET}"
+        exit 1
+    }
+    _flow_has_atlas() { return 1 }
+    exec < /dev/null
+
+    TEST_ROOT=$(mktemp -d)
+
+    # proj1: the discriminating fixture — colon-in-value, % in a non-progress
+    # field, markdown dialect.
+    mkdir -p "$TEST_ROOT/proj1"
+    cat > "$TEST_ROOT/proj1/.STATUS" <<'EOF'
+## Status: active
+## Focus: Fix: the bug at 80% coverage
+## Progress: 42%
+## Priority: P1
+## daily_goal: 3
+EOF
+
+    # proj2: Focus missing -> _dash_get_project_focus falls back to "next"
+    mkdir -p "$TEST_ROOT/proj2"
+    printf "## Status: active\n## next: Write the tests\n" > "$TEST_ROOT/proj2/.STATUS"
+
+    # proj3: Status value needing synonym normalization ("In Progress" -> "active")
+    mkdir -p "$TEST_ROOT/proj3"
+    printf "## Status: In Progress\n" > "$TEST_ROOT/proj3/.STATUS"
+
+    # proj_yaml: YAML dialect (no "## " prefix) — only _dash_get_status_field
+    # supports this today; the inline greps (morning/adhd/capture/atlas-bridge)
+    # only match the markdown "## Field:" dialect.
+    mkdir -p "$TEST_ROOT/proj_yaml"
+    printf "status: active\npriority: 2\n" > "$TEST_ROOT/proj_yaml/.STATUS"
+
+    # proj_nofocus: active, no Focus/Progress fields at all (missing-field case)
+    mkdir -p "$TEST_ROOT/proj_nofocus"
+    printf "## Status: active\n" > "$TEST_ROOT/proj_nofocus/.STATUS"
+
+    # proj_where: fixture for the _flow_where_fallback crash characterization
+    mkdir -p "$TEST_ROOT/proj_where"
+    printf "## Status: active\n## Focus: Ship it\n" > "$TEST_ROOT/proj_where/.STATUS"
+
+    # Separate, minimal root for `morning`/`next` command-level rendering
+    # tests: both cap the visible project list (morning: top 5, next: top 3)
+    # and filesystem readdir order is not alphabetical, so a 6-project root
+    # can silently truncate proj1 out of view. Two projects keeps both
+    # commands' rendering deterministic regardless of directory order.
+    CMD_ROOT=$(mktemp -d)
+    mkdir -p "$CMD_ROOT/proj1" "$CMD_ROOT/proj_nofocus"
+    cp "$TEST_ROOT/proj1/.STATUS" "$CMD_ROOT/proj1/.STATUS"
+    cp "$TEST_ROOT/proj_nofocus/.STATUS" "$CMD_ROOT/proj_nofocus/.STATUS"
+}
+
+cleanup() {
+    reset_mocks
+    unset -f _flow_has_atlas 2>/dev/null
+    [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+    [[ -n "$CMD_ROOT" && -d "$CMD_ROOT" ]] && rm -rf "$CMD_ROOT"
+}
+trap cleanup EXIT
+
+# ============================================================================
+# TESTS: _dash_get_status_field (commands/dash.zsh) — raw field reader
+# ============================================================================
+
+test_dash_field_colon_in_value() {
+    test_case "_dash_get_status_field preserves a colon inside the value"
+    local v=$(_dash_get_status_field "$TEST_ROOT/proj1/.STATUS" "Focus")
+    assert_equals "$v" "Fix: the bug at 80% coverage" "colon-in-value focus" && test_pass
+}
+
+test_dash_field_percent_in_non_progress_field() {
+    test_case "_dash_get_status_field does not touch a % inside Focus"
+    local v=$(_dash_get_status_field "$TEST_ROOT/proj1/.STATUS" "Focus")
+    assert_contains "$v" "80%" "% preserved in non-progress field" && test_pass
+}
+
+test_dash_field_progress_keeps_percent() {
+    test_case "_dash_get_status_field('Progress') keeps the raw '%' (no strip in the reader itself)"
+    local v=$(_dash_get_status_field "$TEST_ROOT/proj1/.STATUS" "Progress")
+    assert_equals "$v" "42%" "raw Progress field value" && test_pass
+}
+
+test_dash_field_missing_returns_empty() {
+    test_case "_dash_get_status_field returns empty for a missing field"
+    local v=$(_dash_get_status_field "$TEST_ROOT/proj1/.STATUS" "NoSuchField")
+    assert_empty "$v" "missing field -> empty" && test_pass
+}
+
+test_dash_field_yaml_dialect() {
+    test_case "_dash_get_status_field matches the YAML-ish 'field:' dialect (no ##)"
+    local v=$(_dash_get_status_field "$TEST_ROOT/proj_yaml/.STATUS" "status")
+    assert_equals "$v" "active" "yaml dialect field read" && test_pass
+}
+
+# ============================================================================
+# TESTS: dash.zsh wrapper functions (status/focus/progress)
+# ============================================================================
+
+test_dash_project_status() {
+    test_case "_dash_get_project_status reads Status"
+    local v=$(_dash_get_project_status "$TEST_ROOT/proj1/.STATUS")
+    assert_equals "$v" "active" "project status" && test_pass
+}
+
+test_dash_project_status_missing_file() {
+    test_case "_dash_get_project_status on a missing file returns empty"
+    local v=$(_dash_get_project_status "$TEST_ROOT/does-not-exist/.STATUS")
+    assert_empty "$v" "missing file -> empty status" && test_pass
+}
+
+test_dash_project_status_synonym_mapping() {
+    test_case "_dash_get_project_status normalizes 'In Progress' -> 'active'"
+    local v=$(_dash_get_project_status "$TEST_ROOT/proj3/.STATUS")
+    assert_equals "$v" "active" "status synonym mapping" && test_pass
+}
+
+test_dash_project_focus_fallback_to_next() {
+    test_case "_dash_get_project_focus falls back to 'next' when Focus is absent"
+    local v=$(_dash_get_project_focus "$TEST_ROOT/proj2/.STATUS")
+    assert_equals "$v" "Write the tests" "focus falls back to next" && test_pass
+}
+
+test_dash_project_progress_percent_not_actually_stripped() {
+    test_case "_dash_get_project_progress: the '%' is NOT actually stripped today (zsh pattern quirk in \${var//%/})"
+    local v=$(_dash_get_project_progress "$TEST_ROOT/proj1/.STATUS")
+    # Pre-existing bug in dash.zsh, out of Phase 1's migration scope (only
+    # _dash_get_status_field itself is migrated) — characterized so it is
+    # not silently changed by an unrelated edit.
+    assert_equals "$v" "42%" "dash progress wrapper's %-strip is a known no-op" && test_pass
+}
+
+# ============================================================================
+# TESTS: morning (commands/morning.zsh) inline Focus/Progress greps
+# ============================================================================
+
+test_morning_focus_with_colon_and_percent() {
+    test_case "morning renders a Focus value containing a colon and a %"
+    local output=$(FLOW_PROJECTS_ROOT="$CMD_ROOT" morning 2>&1)
+    assert_contains "$output" "Fix: the bug at 80% coverage" "morning focus rendering" && test_pass
+}
+
+test_morning_progress_strips_percent_and_pads() {
+    test_case "morning renders Progress as ' 42%' (tr -d '%' then re-added by printf)"
+    local output=$(FLOW_PROJECTS_ROOT="$CMD_ROOT" morning 2>&1)
+    assert_contains "$output" "[ 42%]" "morning progress rendering" && test_pass
+}
+
+test_morning_missing_focus_omits_arrow() {
+    test_case "morning omits the focus arrow when Focus is absent"
+    local output=$(FLOW_PROJECTS_ROOT="$CMD_ROOT" morning 2>&1)
+    local line=$(echo "$output" | grep "proj_nofocus")
+    assert_not_contains "$line" "→" "no focus -> no arrow" && test_pass
+}
+
+# ============================================================================
+# TESTS: next (commands/adhd.zsh) inline Focus grep
+# ============================================================================
+
+test_next_focus_with_colon_and_percent() {
+    test_case "next renders a Focus value containing a colon and a %"
+    local output=$(FLOW_PROJECTS_ROOT="$CMD_ROOT" next 2>&1)
+    assert_contains "$output" "Fix: the bug at 80% coverage" "next focus rendering" && test_pass
+}
+
+test_next_missing_focus_omits_arrow() {
+    test_case "next omits the focus arrow when Focus is absent"
+    local output=$(FLOW_PROJECTS_ROOT="$CMD_ROOT" next 2>&1)
+    local line=$(echo "$output" | grep "proj_nofocus")
+    assert_not_contains "$line" "→" "no focus -> no arrow" && test_pass
+}
+
+# ============================================================================
+# TESTS: capture.zsh's _flow_read_goal (inline daily_goal grep)
+# ============================================================================
+
+test_capture_reads_daily_goal_from_status() {
+    test_case "_flow_read_goal reads '## daily_goal:' from the project .STATUS"
+    local result
+    (cd "$TEST_ROOT/proj1" && result=$(_flow_read_goal); echo "$result") > /tmp/.capture_goal_result.$$
+    result=$(< /tmp/.capture_goal_result.$$)
+    rm -f /tmp/.capture_goal_result.$$
+    assert_equals "$result" "3" "daily_goal read from .STATUS" && test_pass
+}
+
+# ============================================================================
+# TESTS: _flow_where_fallback (lib/atlas-bridge.zsh) — CRASH characterization
+# ============================================================================
+
+test_where_fallback_currently_crashes_on_status() {
+    test_case "_flow_where_fallback today: 'local status=' crashes before printing Status:/Focus: (zsh read-only var)"
+    local output
+    (cd "$TEST_ROOT/proj_where" && FLOW_PROJECTS_ROOT="$TEST_ROOT" _flow_where_fallback "proj_where" 2>/dev/null) > /tmp/.where_result.$$
+    output=$(< /tmp/.where_result.$$)
+    rm -f /tmp/.where_result.$$
+    assert_contains "$output" "📁 Project: proj_where" "project line still prints" && \
+    assert_not_contains "$output" "Status:" "Status: line never reached — crashes first" && \
+    assert_not_contains "$output" "Focus:" "Focus: line never reached — crashes first" && test_pass
+}
+
+# ============================================================================
+# RUN TESTS
+# ============================================================================
+
+main() {
+    test_suite "Status Field Reader Characterization (Phase 1 parity guard)"
+
+    setup
+
+    echo "${CYAN}--- _dash_get_status_field (raw reader) ---${RESET}"
+    test_dash_field_colon_in_value
+    test_dash_field_percent_in_non_progress_field
+    test_dash_field_progress_keeps_percent
+    test_dash_field_missing_returns_empty
+    test_dash_field_yaml_dialect
+
+    echo ""
+    echo "${CYAN}--- dash.zsh wrapper functions ---${RESET}"
+    test_dash_project_status
+    test_dash_project_status_missing_file
+    test_dash_project_status_synonym_mapping
+    test_dash_project_focus_fallback_to_next
+    test_dash_project_progress_percent_not_actually_stripped
+
+    echo ""
+    echo "${CYAN}--- morning (inline greps) ---${RESET}"
+    test_morning_focus_with_colon_and_percent
+    test_morning_progress_strips_percent_and_pads
+    test_morning_missing_focus_omits_arrow
+
+    echo ""
+    echo "${CYAN}--- next (inline greps) ---${RESET}"
+    test_next_focus_with_colon_and_percent
+    test_next_missing_focus_omits_arrow
+
+    echo ""
+    echo "${CYAN}--- capture.zsh _flow_read_goal ---${RESET}"
+    test_capture_reads_daily_goal_from_status
+
+    echo ""
+    echo "${CYAN}--- _flow_where_fallback ---${RESET}"
+    test_where_fallback_currently_crashes_on_status
+
+    cleanup
+    test_suite_end
+    exit $?
+}
+
+main "$@"

--- a/tests/test-status-field-parity.zsh
+++ b/tests/test-status-field-parity.zsh
@@ -15,14 +15,16 @@
 # It must be GREEN on today's code, before `_flow_status_field` exists. After
 # the refactor migrates these call sites onto the shared accessor, this same
 # suite must stay green (parity) — see task 1.7. The one sanctioned exception
-# is `_flow_where_fallback`: today it CRASHES on `local status=...` (`status`
-# is a zsh read-only special variable, even as a function-local) and never
-# prints Status:/Focus: at all. That crash is characterized explicitly below
-# (test_where_fallback_currently_crashes_on_status) and is EXPECTED to change
-# post-refactor — the migration renames the colliding local and fixes it as
-# an unavoidable side effect of touching that exact line. This is a discovered
-# bug fix, not a silent behavior-loss regression; flagged in the Phase 1
-# report per the "don't adjust the test to hide a diff" rule.
+# is `_flow_where_fallback`: it originally CRASHED on `local status=...`
+# (`status` is a zsh read-only special variable, even as a function-local)
+# and never printed Status:/Focus: at all. That crash was characterized first
+# (see git history for `test_where_fallback_currently_crashes_on_status`),
+# THEN updated to `test_where_fallback_status_and_focus_now_print` once the
+# atlas-bridge.zsh:836 migration (task 1.5) fixed it as an unavoidable side
+# effect of renaming the colliding local. This is a discovered bug fix, not a
+# silent behavior-loss regression — flagged explicitly in the Phase 1 report
+# rather than silently hiding the diff, per the "don't adjust the test"
+# rule's one sanctioned exception.
 
 SCRIPT_DIR="${0:A:h}"
 PROJECT_ROOT="${SCRIPT_DIR:h}"
@@ -227,18 +229,29 @@ test_capture_reads_daily_goal_from_status() {
 }
 
 # ============================================================================
-# TESTS: _flow_where_fallback (lib/atlas-bridge.zsh) — CRASH characterization
+# TESTS: _flow_where_fallback (lib/atlas-bridge.zsh)
 # ============================================================================
+#
+# UPDATED post-refactor (the one sanctioned exception to "don't adjust the
+# characterization test", per this file's header comment): pre-refactor, this
+# assertion captured `_flow_where_fallback` CRASHING on `local status=...`
+# (status is a zsh read-only special variable, even function-local) and
+# never printing Status:/Focus: at all — see git history for the original
+# `test_where_fallback_currently_crashes_on_status`. The atlas-bridge.zsh:836
+# migration (task 1.5) necessarily renamed that colliding local as part of
+# routing the read through `_flow_status_field`, which fixed the crash as an
+# unavoidable side effect. This is a discovered bug fix, not a silent
+# behavior-loss regression — flagged in the Phase 1 report.
 
-test_where_fallback_currently_crashes_on_status() {
-    test_case "_flow_where_fallback today: 'local status=' crashes before printing Status:/Focus: (zsh read-only var)"
+test_where_fallback_status_and_focus_now_print() {
+    test_case "_flow_where_fallback: Status:/Focus: now print correctly (crash fixed by the migration)"
     local output
     (cd "$TEST_ROOT/proj_where" && FLOW_PROJECTS_ROOT="$TEST_ROOT" _flow_where_fallback "proj_where" 2>/dev/null) > /tmp/.where_result.$$
     output=$(< /tmp/.where_result.$$)
     rm -f /tmp/.where_result.$$
-    assert_contains "$output" "📁 Project: proj_where" "project line still prints" && \
-    assert_not_contains "$output" "Status:" "Status: line never reached — crashes first" && \
-    assert_not_contains "$output" "Focus:" "Focus: line never reached — crashes first" && test_pass
+    assert_contains "$output" "📁 Project: proj_where" "project line prints" && \
+    assert_contains "$output" "Status: active" "Status: now prints" && \
+    assert_contains "$output" "Focus: Ship it" "Focus: now prints" && test_pass
 }
 
 # ============================================================================
@@ -282,7 +295,7 @@ main() {
 
     echo ""
     echo "${CYAN}--- _flow_where_fallback ---${RESET}"
-    test_where_fallback_currently_crashes_on_status
+    test_where_fallback_status_and_focus_now_print
 
     cleanup
     test_suite_end

--- a/tests/test-status-schema.zsh
+++ b/tests/test-status-schema.zsh
@@ -1,0 +1,259 @@
+#!/usr/bin/env zsh
+# tests/test-status-schema.zsh
+# Red-then-green tests for scripts/check-status.zsh (SPEC-planning-
+# coordination-2026-07-01 §3.6, ORCHESTRATE Phase 3, D9/D11).
+#
+# D11 (warn-only, hard constraint): check-status.zsh must exit 0 ALWAYS this
+# cycle, no matter how malformed the input — it prints violations, never
+# blocks. Every test below that feeds it a broken fixture also asserts
+# exit 0, not just the warning text.
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh" || { echo "ERROR: Cannot source test-framework.zsh"; exit 1 }
+
+CHECKER="$PROJECT_ROOT/scripts/check-status.zsh"
+TEMPLATE="$PROJECT_ROOT/templates/.STATUS.template"
+
+setup() {
+    TEST_ROOT=$(mktemp -d)
+}
+
+cleanup() {
+    [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+test_checker_script_exists() {
+    test_case "scripts/check-status.zsh exists"
+    assert_file_exists "$CHECKER" && test_pass
+}
+
+test_template_exists() {
+    test_case "templates/.STATUS.template exists"
+    assert_file_exists "$TEMPLATE" && test_pass
+}
+
+test_clean_fixture_no_warnings_exit_0() {
+    test_case "a fully valid .STATUS: no warnings printed, exit 0"
+    mkdir -p "$TEST_ROOT/clean"
+    cat > "$TEST_ROOT/clean/.STATUS" <<'EOF'
+## Project: demo
+## Type: zsh-plugin
+## Status: active
+## Focus: Ship it
+## Phase: Building
+## Priority: 2
+## Progress: 42
+
+## Schedule:
+- 2030-01-01 | New year check-in | general
+- weekly:fri | Grading window | recurring
+EOF
+    local output rc
+    output=$(zsh "$CHECKER" "$TEST_ROOT/clean/.STATUS" 2>&1)
+    rc=$?
+    assert_exit_code $rc 0 "clean fixture -> exit 0" && \
+    assert_not_contains "$output" "WARN" "clean fixture -> no warnings" && test_pass
+}
+
+test_missing_required_field_warns_but_exits_0() {
+    test_case "missing required field: warns, still exits 0"
+    mkdir -p "$TEST_ROOT/missing-field"
+    cat > "$TEST_ROOT/missing-field/.STATUS" <<'EOF'
+## Project: demo
+## Type: zsh-plugin
+## Status: active
+## Priority: 2
+## Progress: 42
+EOF
+    local output rc
+    output=$(zsh "$CHECKER" "$TEST_ROOT/missing-field/.STATUS" 2>&1)
+    rc=$?
+    assert_exit_code $rc 0 "missing field -> still exit 0 (warn-only)" && \
+    assert_contains "$output" "Focus" "reports the missing Focus field" && test_pass
+}
+
+test_bad_progress_warns_but_exits_0() {
+    test_case "Progress out of 0-100 range: warns, still exits 0"
+    mkdir -p "$TEST_ROOT/bad-progress"
+    cat > "$TEST_ROOT/bad-progress/.STATUS" <<'EOF'
+## Project: demo
+## Type: zsh-plugin
+## Status: active
+## Focus: Ship it
+## Phase: Building
+## Priority: 2
+## Progress: 150
+EOF
+    local output rc
+    output=$(zsh "$CHECKER" "$TEST_ROOT/bad-progress/.STATUS" 2>&1)
+    rc=$?
+    assert_exit_code $rc 0 "bad Progress -> still exit 0 (warn-only)" && \
+    assert_contains "$output" "Progress" "reports the bad Progress value" && test_pass
+}
+
+test_non_numeric_progress_warns_but_exits_0() {
+    test_case "non-numeric Progress: warns, still exits 0"
+    mkdir -p "$TEST_ROOT/nonnumeric-progress"
+    cat > "$TEST_ROOT/nonnumeric-progress/.STATUS" <<'EOF'
+## Project: demo
+## Type: zsh-plugin
+## Status: active
+## Focus: Ship it
+## Phase: Building
+## Priority: 2
+## Progress: mostly-done
+EOF
+    local output rc
+    output=$(zsh "$CHECKER" "$TEST_ROOT/nonnumeric-progress/.STATUS" 2>&1)
+    rc=$?
+    assert_exit_code $rc 0 "non-numeric Progress -> still exit 0" && \
+    assert_contains "$output" "Progress" "reports the non-numeric Progress value" && test_pass
+}
+
+test_bad_status_warns_but_exits_0() {
+    test_case "Status outside the allowed set: warns, still exits 0"
+    mkdir -p "$TEST_ROOT/bad-status"
+    cat > "$TEST_ROOT/bad-status/.STATUS" <<'EOF'
+## Project: demo
+## Type: zsh-plugin
+## Status: wibble
+## Focus: Ship it
+## Phase: Building
+## Priority: 2
+## Progress: 42
+EOF
+    local output rc
+    output=$(zsh "$CHECKER" "$TEST_ROOT/bad-status/.STATUS" 2>&1)
+    rc=$?
+    assert_exit_code $rc 0 "bad Status -> still exit 0" && \
+    assert_contains "$output" "Status" "reports the bad Status value" && test_pass
+}
+
+test_status_synonym_accepted() {
+    test_case "Status synonym ('In Progress', normalized by _flow_status_field) is NOT flagged"
+    mkdir -p "$TEST_ROOT/status-synonym"
+    cat > "$TEST_ROOT/status-synonym/.STATUS" <<'EOF'
+## Project: demo
+## Type: zsh-plugin
+## Status: In Progress
+## Focus: Ship it
+## Phase: Building
+## Priority: 2
+## Progress: 42
+EOF
+    local output rc
+    output=$(zsh "$CHECKER" "$TEST_ROOT/status-synonym/.STATUS" 2>&1)
+    rc=$?
+    assert_exit_code $rc 0 "synonym status -> exit 0" && \
+    assert_not_contains "$output" "Status 'In Progress'" "synonym accepted, not flagged as invalid" && test_pass
+}
+
+test_malformed_schedule_line_warns_but_exits_0() {
+    test_case "malformed Schedule line: warns, still exits 0"
+    mkdir -p "$TEST_ROOT/bad-schedule"
+    cat > "$TEST_ROOT/bad-schedule/.STATUS" <<'EOF'
+## Project: demo
+## Type: zsh-plugin
+## Status: active
+## Focus: Ship it
+## Phase: Building
+## Priority: 2
+## Progress: 42
+
+## Schedule:
+- next tuesday | Fuzzy date | general
+EOF
+    local output rc
+    output=$(zsh "$CHECKER" "$TEST_ROOT/bad-schedule/.STATUS" 2>&1)
+    rc=$?
+    assert_exit_code $rc 0 "malformed Schedule line -> still exit 0" && \
+    assert_contains "$output" "Schedule" "reports the malformed Schedule line" && test_pass
+}
+
+test_maximally_broken_fixture_still_exits_0() {
+    test_case "D11 hard constraint: a maximally malformed .STATUS still exits 0"
+    mkdir -p "$TEST_ROOT/maximally-broken"
+    cat > "$TEST_ROOT/maximally-broken/.STATUS" <<'EOF'
+this is not a .STATUS file at all
+## Status: nonsense
+## Progress: -5
+## Schedule:
+- garbage line with no pipes
+EOF
+    local rc
+    zsh "$CHECKER" "$TEST_ROOT/maximally-broken/.STATUS" >/dev/null 2>&1
+    rc=$?
+    assert_exit_code $rc 0 "even a maximally broken .STATUS never blocks (D11)" && test_pass
+}
+
+test_template_passes_clean() {
+    test_case "templates/.STATUS.template itself passes clean (per SPEC §3.6)"
+    local output rc
+    output=$(zsh "$CHECKER" "$TEMPLATE" 2>&1)
+    rc=$?
+    assert_exit_code $rc 0 "template -> exit 0" && \
+    assert_not_contains "$output" "WARN" "template -> no warnings" && test_pass
+}
+
+test_flow_cli_own_status_passes_clean() {
+    test_case "flow-cli's own .STATUS passes clean (per SPEC §3.6)"
+    local output rc
+    output=$(zsh "$CHECKER" "$PROJECT_ROOT/.STATUS" 2>&1)
+    rc=$?
+    assert_exit_code $rc 0 "flow-cli's own .STATUS -> exit 0" && \
+    assert_not_contains "$output" "WARN" "flow-cli's own .STATUS -> no warnings" && test_pass
+}
+
+test_no_args_exits_0() {
+    test_case "no arguments: usage message, exit 0 (not an error)"
+    local rc
+    zsh "$CHECKER" >/dev/null 2>&1
+    rc=$?
+    assert_exit_code $rc 0 "no args -> exit 0" && test_pass
+}
+
+test_lint_staged_wired() {
+    test_case "package.json lint-staged has an extensionless '.STATUS' entry (not a glob)"
+    local pkg="$PROJECT_ROOT/package.json"
+    local content=$(cat "$pkg")
+    assert_contains "$content" '".STATUS"' "lint-staged has a literal .STATUS filename key" && \
+    assert_contains "$content" "check-status.zsh" "lint-staged entry runs check-status.zsh" && test_pass
+}
+
+main() {
+    test_suite ".STATUS Schema Enforcer (warn-only, D9/D11)"
+    setup
+
+    echo "${CYAN}--- Files exist ---${RESET}"
+    test_checker_script_exists
+    test_template_exists
+
+    echo ""
+    echo "${CYAN}--- Clean fixtures ---${RESET}"
+    test_clean_fixture_no_warnings_exit_0
+    test_template_passes_clean
+    test_flow_cli_own_status_passes_clean
+
+    echo ""
+    echo "${CYAN}--- Violations (warn, never block) ---${RESET}"
+    test_missing_required_field_warns_but_exits_0
+    test_bad_progress_warns_but_exits_0
+    test_non_numeric_progress_warns_but_exits_0
+    test_bad_status_warns_but_exits_0
+    test_status_synonym_accepted
+    test_malformed_schedule_line_warns_but_exits_0
+    test_maximally_broken_fixture_still_exits_0
+
+    echo ""
+    echo "${CYAN}--- CLI + wiring ---${RESET}"
+    test_no_args_exits_0
+    test_lint_staged_wired
+
+    cleanup
+    test_suite_end
+    exit $?
+}
+
+main "$@"

--- a/tests/test-suggest-project.zsh
+++ b/tests/test-suggest-project.zsh
@@ -1,0 +1,147 @@
+#!/usr/bin/env zsh
+# tests/test-suggest-project.zsh
+# Red-then-green unit tests for `_flow_suggest_project <strategy>` (SPEC §3.1,
+# ORCHESTRATE task 1.1/1.4) — one active/priority scan replacing the 5
+# reimplementations (dash.zsh:181 `_dash_right_now`, dash.zsh:1139
+# `_dash_footer`, morning.zsh:144 `_flow_morning_suggest`, adhd.zsh `next`/`js`).
+#
+# NOT byte-parity guarded (unlike the field readers) — these 5 call sites
+# genuinely differ in selection logic today. Each strategy mode below is
+# pinned by its own red test instead.
+#
+# Strategies:
+#   active             - first active project (dash footer)
+#   active-with-focus  - first active project with a non-empty Focus (dash
+#                        "right now")
+#   priority           - first active project with Priority 1/P1 (morning)
+#   random-active      - random pick from the active list, or first 5 of all
+#                        projects if none active (adhd `js`)
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh" || { echo "ERROR: Cannot source test-framework.zsh"; exit 1 }
+
+setup() {
+    if [[ ! -f "$PROJECT_ROOT/flow.plugin.zsh" ]]; then
+        echo "${RED}ERROR: Cannot find project root${RESET}"
+        exit 1
+    fi
+
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$PROJECT_ROOT"
+    source "$PROJECT_ROOT/flow.plugin.zsh" 2>/dev/null || {
+        echo "${RED}Plugin failed to load${RESET}"
+        exit 1
+    }
+    _flow_has_atlas() { return 1 }
+    exec < /dev/null
+
+    TEST_ROOT=$(mktemp -d)
+}
+
+cleanup() {
+    reset_mocks
+    unset -f _flow_has_atlas 2>/dev/null
+    [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+test_function_exists() {
+    test_case "_flow_suggest_project function exists"
+    assert_function_exists "_flow_suggest_project" && test_pass
+}
+
+test_active_strategy_picks_first_active() {
+    test_case "strategy 'active': first active project, paused ones skipped"
+    local root=$(mktemp -d)
+    mkdir -p "$root/a-paused" "$root/b-active"
+    printf "## Status: paused\n" > "$root/a-paused/.STATUS"
+    printf "## Status: active\n" > "$root/b-active/.STATUS"
+    local v=$(FLOW_PROJECTS_ROOT="$root" _flow_suggest_project active)
+    rm -rf "$root"
+    assert_equals "$v" "b-active" "picks the active one" && test_pass
+}
+
+test_active_with_focus_requires_focus() {
+    test_case "strategy 'active-with-focus': skips active projects with no Focus"
+    local root=$(mktemp -d)
+    mkdir -p "$root/a-no-focus" "$root/b-has-focus"
+    printf "## Status: active\n" > "$root/a-no-focus/.STATUS"
+    printf "## Status: active\n## Focus: Ship it\n" > "$root/b-has-focus/.STATUS"
+    local v=$(FLOW_PROJECTS_ROOT="$root" _flow_suggest_project active-with-focus)
+    rm -rf "$root"
+    assert_equals "$v" "b-has-focus" "only the focused one qualifies" && test_pass
+}
+
+test_active_with_focus_empty_when_none_qualify() {
+    test_case "strategy 'active-with-focus': empty when no active project has Focus"
+    local root=$(mktemp -d)
+    mkdir -p "$root/a-no-focus"
+    printf "## Status: active\n" > "$root/a-no-focus/.STATUS"
+    local v=$(FLOW_PROJECTS_ROOT="$root" _flow_suggest_project active-with-focus)
+    rm -rf "$root"
+    assert_empty "$v" "no qualifying project -> empty" && test_pass
+}
+
+test_priority_strategy_matches_p1_variants() {
+    test_case "strategy 'priority': matches Priority '1' or 'P1' (trailing-space tolerant)"
+    local root=$(mktemp -d)
+    mkdir -p "$root/a-p2" "$root/b-p1"
+    printf "## Status: active\n## Priority: 2\n" > "$root/a-p2/.STATUS"
+    printf "## Status: active\n## Priority: P1 \n" > "$root/b-p1/.STATUS"
+    local v=$(FLOW_PROJECTS_ROOT="$root" _flow_suggest_project priority)
+    rm -rf "$root"
+    assert_equals "$v" "b-p1" "P1 with trailing space still matches" && test_pass
+}
+
+test_priority_strategy_skips_paused_p1() {
+    test_case "strategy 'priority': a paused P1 project does not qualify"
+    local root=$(mktemp -d)
+    mkdir -p "$root/a-paused-p1"
+    printf "## Status: paused\n## Priority: P1\n" > "$root/a-paused-p1/.STATUS"
+    local v=$(FLOW_PROJECTS_ROOT="$root" _flow_suggest_project priority)
+    rm -rf "$root"
+    assert_empty "$v" "paused P1 doesn't qualify" && test_pass
+}
+
+test_random_active_returns_a_known_active_project() {
+    test_case "strategy 'random-active': returns one of the active projects"
+    local root=$(mktemp -d)
+    mkdir -p "$root/only-active"
+    printf "## Status: active\n" > "$root/only-active/.STATUS"
+    local v=$(FLOW_PROJECTS_ROOT="$root" _flow_suggest_project random-active)
+    rm -rf "$root"
+    assert_equals "$v" "only-active" "single-candidate random pick is deterministic" && test_pass
+}
+
+test_no_projects_returns_empty() {
+    test_case "no projects at all -> empty output, exit 1"
+    local root=$(mktemp -d)
+    local out rc
+    out=$(FLOW_PROJECTS_ROOT="$root" _flow_suggest_project active)
+    rc=$?
+    rm -rf "$root"
+    assert_empty "$out" "no projects -> empty" && \
+    assert_exit_code $rc 1 "no projects -> exit 1" && test_pass
+}
+
+main() {
+    test_suite "_flow_suggest_project strategies"
+    setup
+
+    test_function_exists
+    test_active_strategy_picks_first_active
+    test_active_with_focus_requires_focus
+    test_active_with_focus_empty_when_none_qualify
+    test_priority_strategy_matches_p1_variants
+    test_priority_strategy_skips_paused_p1
+    test_random_active_returns_a_known_active_project
+    test_no_projects_returns_empty
+
+    cleanup
+    test_suite_end
+    exit $?
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Grilled (16 decisions, D1–D16) and phase-gated implementation of the flow-cli slice of the planning-coordination proposal. Full design rationale: `docs/specs/SPEC-planning-coordination-2026-07-01.md` + `docs/specs/BRAINSTORM-planning-coordination-2026-07-01.md`.

- **Phase 0** — isolated fix: `next`/`morning` read `$path` (ZSH's PATH array) instead of `$project_path`, silently blanking focus/progress/icon for every project.
- **Phase 1** — 3 shared accessors (`_flow_status_field`, `_flow_resolve_project_path`, `_flow_suggest_project`) in `lib/core.zsh`, replacing 4/2/5 divergent implementations. Guarded by a characterization/parity test suite landed green *before* the refactor. Found and fixed 2 real zsh bugs along the way: `local status=...` crashes (zsh read-only special var) in `_flow_where_fallback`, and a loop-scoped `local` redeclaration quirk that echoes stale values to stdout.
- **Phase 2** — `_schedule_atlas_items`, a third capability-probed schedule source (alongside `.STATUS` and teach-config) that will surface atlas `Task.dueDate` deadlines once atlas ships an `agenda` command. Ships **dark-ready**: tested, inert, silent no-op today (mirrors the existing `schedule push` pattern). Adds a dedupe pass now that 3 sources can collide. Contract pinned in `docs/ATLAS-CONTRACT.md` (v1.2.0) — `.STATUS`-ingestion mechanism deliberately left as atlas's own open design question.
- **Phase 3** — `templates/.STATUS.template` + `scripts/check-status.zsh`, a **warn-only** (never blocks) schema check wired into `lint-staged`.
- **Phase 4** — docs: API reference, agenda/schedule guide (with a real captured multi-source transcript), dispatcher guide, CHANGELOG (mirrored), CONTRIBUTING, CLAUDE.md count refresh, stale-spec hygiene.

**Cross-repo scope:** atlas (`atlas task`/`atlas agenda` CLI) and obsidian-cli-ops (render/seed) are explicitly out of scope — contract-only, deferred to their own specs.

## Test plan

- ✅ `source flow.plugin.zsh` — clean load
- ✅ `./tests/run-all.sh` — **74 passed, 0 failed, 0 timeout, 1 skipped** (pre-existing tool-absence skip), reproduced independently by the reviewer at every phase gate and again post-rebase onto `dev`
- ✅ Characterization suite unchanged pre/post-refactor (byte-parity proven, one disclosed exception: a genuine pre-existing crash fix)
- ✅ `check-status.zsh` verified warn-only live (exit 0 on broken/empty fixtures, clean on template + real `.STATUS`)
- ✅ Dogfooded no-atlas (byte-identical to pre-change) and atlas-stub-present (deadlines merge correctly) — both independently reproduced
- ✅ `mkdocs build --strict` — 0 warnings
- ✅ `markdownlint` (flow-cli's own `.markdownlint.yaml`) — 20 findings, all confirmed pre-existing and untouched by this branch (verified via diff, not just asserted)

Every phase was executed by a background agent and independently re-verified (diff read, tests re-run, technical claims empirically checked) before the next phase was authorized — see `ORCHESTRATE-planning-coordination.md` for the full phase-gate log and checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvJR434JKwmpq8LD458Aum