### PR TITLE
fix(em): em move was broken in production; add em undo + recent-folders (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`em undo`** — single-step undo of the last `em star`/`flag`/`unflag`/`move` action (1-hour window, no multi-level undo stack). Uses `lib/em-cache.zsh`'s existing cache API.
+- **`em move --recent <ID>...`** — quick-pick the target folder from the last 3 move destinations, no `fzf` required.
+- **Centralized `ALIASES` section in `em help`** — single-source list of all short-form command aliases, instead of scattered per-command mentions.
+
+### Fixed
+
+- **`em move` was broken in production** — `_em_move` and its adapter `_em_hml_move` were each defined twice in the same file (zsh's last-definition-wins semantics), and the two live (later) definitions were incompatible with each other: the live `_em_move` called `_em_hml_move` with a numeric message ID in the source-folder position. Every `em move <ID> <folder>` call would attempt to move a message from a non-existent folder named after the ID. Removed the dead pair, kept the multi-ID interface (`em move <FOLDER> <ID>...`) that matches `em move --help`, `MASTER-DISPATCHER-GUIDE.md`, and the existing (previously unregistered) `tests/test-em-move-restore.zsh`. That test file — which would have caught this — was never wired into `tests/run-all.sh`; it is now.
+- Corrected a dozen-plus stale `em move <ID> [FOLDER]` / `em flag <ID> # Alias for em star` references across `docs/help/QUICK-REFERENCE.md`, `docs/reference/MASTER-DISPATCHER-GUIDE.md`, `docs/reference/REFCARD-EMAIL-DISPATCHER.md` (which had both a stale and a correct `em move` row), `docs/guides/EMAIL-DISPATCHER-GUIDE.md`, `docs/guides/EMAIL-COOKBOOK.md`, and `man/man1/em.1` — all inherited the same wrong interface the code bug had.
+
 ## [7.16.0] — 2026-07-07 — agy em-ai backend + em ADHD-UX fixes
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ## [Unreleased]
 
+### Added
+
+- **`em undo`** — single-step undo of the last `em star`/`flag`/`unflag`/`move` action (1-hour window, no multi-level undo stack). Uses `lib/em-cache.zsh`'s existing cache API.
+- **`em move --recent <ID>...`** — quick-pick the target folder from the last 3 move destinations, no `fzf` required.
+- **Centralized `ALIASES` section in `em help`** — single-source list of all short-form command aliases, instead of scattered per-command mentions.
+
+### Fixed
+
+- **`em move` was broken in production** — `_em_move` and its adapter `_em_hml_move` were each defined twice in the same file (zsh's last-definition-wins semantics), and the two live (later) definitions were incompatible with each other: the live `_em_move` called `_em_hml_move` with a numeric message ID in the source-folder position. Every `em move <ID> <folder>` call would attempt to move a message from a non-existent folder named after the ID. Removed the dead pair, kept the multi-ID interface (`em move <FOLDER> <ID>...`) that matches `em move --help`, `MASTER-DISPATCHER-GUIDE.md`, and the existing (previously unregistered) `tests/test-em-move-restore.zsh`. That test file — which would have caught this — was never wired into `tests/run-all.sh`; it is now.
+- Corrected a dozen-plus stale `em move <ID> [FOLDER]` / `em flag <ID> # Alias for em star` references across `docs/help/QUICK-REFERENCE.md`, `docs/reference/MASTER-DISPATCHER-GUIDE.md`, `docs/reference/REFCARD-EMAIL-DISPATCHER.md` (which had both a stale and a correct `em move` row), `docs/guides/EMAIL-DISPATCHER-GUIDE.md`, `docs/guides/EMAIL-COOKBOOK.md`, and `man/man1/em.1` — all inherited the same wrong interface the code bug had.
+
 ## [7.16.0] — 2026-07-07 — agy em-ai backend + em ADHD-UX fixes
 
 ### Added

--- a/docs/guides/EMAIL-COOKBOOK.md
+++ b/docs/guides/EMAIL-COOKBOOK.md
@@ -116,7 +116,7 @@ em read --md 87    # Clean Markdown rendering (better for Outlook emails)
 
 # Now act on it
 em reply 87                         # AI-drafted reply
-em move 87 Archive                  # File it away
+em move Archive 87                  # File it away
 em delete 87                        # Move to Trash (y/N confirm)
 em snooze 87 monday                 # Come back to it Monday 9am
 ```
@@ -200,12 +200,13 @@ em folders
 # Create a new folder
 em create-folder "Research 2026"
 
-# Move emails into it (one at a time or batch)
-em move 101 "Research 2026"
-em mv "Research 2026" 102 103 104   # batch move: folder first, then IDs
+# Move emails into it (folder first, then ID(s))
+em move "Research 2026" 101
+em mv "Research 2026" 102 103 104   # batch move
 
-# Or move with fzf folder picker (no folder arg = interactive)
-em move 105
+# Or pick the target folder interactively
+em move --pick 105          # fzf picker
+em move --recent 105        # quick-pick from last 3 destinations
 
 # List and clean up an old folder
 em inbox 50 "Old Archive"

--- a/docs/guides/EMAIL-DISPATCHER-GUIDE.md
+++ b/docs/guides/EMAIL-DISPATCHER-GUIDE.md
@@ -17,7 +17,7 @@ em read 42            # Smart rendering (HTML/markdown/plain)
 em reply 42           # AI draft in $EDITOR
 em respond            # Batch AI drafts for actionable emails
 em star 42            # Toggle star/flag
-em move 42 Archive    # Move to folder
+em move Archive 42    # Move to folder
 em thread 42          # Conversation thread view
 em snooze 42 2h       # Snooze for later
 em digest             # AI-grouped daily summary
@@ -1225,8 +1225,10 @@ Toggle the IMAP `Flagged` flag on an email:
 
 ```bash
 em star 42              # Toggle star on email #42
-em flag 42              # Alias for em star
 ```
+
+`em flag`/`em unflag` are separate one-way commands (set/clear only, batch-capable) —
+not aliases of `em star`. See the Flag / Unflag section below.
 
 **Output:**
 
@@ -1261,21 +1263,35 @@ em starred — flagged emails
 Move an email to a different folder:
 
 ```bash
-em move 42 Archive      # Move to Archive (with confirmation)
-em move 42              # fzf folder picker (requires fzf)
-em mv 42 Trash          # Alias
+em move Archive 42          # Move email #42 to Archive
+em mv Trash 42               # Alias
+em move Archive 10 20 30     # Batch move (multi-ID)
+em move --from Sent Archive 42  # Move from a non-default source folder
+em move --pick 42            # fzf folder picker
+em move --recent 42          # Quick-pick from the last 3 destination folders
 ```
 
-**With explicit folder:**
+**Output:**
 
 ```text
-Move #42 → Archive? [y/N] y
-✅ Moved #42 to Archive
+✅ Moved 1 email(s) to Archive
 ```
 
-**Without folder (fzf picker):**
+**`--pick` (fzf folder picker):**
 
 Opens an interactive folder picker. Select a folder with Enter, or press Escape to cancel.
+
+**`--recent` (quick-pick, no fzf required):**
+
+```text
+Recent folders:
+  1) Archive
+  2) Projects
+  3) Newsletter
+  Select [1-3]: 1
+```
+
+Undo a move (or star/flag/unflag) with `em undo` — one step, 1-hour window.
 
 ### Thread
 
@@ -1528,8 +1544,6 @@ Archive
 ### Delete Emails
 
 ```bash
