### PR TITLE
feat(em): add agy (Antigravity CLI) as em-ai backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`agy` (Antigravity CLI) as an em-ai backend** — added ahead of `gemini` in the fallback
+  chain (`claude → agy → gemini → none`). `agy`'s output is automatically cleaned (it appends
+  an unrequested status-block footer with no clean-output flag to suppress it) and
+  sanity-checked before use, since `agy` has been observed to exit successfully with a canned
+  response on degenerate input rather than failing loudly. `gemini` is retained as a legacy
+  backend for existing `FLOW_EMAIL_AI=gemini` configs — Google's gemini CLI is deprecated
+  upstream in favor of Antigravity/`agy`, but nothing is removed here.
+
+- **`tests/test-teach-dispatcher-characterization.zsh`** — 35 routing checks that mock action functions and verify every public `teach <cmd>` path before and after the split.
+
 ### Changed
 
 - **Modular `teach` dispatcher** — `lib/dispatchers/teach-dispatcher.zsh` is now a 307-line loader that sources 10 focused modules under `lib/dispatchers/teach/` (main, content, help, init-config, slides, style, backup, status, archive, map). The monolithic 5,611-line file is gone; characterization tests in `tests/test-teach-dispatcher-characterization.zsh` guard routing behavior.
-
-### Added
-
-- **`tests/test-teach-dispatcher-characterization.zsh`** — 35 routing checks that mock action functions and verify every public `teach <cmd>` path before and after the split.
 
 ## [7.15.0] — 2026-07-02 — Homebrew distribution health + doc gap fills
 

--- a/commands/doctor.zsh
+++ b/commands/doctor.zsh
@@ -1389,8 +1389,10 @@ _doctor_check_email() {
   if [[ -n "$FLOW_EMAIL_AI" && "$FLOW_EMAIL_AI" != "none" ]]; then
     if [[ "$FLOW_EMAIL_AI" == "claude" ]]; then
       _doctor_check_email_cmd "claude" "npm:@anthropic-ai/claude-code" "optional" "AI drafts"
+    elif [[ "$FLOW_EMAIL_AI" == "agy" ]]; then
+      _doctor_check_email_cmd "agy" "brew:agy" "optional" "AI drafts (Antigravity CLI)"
     elif [[ "$FLOW_EMAIL_AI" == "gemini" ]]; then
-      _doctor_check_email_cmd "gemini" "pip:google-generativeai" "optional" "AI drafts"
+      _doctor_check_email_cmd "gemini" "pip:google-generativeai" "optional" "AI drafts (legacy backend)"
     fi
   fi
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,13 +8,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ## [Unreleased]
 
+### Added
+
+- **`agy` (Antigravity CLI) as an em-ai backend** — added ahead of `gemini` in the fallback
+  chain (`claude → agy → gemini → none`). `agy`'s output is automatically cleaned (it appends
+  an unrequested status-block footer with no clean-output flag to suppress it) and
+  sanity-checked before use, since `agy` has been observed to exit successfully with a canned
+  response on degenerate input rather than failing loudly. `gemini` is retained as a legacy
+  backend for existing `FLOW_EMAIL_AI=gemini` configs — Google's gemini CLI is deprecated
+  upstream in favor of Antigravity/`agy`, but nothing is removed here.
+
+- **`tests/test-teach-dispatcher-characterization.zsh`** — 35 routing checks that mock action functions and verify every public `teach <cmd>` path before and after the split.
+
 ### Changed
 
 - **Modular `teach` dispatcher** — `lib/dispatchers/teach-dispatcher.zsh` is now a 307-line loader that sources 10 focused modules under `lib/dispatchers/teach/` (main, content, help, init-config, slides, style, backup, status, archive, map). The monolithic 5,611-line file is gone; characterization tests in `tests/test-teach-dispatcher-characterization.zsh` guard routing behavior.
-
-### Added
-
-- **`tests/test-teach-dispatcher-characterization.zsh`** — 35 routing checks that mock action functions and verify every public `teach <cmd>` path before and after the split.
 
 ## [7.15.0] — 2026-07-02 — Homebrew distribution health + doc gap fills
 

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -156,7 +156,7 @@ flow doctor --verbose
 | **glow**                 | recommended | Markdown rendering        | brew        |
 | **email-oauth2-proxy**   | recommended | OAuth2 for Gmail/Outlook  | pip         |
 | **terminal-notifier**    | optional    | Desktop notifications     | brew        |
-| **claude/gemini**        | conditional | AI backend (per `$FLOW_EMAIL_AI`) | varies |
+| **claude/agy/gemini**    | conditional | AI backend (per `$FLOW_EMAIL_AI`; gemini is legacy) | varies |
 
 > This section only appears when `em()` is loaded. Shared deps (fzf, bat, jq) are checked in earlier sections and skipped here.
 

--- a/docs/guides/EMAIL-COOKBOOK.md
+++ b/docs/guides/EMAIL-COOKBOOK.md
@@ -302,7 +302,7 @@ em send --prompt "thank Alice for the report, ask when the budget section will b
 em forward 42 colleague@unm.edu --prompt "FYI, see the budget section on page 3"
 
 # Use a different AI backend for this one reply
-em reply 42 --prompt "be brief and direct" --backend gemini
+em reply 42 --prompt "be brief and direct" --backend agy
 ```
 
 **Explanation:**
@@ -316,7 +316,7 @@ When `--prompt` is used, TTY detection is bypassed (treated as batch mode), maki
 em reply 42 --prompt "acknowledge receipt" --force
 ```
 
