### PR TITLE
fix(teach-deploy): keep --dry-run read-only in CI mode; merge with --no-ff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`teach deploy --dry-run` is now read-only and no longer blocked in CI mode** — `ci_mode`
+  auto-detects whenever stdin is not a TTY, so every automation or agent caller gets it. In that
+  mode two preflight conditions aborted the run *before the plan could render*: "production has new
+  commits" and "uncommitted changes". Neither can affect a dry run, which mutates nothing. The
+  uncommitted-changes handler had a worse edge: interactively it **prompts to commit**, and a pty
+  wrapper (`script -q /dev/null …`) answers the default `Y` and silently creates a real commit —
+  observed once against a live course repo. Both mutation-oriented gates now skip when `dry_run` is
+  true; real deploys still abort on both, asserted by controls in
+  `tests/test-teach-deploy-dryrun-readonly.zsh` (10 assertions, each checking repository state
+  before and after).
+
 - **`em move` was broken in production** — `_em_move` and its adapter `_em_hml_move` were each defined twice in the same file (zsh's last-definition-wins semantics), and the two live (later) definitions were incompatible with each other: the live `_em_move` called `_em_hml_move` with a numeric message ID in the source-folder position. Every `em move <ID> <folder>` call would attempt to move a message from a non-existent folder named after the ID. Removed the dead pair, kept the multi-ID interface (`em move <FOLDER> <ID>...`) that matches `em move --help`, `MASTER-DISPATCHER-GUIDE.md`, and the existing (previously unregistered) `tests/test-em-move-restore.zsh`. That test file — which would have caught this — was never wired into `tests/run-all.sh`; it is now.
 - Corrected a dozen-plus stale `em move <ID> [FOLDER]` / `em flag <ID> # Alias for em star` references across `docs/help/QUICK-REFERENCE.md`, `docs/reference/MASTER-DISPATCHER-GUIDE.md`, `docs/reference/REFCARD-EMAIL-DISPATCHER.md` (which had both a stale and a correct `em move` row), `docs/guides/EMAIL-DISPATCHER-GUIDE.md`, `docs/guides/EMAIL-COOKBOOK.md`, and `man/man1/em.1` — all inherited the same wrong interface the code bug had.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`teach deploy --dry-run` now reports what it is NOT showing** — because a dry run skips the
+  uncommitted-changes handler, its file list is committed work only. A real deploy would offer to
+  commit dirty files first and ship them too, so the plan could silently understate what would
+  deploy. It now names the count of excluded uncommitted files.
+
 - **`teach deploy --direct` now merges with `--no-ff`** — without it a deploy of N draft commits
   fast-forwards production to draft's own tip, leaving no single commit that represents the
   deploy. `teach deploy --rollback` reverts the deploy's commit, so on a fast-forwarded deploy it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`teach deploy --direct` now merges with `--no-ff`** — without it a deploy of N draft commits
+  fast-forwards production to draft's own tip, leaving no single commit that represents the
+  deploy. `teach deploy --rollback` reverts the deploy's commit, so on a fast-forwarded deploy it
+  could only undo the last of the N. `git-helpers.zsh` already assumed otherwise, filtering "merge
+  commits from `--no-ff` deploys" when detecting production conflicts. Covered by
+  `tests/test-teach-deploy-merge-topology.zsh`, which asserts the production tip has two parents
+  and that the second is draft's tip. Note that draft and production legitimately point at the
+  same commit AFTER a deploy — the deploy syncs draft from production — so ref equality is not
+  evidence of a fast-forward; parent count is.
+
 - **`teach deploy --dry-run` is now read-only and no longer blocked in CI mode** — `ci_mode`
   auto-detects whenever stdin is not a TTY, so every automation or agent caller gets it. In that
   mode two preflight conditions aborted the run *before the plan could render*: "production has new

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ### Fixed
 
+- **`teach deploy --dry-run` is now read-only and no longer blocked in CI mode** — `ci_mode`
+  auto-detects whenever stdin is not a TTY, so every automation or agent caller gets it. In that
+  mode two preflight conditions aborted the run *before the plan could render*: "production has new
+  commits" and "uncommitted changes". Neither can affect a dry run, which mutates nothing. The
+  uncommitted-changes handler had a worse edge: interactively it **prompts to commit**, and a pty
+  wrapper (`script -q /dev/null …`) answers the default `Y` and silently creates a real commit —
+  observed once against a live course repo. Both mutation-oriented gates now skip when `dry_run` is
+  true; real deploys still abort on both, asserted by controls in
+  `tests/test-teach-deploy-dryrun-readonly.zsh` (10 assertions, each checking repository state
+  before and after).
+
 - **`em move` was broken in production** — `_em_move` and its adapter `_em_hml_move` were each defined twice in the same file (zsh's last-definition-wins semantics), and the two live (later) definitions were incompatible with each other: the live `_em_move` called `_em_hml_move` with a numeric message ID in the source-folder position. Every `em move <ID> <folder>` call would attempt to move a message from a non-existent folder named after the ID. Removed the dead pair, kept the multi-ID interface (`em move <FOLDER> <ID>...`) that matches `em move --help`, `MASTER-DISPATCHER-GUIDE.md`, and the existing (previously unregistered) `tests/test-em-move-restore.zsh`. That test file — which would have caught this — was never wired into `tests/run-all.sh`; it is now.
 - Corrected a dozen-plus stale `em move <ID> [FOLDER]` / `em flag <ID> # Alias for em star` references across `docs/help/QUICK-REFERENCE.md`, `docs/reference/MASTER-DISPATCHER-GUIDE.md`, `docs/reference/REFCARD-EMAIL-DISPATCHER.md` (which had both a stale and a correct `em move` row), `docs/guides/EMAIL-DISPATCHER-GUIDE.md`, `docs/guides/EMAIL-COOKBOOK.md`, and `man/man1/em.1` — all inherited the same wrong interface the code bug had.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ### Fixed
 
+- **`teach deploy --direct` now merges with `--no-ff`** — without it a deploy of N draft commits
+  fast-forwards production to draft's own tip, leaving no single commit that represents the
+  deploy. `teach deploy --rollback` reverts the deploy's commit, so on a fast-forwarded deploy it
+  could only undo the last of the N. `git-helpers.zsh` already assumed otherwise, filtering "merge
+  commits from `--no-ff` deploys" when detecting production conflicts. Covered by
+  `tests/test-teach-deploy-merge-topology.zsh`, which asserts the production tip has two parents
+  and that the second is draft's tip. Note that draft and production legitimately point at the
+  same commit AFTER a deploy — the deploy syncs draft from production — so ref equality is not
+  evidence of a fast-forward; parent count is.
+
 - **`teach deploy --dry-run` is now read-only and no longer blocked in CI mode** — `ci_mode`
   auto-detects whenever stdin is not a TTY, so every automation or agent caller gets it. In that
   mode two preflight conditions aborted the run *before the plan could render*: "production has new

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ### Fixed
 
+- **`teach deploy --dry-run` now reports what it is NOT showing** — because a dry run skips the
+  uncommitted-changes handler, its file list is committed work only. A real deploy would offer to
+  commit dirty files first and ship them too, so the plan could silently understate what would
+  deploy. It now names the count of excluded uncommitted files.
+
 - **`teach deploy --direct` now merges with `--no-ff`** — without it a deploy of N draft commits
   fast-forwards production to draft's own tip, leaving no single commit that represents the
   deploy. `teach deploy --rollback` reverts the deploy's commit, so on a fast-forwarded deploy it

--- a/lib/dispatchers/teach-deploy-enhanced.zsh
+++ b/lib/dispatchers/teach-deploy-enhanced.zsh
@@ -328,7 +328,12 @@ _deploy_direct_merge() {
 
     # Merge draft into production
     local merge_err
-    merge_err=$(git merge "$draft_branch" --no-edit -m "$commit_message" 2>&1)
+    # --no-ff: always create a merge commit, so each deploy is ONE revertable
+    # point in production history. Without it a deploy spanning N commits
+    # fast-forwards and leaves no single commit representing the deploy,
+    # which breaks --rollback granularity. git-helpers.zsh:693 already
+    # assumes deploys produce merge commits.
+    merge_err=$(git merge "$draft_branch" --no-ff --no-edit -m "$commit_message" 2>&1)
     if [[ $? -ne 0 ]]; then
         _teach_error "Merge conflict! Aborting merge." "$merge_err"
         git merge --abort 2>/dev/null

--- a/lib/dispatchers/teach-deploy-enhanced.zsh
+++ b/lib/dispatchers/teach-deploy-enhanced.zsh
@@ -415,6 +415,18 @@ _deploy_dry_run_report() {
     echo "${FLOW_COLORS[warn]}  DRY RUN — No changes will be made${FLOW_COLORS[reset]}"
     echo "${FLOW_COLORS[dim]}─────────────────────────────────────────────────${FLOW_COLORS[reset]}"
 
+    # The file list below is committed work only (prod...draft). A dry run
+    # deliberately skips the uncommitted-changes handler, so unlike a real
+    # deploy — which offers to commit first — dirty files are NOT represented
+    # here. Say so, otherwise the count silently understates what would ship.
+    if ! _git_is_clean 2>/dev/null; then
+        local _uncommitted
+        _uncommitted=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+        echo ""
+        echo "${FLOW_COLORS[warn]}  Note:${FLOW_COLORS[reset]} $_uncommitted uncommitted file(s) are NOT included below."
+        echo "${FLOW_COLORS[dim]}        A real deploy would offer to commit them first.${FLOW_COLORS[reset]}"
+    fi
+
     # Show files that would be deployed
     local files_changed
     files_changed=$(git diff --name-status "$prod_branch"..."$draft_branch" 2>/dev/null)

--- a/lib/dispatchers/teach-deploy-enhanced.zsh
+++ b/lib/dispatchers/teach-deploy-enhanced.zsh
@@ -50,6 +50,7 @@ _check_math_blanks() {
 # Sets: DEPLOY_DRAFT_BRANCH, DEPLOY_PROD_BRANCH, DEPLOY_COURSE_NAME, DEPLOY_AUTO_PR, DEPLOY_REQUIRE_CLEAN
 _deploy_preflight_checks() {
     local ci_mode="${1:-false}"
+    local dry_run="${2:-false}"
 
     # Check if in git repo
     if ! _git_in_repo; then
@@ -172,9 +173,15 @@ _deploy_preflight_checks() {
         echo "${FLOW_COLORS[success]}  [ok]${FLOW_COLORS[reset]} No production conflicts"
     else
         echo "${FLOW_COLORS[warn]}  [!!]${FLOW_COLORS[reset]} Production has new commits"
-        if [[ "$ci_mode" == "true" ]]; then
+        # A dry run mutates nothing, so a divergent production is information,
+        # not a stop condition — report it and let the plan render. Only a real
+        # CI-mode deploy aborts here, since it cannot prompt to resolve.
+        if [[ "$ci_mode" == "true" && "$dry_run" != "true" ]]; then
             _teach_error "CI mode: production conflicts detected. Resolve manually."
             return 1
+        fi
+        if [[ "$dry_run" == "true" ]]; then
+            echo "${FLOW_COLORS[dim]}       (dry run — a real deploy would need this resolved first)${FLOW_COLORS[reset]}"
         fi
     fi
 
@@ -646,7 +653,7 @@ _teach_deploy_enhanced() {
     # ============================================
     {
 
-    _deploy_preflight_checks "$ci_mode" || return 1
+    _deploy_preflight_checks "$ci_mode" "$dry_run" || return 1
 
     # Read exported variables from preflight
     local draft_branch="$DEPLOY_DRAFT_BRANCH"
@@ -658,7 +665,11 @@ _teach_deploy_enhanced() {
     # ============================================
     # UNCOMMITTED CHANGES HANDLER (all modes)
     # ============================================
-    if [[ "$require_clean" != "false" ]] && ! _git_is_clean; then
+    # A dry run never commits and never merges, so a dirty tree cannot affect
+    # its outcome. Skipping the handler entirely keeps --dry-run read-only:
+    # in CI mode it used to abort here, and interactively it prompted to commit
+    # (auto-accepted by any pty wrapper, silently creating a commit).
+    if [[ "$dry_run" != "true" ]] && [[ "$require_clean" != "false" ]] && ! _git_is_clean; then
         if [[ "$ci_mode" == "true" ]]; then
             _teach_error "Uncommitted changes detected" \
                 "Commit changes before deploying in CI mode"

--- a/tests/test-teach-deploy-dryrun-readonly.zsh
+++ b/tests/test-teach-deploy-dryrun-readonly.zsh
@@ -125,6 +125,11 @@ _assert_readonly "$repo" "dry run (synced)" "$before"
 [[ "$out" != *"Commit and continue"* ]] \
   && _ok "dry run never offers to commit" \
   || _bad "dry run prompted to commit" "the pty auto-accept hazard is back"
+# Skipping the handler means the file list is committed work only, so a dirty
+# tree is silently under-reported unless the report says so.
+[[ "$out" == *"uncommitted file(s) are NOT included"* ]] \
+  && _ok "dry run says which files are excluded" \
+  || _bad "no uncommitted-exclusion note" "the 'Would deploy N files' count understates silently"
 rm -rf "${repo:h}"
 
 # --- 3. CONTROL: a real deploy still refuses a dirty tree -------------------

--- a/tests/test-teach-deploy-dryrun-readonly.zsh
+++ b/tests/test-teach-deploy-dryrun-readonly.zsh
@@ -1,0 +1,150 @@
+#!/usr/bin/env zsh
+# test-teach-deploy-dryrun-readonly.zsh
+#
+# `teach deploy --dry-run` must be READ-ONLY and must not be blocked by
+# conditions it cannot affect.
+#
+# Two bugs motivated this suite:
+#   1. CI mode (auto-detected whenever stdin is not a TTY, so always true for
+#      an agent/automation caller) treated "production has new commits" and
+#      "uncommitted changes" as fatal even under --dry-run, so a dry run could
+#      not render a plan on the normal state of a working course repo.
+#   2. Interactively, the uncommitted-changes handler PROMPTS to commit. Any
+#      pty wrapper (`script -q /dev/null ...`) auto-answers the default Y and
+#      silently creates a real commit — observed in a live course repo.
+#
+# Both are fixed by skipping the mutation-oriented gates when dry_run is true.
+# The real-deploy paths must keep aborting, which is what the controls assert.
+
+PASS=0
+FAIL=0
+
+_ok()   { ((PASS++)); echo "  ✅ $1"; }
+_bad()  { ((FAIL++)); echo "  ❌ $1: $2"; }
+
+ROOT="${0:A:h}/.."
+SRC="$ROOT/lib/dispatchers/teach-deploy-enhanced.zsh"
+[[ -f "$SRC" ]] || { echo "❌ cannot find $SRC"; exit 1; }
+
+# Same bootstrap order as test-teach-deploy-v2-unit.zsh: the dispatcher relies
+# on helpers (_git_in_repo, _teach_error, FLOW_COLORS) that live in these libs.
+BOOT="source '$ROOT/lib/core.zsh' 2>/dev/null || true
+source '$ROOT/lib/git-helpers.zsh' 2>/dev/null || true
+source '$ROOT/lib/deploy-history-helpers.zsh' 2>/dev/null || true
+source '$ROOT/lib/deploy-rollback-helpers.zsh' 2>/dev/null || true
+source '$SRC'
+typeset -f _teach_error >/dev/null 2>&1 || _teach_error() { echo \"teach: \$1\"; [[ -n \"\$2\" ]] && echo \"   \$2\"; return 1; }"
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "⏭️  yq not installed — skipping (config parsing requires it)"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture: a course repo on draft, with a production branch, a remote so the
+# conflict probe can resolve, and one uncommitted change.
+# `synced` = production in sync (conflict check passes)
+# `diverged` = production carries a commit draft does not
+# ---------------------------------------------------------------------------
+_mk_fixture() {
+  local mode="$1"                      # synced | diverged
+  local root; root="$(mktemp -d)"
+  git init -q --bare "$root/bare.git"
+  git init -q -b draft "$root/repo"
+  (
+    cd "$root/repo" || exit 1
+    git config user.email t@t.t
+    git config user.name T
+    mkdir -p .flow
+    printf 'course:\n  name: Fixture\nbranches:\n  draft: draft\n  production: production\n' \
+      > .flow/teach-config.yml
+    echo v1 > page.qmd
+    git add -A && git commit -qm init
+    git branch production
+    git remote add origin "$root/bare.git"
+    git push -q origin draft production
+    git branch -q --set-upstream-to=origin/draft draft
+
+    if [[ "$mode" == "diverged" ]]; then
+      git checkout -q production
+      echo prod-only >> page.qmd
+      git commit -qam "production-only change"
+      git push -q origin production
+      git checkout -q draft
+      echo draft-only >> notes.md
+      git add notes.md && git commit -qm "draft-only change"
+    fi
+
+    echo "uncommitted" >> page.qmd     # the dirty tree every case needs
+  )
+  echo "$root/repo"
+}
+
+# Run the deploy entrypoint with stdin closed, so ci_mode auto-detects true —
+# the mode any non-interactive caller actually gets.
+_run() {
+  local repo="$1"; shift
+  ( cd "$repo" && zsh -c "$BOOT
+_teach_deploy_enhanced $*" </dev/null 2>&1 )
+}
+
+_state() { ( cd "$1" && git rev-parse HEAD && git status --porcelain && git rev-parse production ); }
+
+_assert_readonly() {
+  local repo="$1" label="$2" before="$3"
+  if [[ "$before" == "$(_state "$repo")" ]]; then
+    _ok "$label — no writes"
+  else
+    _bad "$label" "repository state changed"
+  fi
+}
+
+echo "=== teach deploy --dry-run read-only ==="
+
+# --- 1. dry run, dirty tree, diverged production: renders the plan ----------
+repo="$(_mk_fixture diverged)"; before="$(_state "$repo")"
+out="$(_run "$repo" --direct --dry-run)"
+if [[ "$out" == *"DRY RUN"* ]]; then
+  _ok "dry run renders the plan despite dirty tree + diverged production"
+else
+  _bad "dry run blocked" "$(echo "$out" | tail -2)"
+fi
+_assert_readonly "$repo" "dry run (diverged)" "$before"
+[[ "$out" == *"a real deploy would need this resolved first"* ]] \
+  && _ok "divergence is reported as a warning, not a stop" \
+  || _bad "missing divergence hint" "expected the dry-run hint line"
+rm -rf "${repo:h}"
+
+# --- 2. dry run, dirty tree, production synced ------------------------------
+repo="$(_mk_fixture synced)"; before="$(_state "$repo")"
+out="$(_run "$repo" --direct --dry-run)"
+[[ "$out" == *"DRY RUN"* ]] \
+  && _ok "dry run renders the plan on a dirty tree" \
+  || _bad "dry run blocked by dirty tree" "$(echo "$out" | tail -2)"
+_assert_readonly "$repo" "dry run (synced)" "$before"
+[[ "$out" != *"Commit and continue"* ]] \
+  && _ok "dry run never offers to commit" \
+  || _bad "dry run prompted to commit" "the pty auto-accept hazard is back"
+rm -rf "${repo:h}"
+
+# --- 3. CONTROL: a real deploy still refuses a dirty tree -------------------
+repo="$(_mk_fixture synced)"; before="$(_state "$repo")"
+out="$(_run "$repo" --direct)"
+[[ "$out" == *"Uncommitted changes detected"* ]] \
+  && _ok "control: real deploy still aborts on a dirty tree" \
+  || _bad "real deploy did not abort" "$(echo "$out" | tail -2)"
+_assert_readonly "$repo" "control: real deploy (dirty)" "$before"
+rm -rf "${repo:h}"
+
+# --- 4. CONTROL: a real deploy still refuses a diverged production ----------
+repo="$(_mk_fixture diverged)"; before="$(_state "$repo")"
+out="$(_run "$repo" --direct)"
+[[ "$out" == *"production conflicts detected"* ]] \
+  && _ok "control: real deploy still aborts on diverged production" \
+  || _bad "real deploy did not abort" "$(echo "$out" | tail -2)"
+_assert_readonly "$repo" "control: real deploy (diverged)" "$before"
+rm -rf "${repo:h}"
+
+echo ""
+echo "=== $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]]

--- a/tests/test-teach-deploy-merge-topology.zsh
+++ b/tests/test-teach-deploy-merge-topology.zsh
@@ -1,0 +1,89 @@
+#!/usr/bin/env zsh
+# test-teach-deploy-merge-topology.zsh
+#
+# A direct deploy must produce a MERGE COMMIT on production, never a
+# fast-forward.
+#
+# Without --no-ff, deploying N draft commits fast-forwards production to
+# draft's own tip. Production then has no single commit representing "this
+# deploy", so `teach deploy --rollback` — which reverts the deploy's commit —
+# can only undo the last of the N. The codebase already assumes merge commits
+# exist: git-helpers.zsh:693 filters "merge commits from --no-ff deploys" when
+# detecting production conflicts.
+#
+# Caveat for anyone reading a failure here: after a successful deploy, draft
+# and production legitimately point at the SAME commit, because the deploy
+# syncs draft from production afterwards (reflog shows "merge
+# origin/production: Fast-forward" on draft). Ref equality is therefore NOT
+# evidence of a fast-forwarded deploy. Parent count is.
+
+PASS=0
+FAIL=0
+_ok()  { ((PASS++)); echo "  ✅ $1"; }
+_bad() { ((FAIL++)); echo "  ❌ $1: $2"; }
+
+ROOT="${0:A:h}/.."
+SRC="$ROOT/lib/dispatchers/teach-deploy-enhanced.zsh"
+[[ -f "$SRC" ]] || { echo "❌ cannot find $SRC"; exit 1; }
+command -v yq >/dev/null 2>&1 || { echo "⏭️  yq not installed — skipping"; exit 0; }
+
+BOOT="source '$ROOT/lib/core.zsh' 2>/dev/null || true
+source '$ROOT/lib/git-helpers.zsh' 2>/dev/null || true
+source '$ROOT/lib/deploy-history-helpers.zsh' 2>/dev/null || true
+source '$ROOT/lib/deploy-rollback-helpers.zsh' 2>/dev/null || true
+source '$SRC'
+typeset -f _teach_error >/dev/null 2>&1 || _teach_error() { echo \"teach: \$1\"; return 1; }"
+
+echo "=== teach deploy merge topology ==="
+
+root="$(mktemp -d)"
+git init -q --bare "$root/bare.git"
+git init -q -b draft "$root/repo"
+(
+  cd "$root/repo" || exit 1
+  git config user.email t@t.t
+  git config user.name T
+  mkdir -p .flow
+  printf 'course:\n  name: Topology\nbranches:\n  draft: draft\n  production: production\n' \
+    > .flow/teach-config.yml
+  echo v1 > page.qmd
+  git add -A && git commit -qm init
+  git branch production
+  git remote add origin "$root/bare.git"
+  git push -q origin draft production
+  git branch -q --set-upstream-to=origin/draft draft
+  # Two commits, so a fast-forward would visibly collapse the deploy into
+  # draft's own tip rather than producing one deploy commit.
+  echo a >> page.qmd && git commit -qam "content: week 1"
+  echo b >> page.qmd && git commit -qam "content: week 2"
+)
+
+( cd "$root/repo" && zsh -c "$BOOT
+_teach_deploy_enhanced --direct" </dev/null >/dev/null 2>&1 )
+
+parents="$( cd "$root/repo" && git rev-list --parents -n1 production | wc -w | tr -d ' ' )"
+if [[ "$parents" == "3" ]]; then
+  _ok "direct deploy creates a merge commit (2 parents)"
+else
+  _bad "direct deploy did not create a merge commit" "rev-list --parents printed $parents refs, expected 3"
+fi
+
+# The merge commit must actually contain both weeks, i.e. reverting it undoes
+# the whole deploy rather than one commit of it.
+second_parent="$( cd "$root/repo" && git log -1 --pretty=%P production | awk '{print $2}' )"
+if [[ -n "$second_parent" ]]; then
+  subj="$( cd "$root/repo" && git log -1 --pretty=%s "$second_parent" )"
+  if [[ "$subj" == "content: week 2" ]]; then
+    _ok "merge's second parent is draft's tip — one revert undoes the whole deploy"
+  else
+    _bad "unexpected second parent" "$subj"
+  fi
+else
+  _bad "no second parent" "production tip is not a merge"
+fi
+
+rm -rf "$root"
+
+echo ""
+echo "=== $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Two fixes to `teach deploy`, both found by trying to drive it from a non-interactive caller.

## 1. `--dry-run` was neither read-only nor usable in CI mode

`ci_mode` auto-detects whenever stdin is not a TTY (`teach-deploy-enhanced.zsh:530`), so **every**
automation or agent caller gets it. In that mode two preflight conditions aborted the run *before
the plan could render*:

- "production has new commits" (`:170-186`)
- "uncommitted changes" (`:668`)

Neither can affect a dry run, which mutates nothing. Both teaching repos I tested hit the first
one, so a dry run could not render a plan on the ordinary state of a working course repo.

The uncommitted-changes handler had a worse edge. Interactively it **prompts to commit**, and any
pty wrapper answers the default `Y`. Probing whether `script -q /dev/null` could defeat the CI-mode
detection, it did exactly that and **created a real commit in a live course repo** during what was
announced as a read-only dry run. That commit was reverted and the repo restored, but the hazard is
in the handler, not in the wrapper — which is why the fix is here rather than a note telling people
not to use a pty.

Both mutation-oriented gates now skip when `dry_run` is true. Real deploys are untouched and still
abort on both conditions.

## 2. The direct merge omitted `--no-ff`

A deploy of N draft commits fast-forwarded production to draft's own tip, leaving no single commit
representing the deploy. Since `teach deploy --rollback` reverts the deploy's commit, a
fast-forwarded deploy could only be rolled back one commit at a time — it lost rollback granularity
silently rather than failing. `git-helpers.zsh:693` already assumed otherwise, filtering "merge
commits from `--no-ff` deploys" when detecting production conflicts.

Verified in a sandboxed fixture deploying two commits:

```
before:  linear history, production tip == draft's own content commit
after:   70c864d parents=[d7a7215 6f52c5f]   (a merge commit)
```

## Test evidence

All 8 deploy suites: **246 passed, 1 failed, 1 skipped.**

```
dogfood-teach-deploy-v2.zsh              71/71 passed
e2e-teach-deploy-v2.zsh                  44 passed, 0 failed, 1 skipped
test-teach-deploy-dryrun-readonly.zsh    10 passed, 0 failed   (new)
test-teach-deploy-merge-topology.zsh      2 passed, 0 failed   (new)
test-teach-deploy-unit.zsh               25 passed, 1 failed   <- see below
test-teach-deploy-v2-integration.zsh     22 passed, 0 failed
test-teach-deploy-v2-unit.zsh            58 passed, 0 failed
test-teach-deploy.zsh                    14 passed, 0 failed
```

The single failure is `Test 24: Calculate commit count between branches`, and it **reproduces
identically on unmodified `dev`** — pre-existing, not introduced here.

Both new suites check repository state before and after every case, so any write during a
"read-only" path is caught rather than assumed.

**Positive controls**, run separately for each fix:

- Reverting only the dry-run change fails exactly the 3 dry-run assertions while all 4
  real-deploy controls still pass — so the controls are not tautological.
- Reverting only the `--no-ff` fails both topology assertions; restoring it passes both.

## One trap documented in the test header

After a successful deploy, draft and production legitimately point at the **same** commit, because
the deploy syncs draft from production afterwards (`draft@{0}: merge origin/production:
Fast-forward`). Ref equality is therefore **not** evidence of a fast-forwarded deploy — parent
count is. An earlier check of mine got this wrong and reported a fast-forward that had not
happened.

## Changelog

Both `CHANGELOG.md` and `docs/CHANGELOG.md` updated under `[Unreleased]`. Note the two files
already differ by roughly 20KB of pre-existing drift; these entries are mirrored into both rather
than reconciling that separately.

## Context

Found while making cc-config's `/deploy` delegate here instead of reimplementing the
draft-to-production workflow itself (cc-config#7). That delegation stays unshipped until this
lands and a release reaches Homebrew, since `teach` resolves to the brew build.