-em move 42 Archive      # Move email to Archive (with confirmation)
-em move 42              # Move with fzf folder picker
 em inbox Sent           # List sent emails
 em pick Archive         # Browse archive folder
 # Delete by ID (moves to Trash)
@@ -1585,6 +1599,13 @@ em mv Archive 10 20 30           # Batch move
 
 # Move from specific source folder
 em move --from Sent Archive 42   # Sent → Archive
+
+# fzf folder picker / recent-folders quick-pick
+em move --pick 42                # fzf picker
+em move --recent 42              # Pick from last 3 destinations
+
+# Undo the last star/flag/unflag/move (one step, 1hr window)
+em undo
 ```
 
 ### Restore from Trash

--- a/docs/help/QUICK-REFERENCE.md
+++ b/docs/help/QUICK-REFERENCE.md
@@ -1224,8 +1224,9 @@ em star 42              # Toggle star (Flagged) on email
 em starred              # List all starred emails
 
 # Move to folder
-em move 42 Archive      # Move with explicit folder
-em move 42              # Move with fzf folder picker (requires fzf)
+em move Archive 42      # Move with explicit folder
+em move --pick 42       # Move with fzf folder picker (requires fzf)
+em move --recent 42     # Quick-pick from last 3 destinations
 
 # Conversation thread
 em thread 42            # Show chronological thread for email
@@ -1303,6 +1304,9 @@ em restore 42 --to Archive       # Restore to specific folder
 em flag 42                       # Star/flag email
 em fl 42 43                      # Batch flag
 em unflag 42                     # Remove star
+
+# Undo the last star/flag/unflag/move (one step, 1hr window)
+em undo
 
 # AI extraction
 em todo 42                       # Extract action items → Reminders.app

--- a/docs/reference/MASTER-DISPATCHER-GUIDE.md
+++ b/docs/reference/MASTER-DISPATCHER-GUIDE.md
@@ -3300,10 +3300,11 @@ calendar ICS parsing, and IMAP IDLE background watching.
 | `em delete --purge <ID>` | | Permanent delete (requires typing "yes") |
 | `em create-folder <name>` | `em cf` | Create a new mail folder |
 | `em delete-folder <name>` | `em df` | Delete folder (type-to-confirm) |
-| `em move <ID> [FOLDER]` | `em mv` | Move email to folder (fzf picker if no folder) |
+| `em move <FOLDER> <ID>...` | `em mv` | Move email(s) to folder (`--pick` for fzf, `--recent` for last 3) |
 | `em restore <ID>` | | Restore from Trash to INBOX |
 | `em flag <ID>...` | `em fl` | One-way: set starred (batch-capable) |
 | `em unflag <ID>...` | | One-way: clear starred (batch-capable) |
+| `em undo` | | Undo last star/flag/unflag/move (1-step, 1hr window) |
 | `em respond` | `em resp` | Batch AI drafts for actionable emails |
 | `em classify <ID>` | | AI category classification |
 | `em summarize <ID>` | `em sum` | One-line AI summary |
@@ -3344,7 +3345,7 @@ em forward 42 user@example.com --prompt 'FYI re: our discussion'
 em reply 42 --backend agy     # Override AI backend per-command
 em respond                 # Batch process actionable emails
 em star 42                 # Toggle star on email
-em move 42 Archive         # Move email to folder
+em move Archive 42         # Move email to folder
 em thread 42               # Show conversation thread
 em snooze 42 2h            # Snooze for 2 hours
 em digest                  # AI-grouped daily summary

--- a/docs/reference/REFCARD-EMAIL-DISPATCHER.md
+++ b/docs/reference/REFCARD-EMAIL-DISPATCHER.md
@@ -86,9 +86,8 @@ mindmap
 | **em summarize** | `sum` | `em summarize <ID>` | One-line summary (AI) |
 | **em ai** | — | `em ai [claude\|gemini\|none\|auto\|toggle]` | Runtime AI backend switching |
 | **em catch** | `c` | `em catch <ID>` | Capture email as task (AI summary → catch) |
-| **em star** | `flag` | `em star <ID>` | Toggle starred (Flagged) status |
+| **em star** | — | `em star <ID>...` | Toggle starred (Flagged) status, multi-ID |
 | **em starred** | — | `em starred [FOLDER]` | List starred emails |
-| **em move** | `mv` | `em move <ID> [FOLDER]` | Move to folder (fzf picker if no folder) |
 | **em thread** | `th` | `em thread <ID>` | Show conversation thread |
 | **em snooze** | `snz` | `em snooze <ID> <TIME>` | Snooze email (2h, 1d, tomorrow, monday) |
 | **em snoozed** | — | `em snoozed` | List snoozed emails with status |
@@ -108,10 +107,11 @@ mindmap
 | **em delete** | `del, rm` | `em delete <ID> [--folder F] [--query Q] [--pick] [--purge]` | Delete email(s) — move to Trash (or permanent with --purge) |
 | **em create-folder** | `cf` | `em create-folder <name>` | Create a new mail folder |
 | **em delete-folder** | `df` | `em delete-folder <name>` | Delete folder (type-to-confirm) |
-| **em move** | `mv` | `em move <FOLDER> <ID> [--from F]` | Move email(s) to folder |
+| **em move** | `mv` | `em move <FOLDER> <ID>... [--from F\|--pick\|--recent]` | Move email(s) to folder |
 | **em restore** | — | `em restore <ID> [--to F]` | Restore from Trash (default: to INBOX) |
 | **em flag** | `fl` | `em flag <ID> [<ID>...]` | Star/flag email(s) |
 | **em unflag** | — | `em unflag <ID> [<ID>...]` | Unstar/unflag email(s) |
+| **em undo** | — | `em undo` | Undo last star/flag/unflag/move (1-step, 1hr window) |
 | **em todo** | `td` | `em todo <ID> [<ID>...]` | Extract action items (AI) → Reminders.app |
 | **em event** | `ev` | `em event <ID> [<ID>...]` | Extract calendar events (AI) → Calendar.app |
 
@@ -531,8 +531,6 @@ em catch 42                     # AI summarize → pipe to catch
 # Organizing
 em star 42                      # Toggle star (flagged)
 em starred                      # List starred emails
-em move 42 Archive              # Move to Archive
-em move 42                      # fzf folder picker
 em thread 42                    # Show conversation thread
 em snooze 42 2h                 # Snooze for 2 hours
 em snooze 42 tomorrow           # Snooze until tomorrow 9am
@@ -547,9 +545,12 @@ em delete --query "newsletter"  # Delete by search
 em delete --purge 42            # PERMANENT delete (requires "yes")
 em move Archive 42              # Move to Archive
 em mv Archive 10 20 30          # Batch move
+em move --pick 42               # fzf folder picker
+em move --recent 42             # Quick-pick from last 3 destinations
 em restore 42                   # Restore from Trash → INBOX
 em flag 42                      # Star/flag email
 em unflag 42                    # Remove star
+em undo                         # Undo the last star/flag/unflag/move
 em todo 42                      # AI → extract action items
 em event 42                     # AI → extract calendar events
 

--- a/lib/dispatchers/email-dispatcher.zsh
+++ b/lib/dispatchers/email-dispatcher.zsh
@@ -110,6 +110,7 @@ em() {
         restore)       shift; _em_restore "$@" ;;
         flag|fl)       shift; _em_flag "$@" ;;
         unflag)        shift; _em_unflag "$@" ;;
+        undo)          shift; _em_undo "$@" ;;
 
         # ─────────────────────────────────────────────────────────────
         # FOLDERS
@@ -223,10 +224,12 @@ ${_C_BLUE}MANAGE${_C_NC}:
   ${_C_CYAN}em delete <ID>${_C_NC}       Delete email (move to Trash)
   ${_C_CYAN}em delete --pick${_C_NC}     Interactive multi-select delete
   ${_C_CYAN}em delete --purge${_C_NC}    Permanent delete (requires \"yes\")
-  ${_C_CYAN}em move <ID> [F]${_C_NC}    Move to folder (fzf picker if no folder)
+  ${_C_CYAN}em move <FOLDER> <ID>...${_C_NC} Move to folder (multi-ID, --pick for fzf)
   ${_C_CYAN}em restore <ID>${_C_NC}     Restore from Trash to INBOX
   ${_C_CYAN}em flag <ID>...${_C_NC}     One-way: set starred (batch-capable)
   ${_C_CYAN}em unflag <ID>...${_C_NC}   One-way: clear starred (batch-capable)
+  ${_C_CYAN}em undo${_C_NC}             Undo the last star/flag/unflag/move (1hr window)
+  ${_C_CYAN}em move --recent <ID>...${_C_NC} Pick target from last 3 move destinations
 "
             ;;
         safety)
@@ -354,10 +357,11 @@ ${_C_BLUE}MANAGE${_C_NC}:
   ${_C_CYAN}em delete <ID>${_C_NC}       Delete email (move to Trash)
   ${_C_CYAN}em delete --pick${_C_NC}     Interactive multi-select delete
   ${_C_CYAN}em delete --purge${_C_NC}    Permanent delete (requires \"yes\")
-  ${_C_CYAN}em move <ID> [F]${_C_NC}    Move to folder (fzf picker if no folder)
+  ${_C_CYAN}em move <FOLDER> <ID>...${_C_NC} Move to folder (multi-ID, --pick for fzf)
   ${_C_CYAN}em restore <ID>${_C_NC}     Restore from Trash to INBOX
   ${_C_CYAN}em flag <ID>...${_C_NC}     One-way: set starred (batch-capable)
   ${_C_CYAN}em unflag <ID>...${_C_NC}   One-way: clear starred (batch-capable)
+  ${_C_CYAN}em undo${_C_NC}             Undo the last star/flag/unflag/move (1hr window)
 
 ${_C_BLUE}AI FEATURES${_C_NC}:
   ${_C_CYAN}em respond${_C_NC}        Batch AI drafts for actionable emails
@@ -378,6 +382,14 @@ ${_C_BLUE}INFO & MANAGEMENT${_C_NC}:
   ${_C_CYAN}em cache stats${_C_NC}    Show AI cache statistics
   ${_C_CYAN}em cache clear${_C_NC}    Clear AI cache
   ${_C_CYAN}em doctor${_C_NC}         Check dependencies
+
+${_C_MAGENTA}ALIASES${_C_NC}: short forms for the most-used commands:
+  ${_C_DIM}i${_C_NC}=inbox  ${_C_DIM}r${_C_NC}=read  ${_C_DIM}s${_C_NC}=send  ${_C_DIM}re${_C_NC}=reply  ${_C_DIM}fwd${_C_NC}=forward
+  ${_C_DIM}f${_C_NC}=find  ${_C_DIM}p${_C_NC}=pick  ${_C_DIM}del/rm${_C_NC}=delete  ${_C_DIM}mv${_C_NC}=move  ${_C_DIM}fl${_C_NC}=flag
+  ${_C_DIM}cf${_C_NC}=create-folder  ${_C_DIM}df${_C_NC}=delete-folder  ${_C_DIM}resp${_C_NC}=respond  ${_C_DIM}cl${_C_NC}=classify
+  ${_C_DIM}sum${_C_NC}=summarize  ${_C_DIM}c${_C_NC}=catch  ${_C_DIM}td${_C_NC}=todo  ${_C_DIM}ev${_C_NC}=event  ${_C_DIM}th${_C_NC}=thread
+  ${_C_DIM}snz${_C_NC}=snooze  ${_C_DIM}dg${_C_NC}=digest  ${_C_DIM}u${_C_NC}=unread  ${_C_DIM}d${_C_NC}=dash  ${_C_DIM}cal${_C_NC}=calendar
+  ${_C_DIM}w${_C_NC}=watch  ${_C_DIM}a${_C_NC}=attach  ${_C_DIM}dr${_C_NC}=doctor  ${_C_DIM}h${_C_NC}=help
 
 ${_C_MAGENTA}SAFETY${_C_NC}: Three tiers of confirmation, scaled to how reversible the action is:
   ${_C_DIM}1. Reversible (delete)${_C_NC}       ${_C_YELLOW}[y/N/e]${_C_NC} single keypress (default: No, e=edit)
@@ -1803,15 +1815,18 @@ _em_move() {
     [[ "$1" == "--help" || "$1" == "-h" || "$1" == "help" ]] && { _em_move_help; return 0; }
     _em_require_himalaya || return 1
 
-    local src_folder="${FLOW_EMAIL_FOLDER:-INBOX}" pick=false target=""
+    local src_folder="${FLOW_EMAIL_FOLDER:-INBOX}" pick=false recent=false target=""
     local -a ids=()
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --from)  shift; src_folder="$1"; shift ;;
-            --pick)  pick=true; shift ;;
+            --from)   shift; src_folder="$1"; shift ;;
+            --pick)   pick=true; shift ;;
+            --recent) recent=true; shift ;;
             *)
-                if [[ -z "$target" ]]; then
+                if [[ "$pick" == true || "$recent" == true ]]; then
+                    ids+=("$1")
+                elif [[ -z "$target" ]]; then
                     target="$1"
                 else
                     ids+=("$1")
@@ -1826,10 +1841,6 @@ _em_move() {
         if ! command -v fzf &>/dev/null; then
             _flow_log_error "fzf required for --pick mode"
             return 1
-        fi
-        # IDs come after --pick (target is actually an ID in this mode)
-        if [[ -n "$target" ]]; then
-            ids=("$target" "${ids[@]}")
         fi
         if [[ ${#ids[@]} -eq 0 ]]; then
             _flow_log_error "Email ID required with --pick"
@@ -1846,6 +1857,37 @@ _em_move() {
         [[ -z "$target" ]] && return 0
     fi
 
+    # --recent mode: quick-pick from last 3 move destinations, no fzf required
+    if [[ "$recent" == true ]]; then
+        if [[ ${#ids[@]} -eq 0 ]]; then
+            _flow_log_error "Email ID required with --recent"
+            echo "Usage: ${_C_CYAN}em move --recent <ID> [<ID>...]${_C_NC}"
+            return 1
+        fi
+        local recent_list
+        recent_list=$(_em_recent_folders_get)
+        if [[ -z "$recent_list" ]]; then
+            _flow_log_error "No recent folders yet — use 'em move <FOLDER> <ID>...' first"
+            return 1
+        fi
+        echo -e "${_C_BOLD}Recent folders:${_C_NC}"
+        local -a recent_arr
+        recent_arr=("${(@f)recent_list}")
+        local i=1 f
+        for f in "${recent_arr[@]}"; do
+            echo "  $i) $f"
+            (( i++ ))
+        done
+        printf "  Select [1-%d]: " "${#recent_arr[@]}"
+        local choice
+        read -r choice
+        if [[ ! "$choice" =~ ^[0-9]+$ ]] || (( choice < 1 || choice > ${#recent_arr[@]} )); then
+            _flow_log_info "Cancelled"
+            return 0
+        fi
+        target="${recent_arr[$choice]}"
+    fi
+
     if [[ -z "$target" ]]; then
         _flow_log_error "Target folder required"
         echo "Usage: ${_C_CYAN}em move <FOLDER> <ID> [<ID>...]${_C_NC}"
@@ -1860,6 +1902,8 @@ _em_move() {
     _em_hml_move "$src_folder" "$target" "${ids[@]}"
     if [[ $? -eq 0 ]]; then
         _flow_log_success "Moved ${#ids[@]} email(s) to $target"
+        _em_undo_record "move" "$src_folder" "$target" "${ids[*]}"
+        _em_recent_folders_add "$target"
     else
         _flow_log_error "Move failed"
         return 1
@@ -1873,9 +1917,11 @@ ${_C_BOLD}em move${_C_NC} — Move emails between folders
 ${_C_CYAN}em move <FOLDER> <ID> [<ID>...]${_C_NC}         Move email(s) to folder
 ${_C_CYAN}em move --from <SRC> <FOLDER> <ID>${_C_NC}      Move from non-default source
 ${_C_CYAN}em move --pick <ID> [<ID>...]${_C_NC}           fzf folder picker
+${_C_CYAN}em move --recent <ID> [<ID>...]${_C_NC}         Quick-pick from last 3 destinations
 
 ${_C_DIM}Aliases: em mv${_C_NC}
 ${_C_DIM}Default source: \$FLOW_EMAIL_FOLDER (${FLOW_EMAIL_FOLDER:-INBOX})${_C_NC}
+${_C_DIM}Undo the last move with: em undo${_C_NC}
 "
 }
 
@@ -1938,6 +1984,7 @@ _em_flag() {
         _em_hml_flags add "$msg_id" Flagged
         _flow_log_success "Flagged email #$msg_id"
     done
+    _em_undo_record "flag" "$*"
 }
 
 _em_unflag() {
@@ -1954,6 +2001,76 @@ _em_unflag() {
         _em_hml_flags remove "$msg_id" Flagged
         _flow_log_success "Unflagged email #$msg_id"
     done
+    _em_undo_record "unflag" "$*"
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# UNDO — single-step undo of the last star/flag/move action
+# ═══════════════════════════════════════════════════════════════════
+
+_em_undo() {
+    [[ "$1" == "--help" || "$1" == "-h" || "$1" == "help" ]] && { _em_undo_help; return 0; }
+    _em_require_himalaya || return 1
+
+    local raw
+    raw=$(_em_undo_get)
+    if [[ -z "$raw" ]]; then
+        _flow_log_info "Nothing to undo"
+        return 1
+    fi
+
+    local -a parts
+    parts=("${(@s:|:)raw}")
+    local action="${parts[1]}"
+
+    case "$action" in
+        star)
+            local ids="${parts[2]}"
+            _em_star ${=ids} >/dev/null
+            _flow_log_success "Undid star toggle: ${ids}"
+            ;;
+        flag)
+            local ids="${parts[2]}"
+            local id
+            for id in ${=ids}; do
+                _em_hml_flags remove "$id" Flagged
+            done
+            _flow_log_success "Undid flag: unflagged ${ids}"
+            ;;
+        unflag)
+            local ids="${parts[2]}"
+            local id
+            for id in ${=ids}; do
+                _em_hml_flags add "$id" Flagged
+            done
+            _flow_log_success "Undid unflag: re-flagged ${ids}"
+            ;;
+        move)
+            local src="${parts[2]}" dst="${parts[3]}" ids="${parts[4]}"
+            if _em_hml_move "$dst" "$src" ${=ids}; then
+                _flow_log_success "Undid move: ${ids} back to ${src}"
+            else
+                _flow_log_error "Undo move failed"
+                return 1
+            fi
+            ;;
+        *)
+            _flow_log_error "Unrecognized undo state: $action"
+            return 1
+            ;;
+    esac
+
+    _em_undo_clear
+}
+
+_em_undo_help() {
+    echo -e "
+${_C_BOLD}em undo${_C_NC} — Undo the last star/flag/unflag/move action
+
+${_C_CYAN}em undo${_C_NC}   Reverse the single most recent star, flag, unflag, or move
+
+${_C_DIM}One-step only — no multi-level undo stack. Undo window: 1 hour.${_C_NC}
+"
 }
 
 # ═══════════════════════════════════════════════════════════════════
@@ -2472,6 +2589,7 @@ _em_star() {
             echo -e "  ${_C_YELLOW}★${_C_NC} Starred #${msg_id}"
         fi
     done
+    _em_undo_record "star" "$*"
 }
 
 _em_starred() {
@@ -2496,53 +2614,6 @@ _em_starred() {
     local count
     count=$(echo "$json" | jq 'length' 2>/dev/null)
     echo -e "\n  ${_C_DIM}${count:-0} starred${_C_NC}"
-}
-
-_em_move() {
-    [[ "$1" == "--help" || "$1" == "-h" || "$1" == "help" ]] && { _em_move_help; return 0; }
-    _em_require_himalaya || return 1
-    local msg_id="$1" target_folder="$2"
-
-    if [[ -z "$msg_id" ]]; then
-        _flow_log_error "Email ID required"
-        echo "Usage: ${_C_CYAN}em move <ID> [folder]${_C_NC}"
-        return 1
-    fi
-
-    local folder="${FLOW_EMAIL_FOLDER:-INBOX}"
-
-    # No folder specified → fzf picker
-    if [[ -z "$target_folder" ]]; then
-        if ! command -v fzf &>/dev/null; then
-            _flow_log_error "Folder required (fzf not available for picker)"
-            echo "Usage: ${_C_CYAN}em move <ID> <folder>${_C_NC}"
-            return 1
-        fi
-
-        target_folder=$(_em_hml_folders 2>/dev/null \
-            | fzf --prompt="Move #${msg_id} to > " --height=15 --no-multi \
-            | awk '{print $1}')
-
-        if [[ -z "$target_folder" ]]; then
-            return 0  # User cancelled
-        fi
-    fi
-
-    # Safety: confirm before moving
-    printf "  Move #%s to %b%s%b? [y/N] " "$msg_id" "${_C_CYAN}" "$target_folder" "${_C_NC}"
-    local confirm
-    read -r confirm
-    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
-        _flow_log_info "Cancelled"
-        return 0
-    fi
-
-    if _em_hml_move "$msg_id" "$target_folder" "$folder"; then
-        _flow_log_success "Moved #${msg_id} → ${target_folder}"
-    else
-        _flow_log_error "Failed to move #${msg_id}"
-        return 1
-    fi
 }
 
 _em_thread() {

--- a/lib/em-cache.zsh
+++ b/lib/em-cache.zsh
@@ -25,6 +25,8 @@ typeset -gA _EM_CACHE_TTL=(
     [drafts]=3600           # 1 hour — drafts might need refreshing
     [schedules]=86400       # 24 hours
     [unread]=60             # 1 minute — unread count changes often
+    [undo_state]=3600       # 1 hour — undo window for last star/flag/move action
+    [recent_folders]=2592000 # 30 days — recently-used move destinations persist
 )
 
 # ═══════════════════════════════════════════════════════════════════
@@ -126,6 +128,73 @@ _em_cache_invalidate() {
     for op_dir in "$cache_base"/*(N/); do
         rm -f "$op_dir/$key.txt"
     done
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# UNDO STATE — single-step undo of the last star/flag/move action
+# ═══════════════════════════════════════════════════════════════════
+#
+# Record format (pipe-delimited, one line): action|arg1|arg2|...|ids (space-separated)
+#   star|<ids>              undo = re-toggle same ids (symmetric)
+#   flag|<ids>               undo = unflag same ids
+#   unflag|<ids>              undo = flag same ids
+#   move|<src>|<dst>|<ids>    undo = move dst->src same ids
+#
+# Explicitly capped at one step — recording a new action overwrites the
+# previous one, no multi-level stack.
+
+_em_undo_record() {
+    # Args: action, ...args, then a literal "--" separator, then ids...
+    # Simpler form used by callers: _em_undo_record "star" "$ids_string"
+    #                                _em_undo_record "move" "$src" "$dst" "$ids_string"
+    local action="$1"; shift
+    local payload="$action"
+    local part
+    for part in "$@"; do
+        payload="${payload}|${part}"
+    done
+    _em_cache_set "undo_state" "last" "$payload"
+}
+
+_em_undo_get() {
+    _em_cache_get "undo_state" "last"
+}
+
+_em_undo_clear() {
+    local cache_base="$(_em_cache_dir)/undo_state"
+    local key=$(_em_cache_key "last")
+    rm -f "$cache_base/$key.txt"
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# RECENT FOLDERS — last N=3 move destinations, most-recent-first
+# ═══════════════════════════════════════════════════════════════════
+
+_em_recent_folders_add() {
+    # Args: folder — push to front, dedup, cap at 3
+    local folder="$1"
+    [[ -z "$folder" ]] && return 0
+
+    local existing
+    existing=$(_em_cache_get "recent_folders" "list" 2>/dev/null)
+
+    local -a folders=("$folder")
+    local line
+    while IFS= read -r line; do
+        [[ -z "$line" || "$line" == "$folder" ]] && continue
+        folders+=("$line")
+    done <<< "$existing"
+
+    # Cap at 3
+    (( ${#folders[@]} > 3 )) && folders=("${folders[@]:0:3}")
+
+    local joined
+    joined=$(printf '%s\n' "${folders[@]}")
+    _em_cache_set "recent_folders" "list" "$joined"
+}
+
+_em_recent_folders_get() {
+    _em_cache_get "recent_folders" "list" 2>/dev/null
 }
 
 _em_cache_clear() {

--- a/lib/em-himalaya.zsh
+++ b/lib/em-himalaya.zsh
@@ -453,13 +453,6 @@ _em_hml_headers() {
 # MESSAGE MOVE
 # ═══════════════════════════════════════════════════════════════════
 
-_em_hml_move() {
-    # Move message to a different folder
-    # Args: message_id, target_folder, source_folder (default: INBOX)
-    local msg_id="$1" target="$2" source="${3:-INBOX}"
-    himalaya message move -f "$source" "$msg_id" "$target" 2>/dev/null
-}
-
 # ═══════════════════════════════════════════════════════════════════
 # QUICK COUNTS
 # ═══════════════════════════════════════════════════════════════════

--- a/man/man1/em.1
+++ b/man/man1/em.1
@@ -140,8 +140,10 @@ Interactive multi-select delete via fzf.
 Permanent delete (requires typing "yes" to confirm).
 .RE
 .TP
-.B move\fR, \fBmv \fIID\fR [\fIFOLDER\fR]
-Move email to folder. Opens fzf folder picker if FOLDER is omitted.
+.B move\fR, \fBmv \fIFOLDER\fR \fIID\fR...
+Move email(s) to folder (multi-ID). \fB--from\fR \fISRC\fR to override the source folder,
+\fB--pick\fR for an fzf folder picker, \fB--recent\fR to quick-pick from the last 3
+destination folders.
 .TP
 .B restore \fIID\fR
 Restore email from Trash to INBOX.
@@ -151,6 +153,10 @@ One-way: set starred status (batch-capable, multiple IDs allowed).
 .TP
 .B unflag \fIID\fR...
 One-way: clear starred status (batch-capable, multiple IDs allowed).
+.TP
+.B undo
+Undo the single most recent star, flag, unflag, or move action. One-step only
+(no multi-level undo stack); 1-hour undo window.
 .SS Organize
 .TP
 .B star \fIID\fR...
@@ -366,7 +372,7 @@ Manage folders:
 .nf
 em folders
 em create-folder Archive
-em move 42 Archive
+em move Archive 42
 .fi
 .RE
 .PP

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -85,6 +85,8 @@ run_test ./tests/test-em-help-guards.zsh
 run_test ./tests/test-em-flag-star.zsh
 run_test ./tests/test-em-ai-switch.zsh
 run_test ./tests/test-em-ai-agy.zsh
+run_test ./tests/test-em-move-restore.zsh
+run_test ./tests/test-em-undo.zsh
 run_test ./tests/test-tok.zsh
 run_test ./tests/test-tok-sync.zsh
 

--- a/tests/test-em-help-guards.zsh
+++ b/tests/test-em-help-guards.zsh
@@ -35,6 +35,7 @@ HELP_CALLED=0
 _em_help() { HELP_CALLED=1; }
 _em_delete_help() { HELP_CALLED=1; }
 _em_move_help() { HELP_CALLED=1; }
+_em_undo_help() { HELP_CALLED=1; }
 _em_restore_help() { HELP_CALLED=1; }
 _em_respond_help() { HELP_CALLED=1; }
 
@@ -70,6 +71,7 @@ test_pairs=(
     "summarize:_em_summarize"
     "delete:_em_delete"
     "move:_em_move"
+    "undo:_em_undo"
     "restore:_em_restore"
     "html:_em_html"
     "attach:_em_attach"

--- a/tests/test-em-undo.zsh
+++ b/tests/test-em-undo.zsh
@@ -1,0 +1,267 @@
+#!/usr/bin/env zsh
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST SUITE: em undo + recent-folders (Phase 3, SPEC-em-ux-refactor-2026-07-07.md)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Purpose: Validate the single-step undo cache (_em_undo_record/get/clear),
+#          _em_undo's reversal logic per action type, and the recent-folders
+#          quick-list (_em_recent_folders_add/get) used by `em move --recent`.
+#
+# Isolation: _em_cache_dir is mocked to a mktemp directory so these tests never
+# touch the real ~/.flow or project-local .flow/email-cache.
+#
+# Created: 2026-07-07
+# ══════════════════════════════════════════════════════════════════════════════
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="${SCRIPT_DIR:h}"
+source "$SCRIPT_DIR/test-framework.zsh" || { echo "ERROR: Cannot source test-framework.zsh"; exit 1 }
+
+typeset -g TEST_CACHE_DIR=""
+
+setup() {
+    typeset -g project_root=""
+    if [[ -n "${0:A}" ]]; then project_root="${0:A:h:h}"; fi
+    if [[ -z "$project_root" || ! -f "$project_root/flow.plugin.zsh" ]]; then
+        if [[ -f "$PWD/flow.plugin.zsh" ]]; then project_root="$PWD"
+        elif [[ -f "$PWD/../flow.plugin.zsh" ]]; then project_root="$PWD/.."
+        fi
+    fi
+    [[ -z "$project_root" || ! -f "$project_root/flow.plugin.zsh" ]] && { echo "ERROR: Cannot find project root"; exit 1; }
+
+    FLOW_QUIET=1
+    FLOW_ATLAS_ENABLED=no
+    FLOW_PLUGIN_DIR="$project_root"
+    exec < /dev/null
+    source "$project_root/flow.plugin.zsh"
+
+    TEST_CACHE_DIR=$(mktemp -d)
+    _em_cache_dir() { echo "$TEST_CACHE_DIR"; }
+    _em_require_himalaya() { return 0; }
+}
+
+cleanup() {
+    reset_mocks
+    [[ -n "$TEST_CACHE_DIR" && -d "$TEST_CACHE_DIR" ]] && rm -rf "$TEST_CACHE_DIR"
+}
+trap cleanup EXIT
+
+# ═══════════════════════════════════════════════════════════════
+# Section 1: Undo-state cache round trip
+# ═══════════════════════════════════════════════════════════════
+
+test_undo_record_get_roundtrip() {
+    test_case "_em_undo_record then _em_undo_get returns the same payload"
+    _em_undo_record "star" "42 43"
+    local got
+    got=$(_em_undo_get)
+    if [[ "$got" == "star|42 43" ]]; then test_pass; else test_fail "got: '$got'"; fi
+}
+
+test_undo_record_overwrites_no_stack() {
+    test_case "second _em_undo_record overwrites the first (single-step, no stack)"
+    _em_undo_record "flag" "1"
+    _em_undo_record "unflag" "2"
+    local got
+    got=$(_em_undo_get)
+    if [[ "$got" == "unflag|2" ]]; then test_pass; else test_fail "got: '$got'"; fi
+}
+
+test_undo_clear_empties_state() {
+    test_case "_em_undo_clear removes the recorded state"
+    _em_undo_record "star" "1"
+    _em_undo_clear
+    local got
+    got=$(_em_undo_get)
+    if [[ -z "$got" ]]; then test_pass; else test_fail "expected empty, got: '$got'"; fi
+}
+
+# ═══════════════════════════════════════════════════════════════
+# Section 2: _em_undo with nothing recorded
+# ═══════════════════════════════════════════════════════════════
+
+test_undo_nothing_to_undo() {
+    test_case "_em_undo with no recorded state returns 1"
+    local output
+    output=$(_em_undo 2>&1)
+    local rc=$?
+    if [[ $rc -eq 1 ]]; then test_pass; else test_fail "expected rc=1, got rc=$rc, output: $output"; fi
+}
+
+# ═══════════════════════════════════════════════════════════════
+# Section 3: _em_undo reversal per action type
+# ═══════════════════════════════════════════════════════════════
+
+test_undo_star_retoggles_same_ids() {
+    test_case "_em_undo of a star action re-calls _em_star with the same ids"
+    create_mock "_em_star"
+    _em_undo_record "star" "42 43"
+    _em_undo &>/dev/null
+    assert_mock_called "_em_star" 1 && assert_mock_args "_em_star" "42 43" && test_pass
+    reset_mocks
+}
+
+test_undo_flag_unflags_same_ids() {
+    test_case "_em_undo of a flag action unflags the same ids via _em_hml_flags"
+    create_mock "_em_hml_flags"
+    _em_undo_record "flag" "10 20"
+    _em_undo &>/dev/null
+    assert_mock_called "_em_hml_flags" 2 && test_pass
+    reset_mocks
+}
+
+test_undo_unflag_flags_same_ids() {
+    test_case "_em_undo of an unflag action re-flags the same ids via _em_hml_flags"
+    create_mock "_em_hml_flags"
+    _em_undo_record "unflag" "10 20"
+    _em_undo &>/dev/null
+    assert_mock_called "_em_hml_flags" 2 && test_pass
+    reset_mocks
+}
+
+test_undo_move_swaps_src_dst() {
+    test_case "_em_undo of a move action calls _em_hml_move with src/dst swapped"
+    create_mock "_em_hml_move" 'return 0'
+    _em_undo_record "move" "INBOX" "Archive" "42 43"
+    _em_undo &>/dev/null
+    assert_mock_called "_em_hml_move" 1 && assert_mock_args "_em_hml_move" "Archive INBOX 42 43" && test_pass
+    reset_mocks
+}
+
+test_undo_clears_state_after_running() {
+    test_case "_em_undo clears the recorded state after a successful undo (one-step only)"
+    create_mock "_em_star"
+    _em_undo_record "star" "1"
+    _em_undo &>/dev/null
+    local got
+    got=$(_em_undo_get)
+    if [[ -z "$got" ]]; then test_pass; else test_fail "expected state cleared, got: '$got'"; fi
+}
+
+test_undo_move_failure_does_not_clear_state() {
+    test_case "_em_undo of a move that fails does NOT clear state (nothing to retry-undo)"
+    create_mock "_em_hml_move" 'return 1'
+    _em_undo_record "move" "INBOX" "Archive" "42"
+    _em_undo &>/dev/null
+    local got
+    got=$(_em_undo_get)
+    if [[ "$got" == "move|INBOX|Archive|42" ]]; then test_pass; else test_fail "expected state preserved, got: '$got'"; fi
+}
+
+# ═══════════════════════════════════════════════════════════════
+# Section 4: Recent folders quick-list
+# ═══════════════════════════════════════════════════════════════
+
+test_recent_folders_add_get_roundtrip() {
+    test_case "_em_recent_folders_add then _em_recent_folders_get returns it"
+    _em_recent_folders_add "Archive"
+    local got
+    got=$(_em_recent_folders_get)
+    if [[ "$got" == "Archive" ]]; then test_pass; else test_fail "got: '$got'"; fi
+}
+
+test_recent_folders_most_recent_first() {
+    test_case "_em_recent_folders_add puts the newest folder first"
+    _em_recent_folders_add "Archive"
+    _em_recent_folders_add "Projects"
+    local got
+    got=$(_em_recent_folders_get)
+    local -a arr
+    arr=("${(@f)got}")
+    if [[ "${arr[1]}" == "Projects" && "${arr[2]}" == "Archive" ]]; then
+        test_pass
+    else
+        test_fail "got: ${arr[*]}"
+    fi
+}
+
+test_recent_folders_dedup() {
+    test_case "_em_recent_folders_add dedups a repeated folder instead of listing it twice"
+    _em_recent_folders_add "Archive"
+    _em_recent_folders_add "Projects"
+    _em_recent_folders_add "Archive"
+    local got
+    got=$(_em_recent_folders_get)
+    local -a arr
+    arr=("${(@f)got}")
+    if [[ ${#arr[@]} -eq 2 && "${arr[1]}" == "Archive" && "${arr[2]}" == "Projects" ]]; then
+        test_pass
+    else
+        test_fail "got: ${arr[*]}"
+    fi
+}
+
+test_recent_folders_capped_at_3() {
+    test_case "_em_recent_folders_add caps the list at 3 entries"
+    _em_recent_folders_add "A"
+    _em_recent_folders_add "B"
+    _em_recent_folders_add "C"
+    _em_recent_folders_add "D"
+    local got
+    got=$(_em_recent_folders_get)
+    local -a arr
+    arr=("${(@f)got}")
+    if [[ ${#arr[@]} -eq 3 && "${arr[1]}" == "D" && "${arr[2]}" == "C" && "${arr[3]}" == "B" ]]; then
+        test_pass
+    else
+        test_fail "got: ${arr[*]}"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════
+# Section 5: em move --recent
+# ═══════════════════════════════════════════════════════════════
+
+test_move_recent_no_history_errors() {
+    test_case "em move --recent with no recent-folders history errors out"
+    rm -rf "$TEST_CACHE_DIR/recent_folders"
+    local output rc
+    output=$(_em_move --recent 42 2>&1)
+    rc=$?
+    if [[ $rc -eq 1 ]]; then test_pass; else test_fail "expected rc=1, output: $output"; fi
+}
+
+test_move_recent_picks_from_list() {
+    test_case "em move --recent lets the user pick a numbered recent folder"
+    _em_recent_folders_add "Archive"
+    _em_recent_folders_add "Projects"
+    create_mock "_em_hml_move" 'return 0'
+    echo "1" | _em_move --recent 42 &>/dev/null
+    assert_mock_called "_em_hml_move" 1 && assert_mock_args "_em_hml_move" "INBOX Projects 42" && test_pass
+    reset_mocks
+}
+
+# ═══════════════════════════════════════════════════════════════
+# RUN
+# ═══════════════════════════════════════════════════════════════
+
+test_suite_start "em undo + recent-folders (Phase 3)"
+setup
+
+echo "${CYAN}Section 1: Undo-state cache round trip${RESET}"
+test_undo_record_get_roundtrip
+test_undo_record_overwrites_no_stack
+test_undo_clear_empties_state
+
+echo "${CYAN}Section 2: _em_undo with nothing recorded${RESET}"
+test_undo_nothing_to_undo
+
+echo "${CYAN}Section 3: _em_undo reversal per action type${RESET}"
+test_undo_star_retoggles_same_ids
+test_undo_flag_unflags_same_ids
+test_undo_unflag_flags_same_ids
+test_undo_move_swaps_src_dst
+test_undo_clears_state_after_running
+test_undo_move_failure_does_not_clear_state
+
+echo "${CYAN}Section 4: Recent folders quick-list${RESET}"
+test_recent_folders_add_get_roundtrip
+test_recent_folders_most_recent_first
+test_recent_folders_dedup
+test_recent_folders_capped_at_3
+
+echo "${CYAN}Section 5: em move --recent${RESET}"
+test_move_recent_no_history_errors
+test_move_recent_picks_from_list
+
+test_suite_end


### PR DESCRIPTION
## Summary

While implementing Phase 3 of `docs/specs/SPEC-em-ux-refactor-2026-07-07.md`, found that
`em move <ID> <folder>` is currently broken: `_em_move` and its adapter `_em_hml_move` were
each defined twice (dispatcher + adapter layer), and zsh's last-definition-wins semantics
meant the two *live* definitions were incompatible — the live `_em_move` called
`_em_hml_move` with the numeric message ID in the source-folder position. Every move would
try to move a message from a folder named after its own ID.

Same failure class as the `flag`/`star` case-duplicate bug fixed in PR #493 — this time a
duplicate **function definition** rather than a duplicate case label. Caught by
`tests/test-em-move-restore.zsh`, which was never wired into `tests/run-all.sh` (orphaned,
like `test-em-ai-switch.zsh` was before) — it now passes 8/8 against the fixed source and is
registered.

Kept the multi-ID interface (`em move <FOLDER> <ID>...`) since it's what `em move --help`,
`MASTER-DISPATCHER-GUIDE.md`, and the orphaned test already documented/expected. Fixed the
same stale `<ID>`-first interface (plus a leftover "`em flag` = alias for `em star`" line)
across `QUICK-REFERENCE.md`, `MASTER-DISPATCHER-GUIDE.md`, `REFCARD-EMAIL-DISPATCHER.md`
(which had both a stale and a correct `em move` row), `EMAIL-DISPATCHER-GUIDE.md`,
`EMAIL-COOKBOOK.md`, and `man/man1/em.1`.

## Phase 3 (bundled per the spec)

- `em undo` — single-step undo of the last star/flag/unflag/move (1hr window, no stack),
  built on `lib/em-cache.zsh`'s existing get/set API
- `em move --recent <ID>...` — quick-pick target folder from last 3 destinations, no fzf
- Centralized `ALIASES` section in `em help` (single source of truth)

## Test plan

- `tests/test-em-move-restore.zsh`: 3/8 → 8/8 against fixed source, now registered in
  `run-all.sh`
- `tests/test-em-undo.zsh` (new, 16 tests): undo cache round-trip, per-action-type reversal,
  recent-folders dedup/cap/ordering, `em move --recent`
- `tests/test-em-help-guards.zsh`: added `undo` to `--help` coverage
- Full suite: 80 passed, 0 failed, 1 skipped (baseline-matching, external tool absence)
- `mkdocs build --strict`: clean
- Man-page guard: 12/12