-**Pro tip:** Combine `--prompt` with `--backend` to use Gemini for quick tasks (faster, lower quota usage) and Claude for nuanced replies. The `--backend` flag overrides `FLOW_EMAIL_AI` for that single command only — your global setting stays unchanged.
+**Pro tip:** Combine `--prompt` with `--backend` to use agy for quick tasks (faster, lower quota usage) and Claude for nuanced replies. The `--backend` flag overrides `FLOW_EMAIL_AI` for that single command only — your global setting stays unchanged. (`gemini` is also still available as a legacy backend for existing configs.)
 
 ---
 
@@ -332,7 +332,8 @@ em ai
 
 # Switch to a specific backend
 em ai claude
-em ai gemini
+em ai agy
+em ai gemini    # legacy backend, still supported for existing configs
 em ai none      # disable AI entirely
 
 # Cycle through available backends one at a time
@@ -344,9 +345,9 @@ em ai auto
 
 **Explanation:**
 
-`em ai` changes `FLOW_EMAIL_AI` in the current shell session without touching your config file. The change takes effect immediately for all subsequent `em` commands. The fallback chain is: claude -> gemini -> none (graceful timeout). Use `em ai none` when you need sub-second response times and do not want any AI operations blocking your workflow.
+`em ai` changes `FLOW_EMAIL_AI` in the current shell session without touching your config file. The change takes effect immediately for all subsequent `em` commands. The fallback chain is: claude -> agy -> gemini -> none (graceful timeout). Use `em ai none` when you need sub-second response times and do not want any AI operations blocking your workflow.
 
-**Pro tip:** Set `FLOW_EMAIL_AI=gemini` in `.flow/email.conf` for a specific project if that project's email volume is high and you want to preserve Claude quota for code tasks. Project config overrides global config automatically.
+**Pro tip:** Set `FLOW_EMAIL_AI=agy` in `.flow/email.conf` for a specific project if that project's email volume is high and you want to preserve Claude quota for code tasks. Project config overrides global config automatically. (`agy` succeeds `gemini` as the recommended fast/legacy-successor backend — Google's gemini CLI has been deprecated in favor of Antigravity/agy.)
 
 ---
 

--- a/docs/guides/EMAIL-DISPATCHER-GUIDE.md
+++ b/docs/guides/EMAIL-DISPATCHER-GUIDE.md
@@ -85,7 +85,8 @@ compose, triage, or analyze email content.
 | [email-oauth2-proxy](https://github.com/simonrob/email-oauth2-proxy) | OAuth2 for Gmail/Outlook | `pip install email-oauth2-proxy` |
 | terminal-notifier | Desktop notifications | `brew install terminal-notifier` |
 | claude CLI | AI drafts (primary) | See [Claude Code docs](https://claude.ai/docs) |
-| gemini CLI | AI drafts (fallback) | `pip install google-generativeai` |
+| agy CLI | AI drafts (fallback) | `brew install agy` |
+| gemini CLI | AI drafts (legacy fallback) | `pip install google-generativeai` |
 
 ### Check Your Setup
 
@@ -869,7 +870,7 @@ em doctor                        # Verify watcher dependencies
 
 ## AI Features Deep Dive
 
-The `em` dispatcher includes optional AI features powered by Claude or Gemini. All AI operations are:
+The `em` dispatcher includes optional AI features powered by Claude, Antigravity (agy), or Gemini (legacy). All AI operations are:
 - **Cached** - Results stored with TTL to avoid redundant API calls
 - **Timeout-protected** - Operations have per-type timeouts (10-30s)
 - **Fallback-enabled** - Tries alternate backends on failure
@@ -881,7 +882,9 @@ Configure via environment variable:
 
 ```bash
 export FLOW_EMAIL_AI="claude"    # Default (claude CLI)
-export FLOW_EMAIL_AI="gemini"    # Google Gemini CLI
+export FLOW_EMAIL_AI="agy"       # Antigravity CLI (agy)
+export FLOW_EMAIL_AI="gemini"    # Google Gemini CLI (legacy — gemini CLI is deprecated
+                                  # upstream in favor of agy; kept for existing configs)
 export FLOW_EMAIL_AI="none"      # Disable AI features
 ```
 
@@ -892,12 +895,22 @@ export FLOW_EMAIL_AI="none"      # Disable AI features
    - Timeout: 30s for drafts, 15s for summaries
    - Best for: Professional tone, detailed replies
 
-2. **gemini** (fallback) - Uses Gemini CLI
+2. **agy** (fallback) - Uses Antigravity CLI (`agy -p`)
+   - Requires: `agy` in PATH (`brew install agy`)
+   - Timeout: same as Claude
+   - Best for: Quick responses, factual content — the successor to the gemini backend
+   - Note: agy's raw output includes a status-block footer that `em` automatically strips,
+     and responses are sanity-checked before use (agy has been observed to return a canned
+     "system operational" response on bad input while still exiting successfully) — a failed
+     check falls through to the next backend in the chain automatically, no action needed
+
+3. **gemini** (legacy fallback) - Uses Gemini CLI
    - Requires: `gemini` in PATH
    - Timeout: same as Claude
-   - Best for: Quick responses, factual content
+   - Deprecated upstream in favor of `agy`; retained here only for existing
+     `FLOW_EMAIL_AI=gemini` configs — new setups should use `agy`
 
-3. **none** - Disables all AI features
+4. **none** - Disables all AI features
    - `em reply` opens blank draft
    - `em respond` unavailable
    - `em classify` / `em summarize` unavailable
@@ -907,7 +920,7 @@ export FLOW_EMAIL_AI="none"      # Disable AI features
 If the primary backend fails (timeout, not installed, API error), `em` automatically tries the next available backend:
 
 ```text
-claude → gemini → fail gracefully
+claude → agy → gemini → fail gracefully
 ```
 
 ## AI Backend Switching
@@ -918,8 +931,9 @@ Switch AI backends at runtime without restarting your shell or editing config fi
 
 ```bash
 em ai                 # Show current backend status
-em ai gemini          # Switch to Gemini (faster startup)
+em ai agy             # Switch to Antigravity (agy)
 em ai claude          # Switch back to Claude
+em ai gemini          # Switch to Gemini (legacy)
 em ai toggle          # Cycle through available backends
 em ai none            # Disable AI entirely
 ```
@@ -932,11 +946,11 @@ Running `em ai` with no arguments shows:
 Email AI Backend
 
   Current:     claude
-  Available:   claude gemini
+  Available:   claude agy gemini
   Timeout:     30s
-  Gemini args: -e none
+  Gemini args: -e none (legacy)
 
-  Switch: em ai claude | em ai gemini | em ai toggle
+  Switch: em ai claude | em ai agy | em ai gemini | em ai toggle
 ```
 
 ### Gemini Speed Optimization

--- a/docs/help/QUICK-REFERENCE.md
+++ b/docs/help/QUICK-REFERENCE.md
@@ -1117,7 +1117,7 @@ em send --prompt "thank Alice for the report, ask about timeline"
 em forward 42 colleague@unm.edu --prompt "FYI, see the budget section"
 
 # Override AI backend for any command
-em reply 42 --prompt "be brief" --backend gemini
+em reply 42 --prompt "be brief" --backend agy
 ```
 
 ### Forward
@@ -1311,7 +1311,7 @@ em cache prune                # Remove expired entries only
 em cache warm 20              # Pre-warm latest 20 emails (background)
 
 # Configuration
-export FLOW_EMAIL_AI=claude     # AI backend (claude/gemini/none)
+export FLOW_EMAIL_AI=claude     # AI backend (claude/agy/gemini legacy/none)
 export FLOW_EMAIL_PAGE_SIZE=25  # Inbox page size
 ```
 

--- a/docs/reference/MASTER-API-REFERENCE.md
+++ b/docs/reference/MASTER-API-REFERENCE.md
@@ -6256,7 +6256,7 @@ _em_forward <msg_id> [to] [--prompt text] [--backend name] [--force]
 - `$1` - Email message ID
 - `$2` - Recipient email address (optional)
 - `--prompt` - AI forwarding note with custom instructions
-- `--backend` - Override AI backend (claude/gemini)
+- `--backend` - Override AI backend (claude/agy/gemini legacy)
 - `--force` / `--yes` - Skip safety gate
 
 **Returns:**

--- a/docs/reference/MASTER-ARCHITECTURE.md
+++ b/docs/reference/MASTER-ARCHITECTURE.md
@@ -410,7 +410,7 @@ graph TB
 
 1. **Adapter isolation** — All himalaya CLI specifics live in `em-himalaya.zsh`. If himalaya changes CLI flags, fix only this file.
 2. **Safety gates** — Every send operation goes through `_em_confirm_send()` with `[y/N]` default-No.
-3. **AI pluggable** — Backend configurable via `FLOW_EMAIL_AI` (claude/gemini/none) with per-operation timeouts.
+3. **AI pluggable** — Backend configurable via `FLOW_EMAIL_AI` (claude/agy/gemini legacy/none) with per-operation timeouts.
 4. **Preview cleanup** — 6 sed filters strip email noise (CID refs, Safe Links, MIME markers) in both `em pick` preview and `em read`.
 
 ---

--- a/docs/reference/MASTER-DISPATCHER-GUIDE.md
+++ b/docs/reference/MASTER-DISPATCHER-GUIDE.md
@@ -3320,7 +3320,7 @@ calendar ICS parsing, and IMAP IDLE background watching.
 | `em calendar <ID>` | `em cal` | Parse ICS attachment; add to Apple Calendar |
 | `em watch start\|stop\|status\|log` | `em w` | IMAP IDLE background watcher [experimental] |
 | `em cache stats\|prune\|clear\|warm` | | Manage AI cache |
-| `em ai [backend]` | | Show/switch AI backend (claude, gemini, none, toggle, auto) |
+| `em ai [backend]` | | Show/switch AI backend (claude, agy, gemini legacy, none, toggle, auto) |
 | `em star <ID>` | `em flag` | Toggle star (Flagged) on email |
 | `em starred` | | List all starred/flagged emails |
 | `em move <ID> [FOLDER]` | `em mv` | Move email to folder (fzf picker if no folder) |
@@ -3342,7 +3342,7 @@ em reply 42 --force        # Skip preview gate (v2.0)
 em reply 42 --prompt 'decline politely'  # AI draft with custom instructions
 em send user@example.com "Meeting" --prompt 'suggest Tuesday 2pm'
 em forward 42 user@example.com --prompt 'FYI re: our discussion'
-em reply 42 --backend gemini  # Override AI backend per-command
+em reply 42 --backend agy     # Override AI backend per-command
 em respond                 # Batch process actionable emails
 em star 42                 # Toggle star on email
 em move 42 Archive         # Move email to folder
@@ -3370,7 +3370,7 @@ enhancement based on the installed himalaya CLI version.
 
 | Variable | Default | Description |
 | ---------- | --------- | ------------- |
-| `FLOW_EMAIL_AI` | `claude` | AI backend (claude/gemini/none) |
+| `FLOW_EMAIL_AI` | `claude` | AI backend (claude/agy/gemini legacy/none) |
 | `FLOW_EMAIL_PAGE_SIZE` | `25` | Default inbox page size |
 | `FLOW_EMAIL_FOLDER` | `INBOX` | Default folder |
 | `FLOW_EMAIL_TRASH_FOLDER` | `Trash` | Trash folder (Exchange: "Deleted Items") |
@@ -3381,7 +3381,7 @@ enhancement based on the installed himalaya CLI version.
 - **v2.0:** `em send`, `em reply`, and `em forward` show full preview + `[y/N/e]` gate before sending. Use `--force` to bypass.
 - **Smart TTY detection:** Non-interactive contexts (no TTY) auto-route to batch path, preventing `$EDITOR` hangs.
 - **`--prompt` flag:** Available on `reply`, `send`, and `forward`. Forces batch mode. Implies `--ai` on `em send`.
-- **`--backend` flag:** Override AI backend per-command (e.g. `--backend gemini`).
+- **`--backend` flag:** Override AI backend per-command (e.g. `--backend agy`).
 - Every delete requires `[y/N]` confirmation (default: No). `--purge` requires typing "yes".
 - Folder/query deletes show count + first 5 subjects before confirming.
 - `em delete-folder` requires typing the folder name in full.

--- a/docs/reference/REFCARD-EMAIL-DISPATCHER.md
+++ b/docs/reference/REFCARD-EMAIL-DISPATCHER.md
@@ -488,7 +488,7 @@ em re 42 --no-ai                # Reply without AI
 em re 42 --all                  # Reply-all
 em re 42 --batch                # Non-interactive (preview+confirm)
 em re 42 --prompt "decline, suggest office hours"  # AI draft with instructions
-em re 42 --backend gemini       # Override AI backend for this reply
+em re 42 --backend agy          # Override AI backend for this reply
 
 # ─────────────────────────────────────────────────────────────
 # Composing
@@ -711,7 +711,7 @@ em re 42 --batch                # Preview, then [y/N]
 
 # AI-guided with custom instructions
 em re 42 --prompt "decline politely"    # Custom AI draft
-em re 42 --prompt "be brief" --backend gemini  # With backend override
+em re 42 --prompt "be brief" --backend agy  # With backend override
 ```
 
 ### Forwarding

--- a/docs/tutorials/46-em-v2-features.md
+++ b/docs/tutorials/46-em-v2-features.md
@@ -459,7 +459,7 @@ em send alice@unm.edu "Meeting" --prompt "suggest Tuesday 2pm, keep it brief"
 Use `--backend` to switch AI providers for a single command without changing your global setting:
 
 ```zsh
-em reply 42 --prompt "acknowledge receipt" --backend gemini
+em reply 42 --prompt "acknowledge receipt" --backend agy
 ```
 
 This overrides `FLOW_EMAIL_AI` for that one command only.

--- a/lib/em-ai.zsh
+++ b/lib/em-ai.zsh
@@ -9,7 +9,7 @@
 #
 # Used by:      lib/dispatchers/email-dispatcher.zsh, lib/em-cache.zsh
 #
-# Backends:     claude CLI, gemini CLI (extensible)
+# Backends:     claude CLI, agy CLI, gemini CLI (legacy) (extensible)
 # Design:       Per-operation backend selection, timeout, fallback chain,
 #               cache integration to avoid redundant AI calls.
 #
@@ -23,6 +23,9 @@ typeset -gA _EM_AI_BACKENDS=(
     [claude_cmd]="claude"
     [claude_flags]="-p --output-format text"
     [claude_extra_args]=""
+    [agy_cmd]="agy"
+    [agy_flags]="-p"
+    [agy_extra_args]="${FLOW_EMAIL_AGY_EXTRA_ARGS:-}"
     [gemini_cmd]="gemini"
     [gemini_flags]=""
     [gemini_extra_args]="${FLOW_EMAIL_GEMINI_EXTRA_ARGS:--e none}"
@@ -82,7 +85,7 @@ _em_ai_query() {
     local timeout_s
     timeout_s=$(_em_ai_timeout_for_op "$operation")
     local result=""
-    result=$(_em_ai_execute "$backend" "$prompt" "$input" "$timeout_s")
+    result=$(_em_ai_execute "$backend" "$prompt" "$input" "$timeout_s" "$operation")
     local exit_code=$?
 
     # --- Step 4: Fallback on failure ---
@@ -90,7 +93,7 @@ _em_ai_query() {
         local fallback
         for fallback in $(_em_ai_fallback_chain "$backend"); do
             _flow_log_debug "em-ai: trying fallback backend: $fallback" 2>/dev/null
-            result=$(_em_ai_execute "$fallback" "$prompt" "$input" "$timeout_s")
+            result=$(_em_ai_execute "$fallback" "$prompt" "$input" "$timeout_s" "$operation")
             exit_code=$?
             [[ $exit_code -eq 0 ]] && break
         done
@@ -140,9 +143,9 @@ _em_ai_validate_extra_args() {
 
 _em_ai_execute() {
     # Execute a single AI backend call
-    # Args: backend, prompt, input, timeout_seconds
+    # Args: backend, prompt, input, timeout_seconds, operation (optional, for agy validation)
     # Security (Finding 13): extra_args validated via _em_ai_validate_extra_args
-    local backend="$1" prompt="$2" input="$3" timeout_s="${4:-15}"
+    local backend="$1" prompt="$2" input="$3" timeout_s="${4:-15}" operation="${5:-}"
 
     case "$backend" in
         claude)
@@ -161,6 +164,47 @@ _em_ai_execute() {
                 _flow_log_warning "AI timed out (claude, ${timeout_s}s)" 2>/dev/null
             fi
             return $rc
+            ;;
+        agy)
+            if ! command -v agy &>/dev/null; then
+                return 1
+            fi
+            local extra="${_EM_AI_BACKENDS[agy_extra_args]:-}"
+            # Finding 13: validate before word-splitting and interpolating into command
+            if ! _em_ai_validate_extra_args "$extra"; then
+                return 1
+            fi
+            # IMPORTANT: capture agy's output via a temp file, NOT $(...) command
+            # substitution. agy has been observed to spawn a process that keeps
+            # the stdout pipe open after the main agy process exits/is killed —
+            # $(...) then blocks forever (or dies silently) waiting for EOF on
+            # that pipe, even though `timeout` correctly killed the direct agy
+            # process. Redirecting to a real file sidesteps the pipe entirely.
+            local tmpfile
+            tmpfile=$(mktemp "${TMPDIR:-/tmp}/em-ai-agy.XXXXXX") || return 1
+            echo "$input" | timeout "$timeout_s" \
+                agy -p "$prompt" ${=extra} >"$tmpfile" 2>/dev/null
+            local rc=$?
+            local raw
+            raw=$(<"$tmpfile")
+            rm -f "$tmpfile"
+            if [[ $rc -eq 124 ]]; then
+                _flow_log_warning "AI timed out (agy, ${timeout_s}s)" 2>/dev/null
+                return $rc
+            fi
+            if [[ $rc -ne 0 ]]; then
+                return $rc
+            fi
+            # agy has no clean-output flag and can exit 0 on degenerate input
+            # (e.g. bad --model, ignored prompt) — never trust its exit code alone.
+            local cleaned
+            cleaned=$(_em_ai_agy_clean_output "$raw")
+            if ! _em_ai_agy_looks_valid "$operation" "$cleaned"; then
+                _flow_log_warning "em-ai: agy returned an unusable response, falling back" 2>/dev/null
+                return 1
+            fi
+            echo "$cleaned"
+            return 0
             ;;
         gemini)
             if ! command -v gemini &>/dev/null; then
@@ -190,6 +234,56 @@ _em_ai_execute() {
 }
 
 # ═══════════════════════════════════════════════════════════════════
+# AGY OUTPUT VALIDATION
+# ═══════════════════════════════════════════════════════════════════
+# agy (Antigravity CLI) has no clean-output flag: it appends an
+# unrequested markdown status block to every response, and has been
+# observed to exit 0 with a canned "system operational" response on
+# degenerate input (e.g. an invalid --model). These helpers strip the
+# boilerplate and reject responses that look like the canned fallback,
+# since agy's own exit code cannot be trusted to signal failure.
+
+_em_ai_agy_clean_output() {
+    # Strip agy's appended status block from its response.
+    # Args: raw_output
+    local raw="$1"
+    # Cut everything from the first "---" separator line or a
+    # "**🟢 DONE" / "⏭️ NEXT" style marker onward.
+    echo "$raw" | sed -E '/^---[[:space:]]*$/,$d; /\*\*?(🟢|⏭️|⚠️|🔗)/,$d'
+}
+
+_em_ai_agy_looks_valid() {
+    # Sanity-check an agy response beyond its (untrustworthy) exit code.
+    # Args: operation, cleaned_output
+    # Returns: 0 if the response looks like a real answer, 1 if it looks
+    # like agy's canned "system operational" boilerplate.
+    local operation="$1" output="$2"
+
+    [[ -z "$output" ]] && return 1
+
+    # Known canned-response phrases observed when agy ignores the prompt.
+    if [[ "$output" == *"system is operational"* || "$output" == *"System is operational"* \
+        || "$output" == *"what are we working on"* || "$output" == *"What are we working on"* \
+        || "$output" == *"ready for causal inference"* ]]; then
+        return 1
+    fi
+
+    # classify/summarize expect a short single line/word — a suspiciously
+    # long response for these operations is more likely boilerplate than
+    # a real answer.
+    case "$operation" in
+        classify)
+            [[ ${#output} -gt 40 ]] && return 1
+            ;;
+        summarize)
+            [[ ${#output} -gt 200 ]] && return 1
+            ;;
+    esac
+
+    return 0
+}
+
+# ═══════════════════════════════════════════════════════════════════
 # BACKEND SELECTION HELPERS
 # ═══════════════════════════════════════════════════════════════════
 
@@ -208,8 +302,9 @@ _em_ai_timeout_for_op() {
 
 _em_ai_fallback_chain() {
     # Return fallback backends (excluding the one that just failed)
+    # agy is preferred over gemini (legacy, kept for existing configs).
     local failed_backend="$1"
-    local -a chain=(claude gemini)
+    local -a chain=(claude agy gemini)
     local fb
     for fb in "${chain[@]}"; do
         [[ "$fb" != "$failed_backend" ]] && command -v "$fb" &>/dev/null && echo "$fb"
@@ -221,6 +316,7 @@ _em_ai_available() {
     # Returns: space-separated list of available backends
     local -a available=()
     command -v claude &>/dev/null && available+=(claude)
+    command -v agy &>/dev/null && available+=(agy)
     command -v gemini &>/dev/null && available+=(gemini)
     echo "${available[*]}"
 }
@@ -412,12 +508,12 @@ _em_ai_switch() {
 
     # Validate backend
     case "$backend" in
-        claude|gemini|none|auto) ;;  # known backends
+        claude|agy|gemini|none|auto) ;;  # known backends
         *)
             if ! command -v "$backend" &>/dev/null; then
                 _flow_log_error "Unknown backend: $backend"
                 echo "Available: $(_em_ai_available)"
-                echo "Valid: claude, gemini, none, auto"
+                echo "Valid: claude, agy, gemini, none, auto"
                 return 1
             fi
             ;;
@@ -455,13 +551,17 @@ _em_ai_status() {
     # Show extra_args if set
     local gemini_extra="${_EM_AI_BACKENDS[gemini_extra_args]:-}"
     local claude_extra="${_EM_AI_BACKENDS[claude_extra_args]:-}"
-    if [[ -n "$gemini_extra" ]]; then
-        echo -e "  Gemini args: ${_C_DIM}${gemini_extra}${_C_NC}"
-    fi
+    local agy_extra="${_EM_AI_BACKENDS[agy_extra_args]:-}"
     if [[ -n "$claude_extra" ]]; then
         echo -e "  Claude args: ${_C_DIM}${claude_extra}${_C_NC}"
     fi
+    if [[ -n "$agy_extra" ]]; then
+        echo -e "  Agy args:    ${_C_DIM}${agy_extra}${_C_NC}"
+    fi
+    if [[ -n "$gemini_extra" ]]; then
+        echo -e "  Gemini args: ${_C_DIM}${gemini_extra}${_C_NC} (legacy)"
+    fi
 
     echo ""
-    echo -e "  ${_C_DIM}Switch: em ai claude | em ai gemini | em ai toggle${_C_NC}"
+    echo -e "  ${_C_DIM}Switch: em ai claude | em ai agy | em ai gemini | em ai toggle${_C_NC}"
 }

--- a/man/man1/em.1
+++ b/man/man1/em.1
@@ -79,7 +79,7 @@ Send without preview confirmation.
 .B --prompt \fIinstructions\fR
 AI-compose from prompt instructions.
 .TP
-.B --backend \fIclaude\fR|\fIgemini\fR
+.B --backend \fIclaude\fR|\fIagy\fR|\fIgemini\fR
 Override AI backend for this operation.
 .RE
 .TP
@@ -102,7 +102,7 @@ Send immediately without preview.
 .B --prompt \fIinstructions\fR
 Custom instructions for AI draft.
 .TP
-.B --backend \fIclaude\fR|\fIgemini\fR
+.B --backend \fIclaude\fR|\fIagy\fR|\fIgemini\fR
 Override AI backend for this operation.
 .RE
 .TP
@@ -113,7 +113,7 @@ Forward an email.
 .B --prompt \fItext\fR
 AI-compose a custom forwarding note.
 .TP
-.B --backend \fIclaude\fR|\fIgemini\fR
+.B --backend \fIclaude\fR|\fIagy\fR|\fIgemini\fR
 Override AI backend.
 .TP
 .B --force
@@ -244,8 +244,11 @@ Show current AI backend setting.
 .B ai claude
 Switch to Claude as the AI backend.
 .TP
+.B ai agy
+Switch to Antigravity (agy) as the AI backend.
+.TP
 .B ai gemini
-Switch to Gemini as the AI backend.
+Switch to Gemini as the AI backend (legacy; superseded by agy).
 .TP
 .B ai none
 Disable AI features.

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -82,6 +82,8 @@ run_test ./tests/test-dot-chezmoi-safety.zsh
 run_test ./tests/test-em-dispatcher.zsh
 run_test ./tests/test-em-prompt-flag.zsh
 run_test ./tests/test-em-help-guards.zsh
+run_test ./tests/test-em-ai-switch.zsh
+run_test ./tests/test-em-ai-agy.zsh
 run_test ./tests/test-tok.zsh
 run_test ./tests/test-tok-sync.zsh
 

--- a/tests/test-em-ai-agy.zsh
+++ b/tests/test-em-ai-agy.zsh
@@ -1,0 +1,172 @@
+#!/usr/bin/env zsh
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST SUITE: agy Output Cleaning & Validation
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Purpose: Validate _em_ai_agy_clean_output / _em_ai_agy_looks_valid.
+# Context: agy (Antigravity CLI) has no clean-output flag and has been observed
+#          to exit 0 with a canned "system operational" response on degenerate
+#          input — these helpers strip its boilerplate and reject responses
+#          that look like that canned fallback, since agy's exit code alone
+#          cannot be trusted.
+#
+# Created: 2026-07-07
+# ══════════════════════════════════════════════════════════════════════════════
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh" || { echo "ERROR: Cannot source test-framework.zsh"; exit 1 }
+
+setup() {
+    typeset -g project_root=""
+    if [[ -n "${0:A}" ]]; then project_root="${0:A:h:h}"; fi
+    if [[ -z "$project_root" || ! -f "$project_root/flow.plugin.zsh" ]]; then
+        if [[ -f "$PWD/flow.plugin.zsh" ]]; then project_root="$PWD"
+        elif [[ -f "$PWD/../flow.plugin.zsh" ]]; then project_root="$PWD/.."
+        fi
+    fi
+    [[ -z "$project_root" || ! -f "$project_root/flow.plugin.zsh" ]] && { echo "ERROR: Cannot find project root"; exit 1; }
+
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$project_root"
+    exec < /dev/null  # Non-interactive
+    source "$project_root/flow.plugin.zsh"
+}
+
+cleanup() {
+    reset_mocks
+}
+trap cleanup EXIT
+
+# ═══════════════════════════════════════════════════════════════
+# Section 1: _em_ai_agy_clean_output strips the boilerplate block
+# ═══════════════════════════════════════════════════════════════
+
+test_clean_output_strips_emoji_block() {
+    test_case "_em_ai_agy_clean_output strips the emoji status block"
+    local raw="Fox jumps over lazy dog.
+
+- **🟢 DONE:** Summarized the sentence.
+- **⏭️ NEXT:** Await further instructions.
+- **⚠️ WATCH OUT FOR:** None.
+- **🔗 CONNECTED TO:** N/A."
+    local cleaned
+    cleaned=$(_em_ai_agy_clean_output "$raw")
+    if [[ "$cleaned" == *"Fox jumps"* && "$cleaned" != *"DONE"* && "$cleaned" != *"CONNECTED TO"* ]]; then
+        test_pass
+    else
+        test_fail "Expected boilerplate stripped, got: $cleaned"
+    fi
+}
+
+test_clean_output_strips_separator_block() {
+    test_case "_em_ai_agy_clean_output strips a --- separated block"
+    local raw="Real answer here.
+
+---
+
+- **🟢 DONE:** something
+"
+    local cleaned
+    cleaned=$(_em_ai_agy_clean_output "$raw")
+    if [[ "$cleaned" == *"Real answer here"* && "$cleaned" != *"DONE"* ]]; then
+        test_pass
+    else
+        test_fail "Expected content before separator kept, block removed, got: $cleaned"
+    fi
+}
+
+test_clean_output_passes_through_plain_text() {
+    test_case "_em_ai_agy_clean_output leaves plain text untouched"
+    local raw="student"
+    local cleaned
+    cleaned=$(_em_ai_agy_clean_output "$raw")
+    if [[ "$cleaned" == "student" ]]; then
+        test_pass
+    else
+        test_fail "Expected 'student' unchanged, got: $cleaned"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════
+# Section 2: _em_ai_agy_looks_valid rejects canned boilerplate
+# ═══════════════════════════════════════════════════════════════
+
+test_looks_valid_rejects_operational_boilerplate() {
+    test_case "_em_ai_agy_looks_valid rejects 'system is operational' canned response"
+    local canned="System is operational. Ready for causal inference research. What are we working on?"
+    if _em_ai_agy_looks_valid "summarize" "$canned"; then
+        test_fail "Expected canned boilerplate to be rejected"
+    else
+        test_pass
+    fi
+}
+
+test_looks_valid_rejects_empty() {
+    test_case "_em_ai_agy_looks_valid rejects empty output"
+    if _em_ai_agy_looks_valid "classify" ""; then
+        test_fail "Expected empty output to be rejected"
+    else
+        test_pass
+    fi
+}
+
+test_looks_valid_rejects_long_classify_response() {
+    test_case "_em_ai_agy_looks_valid rejects an overly long classify response"
+    local long="this-is-a-suspiciously-long-classification-category-that-is-not-a-real-single-word-category"
+    if _em_ai_agy_looks_valid "classify" "$long"; then
+        test_fail "Expected long classify response to be rejected"
+    else
+        test_pass
+    fi
+}
+
+test_looks_valid_accepts_short_classify_response() {
+    test_case "_em_ai_agy_looks_valid accepts a real short classify response"
+    if _em_ai_agy_looks_valid "classify" "student"; then
+        test_pass
+    else
+        test_fail "Expected 'student' to be accepted as a valid classify response"
+    fi
+}
+
+test_looks_valid_accepts_real_summary() {
+    test_case "_em_ai_agy_looks_valid accepts a real one-line summary"
+    local summary="Student Jane: absent Friday, requests notes"
+    if _em_ai_agy_looks_valid "summarize" "$summary"; then
+        test_pass
+    else
+        test_fail "Expected real summary to be accepted"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════
+
+main() {
+    test_suite_start "agy Output Cleaning & Validation"
+
+    setup
+
+    echo "${CYAN}Section 1: _em_ai_agy_clean_output${RESET}"
+    test_clean_output_strips_emoji_block
+    test_clean_output_strips_separator_block
+    test_clean_output_passes_through_plain_text
+    echo ""
+
+    echo "${CYAN}Section 2: _em_ai_agy_looks_valid${RESET}"
+    test_looks_valid_rejects_operational_boilerplate
+    test_looks_valid_rejects_empty
+    test_looks_valid_rejects_long_classify_response
+    test_looks_valid_accepts_short_classify_response
+    test_looks_valid_accepts_real_summary
+    echo ""
+
+    cleanup
+    test_suite_end
+    exit $?
+}
+
+main

--- a/tests/test-em-ai-switch.zsh
+++ b/tests/test-em-ai-switch.zsh
@@ -78,6 +78,16 @@ test_ai_switch_gemini() {
     fi
 }
 
+test_ai_switch_agy() {
+    test_case "_em_ai_switch agy succeeds"
+    _em_ai_switch "agy" &>/dev/null
+    if [[ $? -eq 0 && "$FLOW_EMAIL_AI" == "agy" ]]; then
+        test_pass
+    else
+        test_fail "Expected FLOW_EMAIL_AI=agy, got '$FLOW_EMAIL_AI'"
+    fi
+}
+
 test_ai_switch_none() {
     test_case "_em_ai_switch none succeeds"
     _em_ai_switch "none" &>/dev/null
@@ -142,16 +152,16 @@ test_ai_toggle_cycles() {
     test_case "_em_ai_toggle cycles through available backends"
 
     # Override _em_ai_available directly (avoids create_mock eval issues)
-    _em_ai_available() { echo "claude gemini"; }
+    _em_ai_available() { echo "claude agy gemini"; }
 
     # Start from claude
     export FLOW_EMAIL_AI="claude"
     _em_ai_toggle &>/dev/null
 
-    if [[ "$FLOW_EMAIL_AI" == "gemini" ]]; then
+    if [[ "$FLOW_EMAIL_AI" == "agy" ]]; then
         test_pass
     else
-        test_fail "Expected toggle from claude -> gemini, got '$FLOW_EMAIL_AI'"
+        test_fail "Expected toggle from claude -> agy, got '$FLOW_EMAIL_AI'"
     fi
 
     _restore_ai_available
@@ -161,7 +171,7 @@ test_ai_toggle_wraps_around() {
     test_case "_em_ai_toggle wraps from last to first"
 
     # Override _em_ai_available directly
-    _em_ai_available() { echo "claude gemini"; }
+    _em_ai_available() { echo "claude agy gemini"; }
 
     # Start from gemini (should wrap to claude)
     export FLOW_EMAIL_AI="gemini"
@@ -339,6 +349,15 @@ test_backends_has_claude_extra_args() {
     fi
 }
 
+test_backends_has_agy_extra_args() {
+    test_case "_EM_AI_BACKENDS has agy_extra_args key"
+    if [[ -n "${_EM_AI_BACKENDS[agy_extra_args]+set}" ]]; then
+        test_pass
+    else
+        test_fail "agy_extra_args key missing from _EM_AI_BACKENDS"
+    fi
+}
+
 test_gemini_extra_args_default() {
     test_case "gemini_extra_args defaults to '-e none'"
     local gemini_args="${_EM_AI_BACKENDS[gemini_extra_args]}"
@@ -360,6 +379,7 @@ main() {
 
     echo "${CYAN}Section 1: _em_ai_switch Valid Backends${RESET}"
     test_ai_switch_claude
+    test_ai_switch_agy
     test_ai_switch_gemini
     test_ai_switch_none
     test_ai_switch_auto
@@ -398,6 +418,7 @@ main() {
     echo "${CYAN}Section 7: extra_args in _EM_AI_BACKENDS${RESET}"
     test_backends_has_gemini_extra_args
     test_backends_has_claude_extra_args
+    test_backends_has_agy_extra_args
     test_gemini_extra_args_default
     echo ""
 


### PR DESCRIPTION
## Summary

- Adds `agy` (Antigravity CLI) as the primary fallback AI backend in `em`'s AI abstraction layer, ahead of `gemini` in the chain (`claude → agy → gemini → none`). Google's `gemini` CLI is deprecated upstream in favor of Antigravity; `gemini` is **kept, not removed**, for existing `FLOW_EMAIL_AI=gemini` configs.
- `agy` needs a validation wrapper, not a drop-in swap: it has no clean-output flag (appends an unrequested markdown status block to every response) and has been observed to exit `0` with a canned "system operational" response on degenerate input rather than failing loudly. New `_em_ai_agy_clean_output`/`_em_ai_agy_looks_valid` helpers strip and sanity-check its output before use; a failed check falls through to the existing fallback chain.
- **Fixes a more serious bug found during live verification:** capturing `agy`'s output via `$(...)` command substitution hangs or dies silently, independent of `timeout` — `agy` leaves a descendant process attached to its stdout pipe, so `$(...)` blocks waiting for an EOF that never comes. Fixed by routing output through a temp file instead of `$(...)`.
- Updates `doctor`'s health check and the full doc surface documenting the `--backend`/`FLOW_EMAIL_AI` option set: `EMAIL-DISPATCHER-GUIDE.md`, `EMAIL-COOKBOOK.md`, `docs/commands/doctor.md`, `MASTER-DISPATCHER-GUIDE.md`, `MASTER-API-REFERENCE.md`, `MASTER-ARCHITECTURE.md`, `REFCARD-EMAIL-DISPATCHER.md`, `QUICK-REFERENCE.md`, `docs/tutorials/46-em-v2-features.md`, `man/man1/em.1`, root + docs `CHANGELOG.md`. Left `docs/specs/*` (historical, point-in-time) and `docs/tutorials/33-himalaya-email.md`'s himalaya.nvim `:HimalayaAi` setting (a separate editor plugin, not `em`) untouched.
- Registered `tests/test-em-ai-switch.zsh` in `run-all.sh`, which had never been wired into the suite.

## Test plan

- [x] `tests/test-em-ai-switch.zsh` — 24/24 pass (added `agy` switch/toggle/extra_args cases)
- [x] `tests/test-em-ai-agy.zsh` (new) — 8/8 pass (clean-output stripping + canned-response validation)
- [x] `./tests/run-all.sh` — 77 passed, 0 failed, 0 timeout, 1 skipped (expected — `e2e-em-dispatcher` skips when the external tool is absent, matches documented baseline). Ran twice for consistency.
- [x] `mkdocs build --strict` — clean, run twice (before and after the second docs pass), 0 warnings both times.
- [x] Live e2e: `_em_ai_execute agy "..." "..." 15 classify` verified against the real `agy` binary post-fix — returns `hello`/`EXIT:0` cleanly through the actual code path (pre-fix: hung/died silently, reproduced 3x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)