### PR TITLE
chore(release): v7.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.17.0] — 2026-08-23 — teach deploy safety + CI coverage
+
 ### Added
 
 - **`em undo`** — single-step undo of the last `em star`/`flag`/`unflag`/`move` action (1-hour window, no multi-level undo stack). Uses `lib/em-cache.zsh`'s existing cache API.
@@ -45,6 +47,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`em move` was broken in production** — `_em_move` and its adapter `_em_hml_move` were each defined twice in the same file (zsh's last-definition-wins semantics), and the two live (later) definitions were incompatible with each other: the live `_em_move` called `_em_hml_move` with a numeric message ID in the source-folder position. Every `em move <ID> <folder>` call would attempt to move a message from a non-existent folder named after the ID. Removed the dead pair, kept the multi-ID interface (`em move <FOLDER> <ID>...`) that matches `em move --help`, `MASTER-DISPATCHER-GUIDE.md`, and the existing (previously unregistered) `tests/test-em-move-restore.zsh`. That test file — which would have caught this — was never wired into `tests/run-all.sh`; it is now.
 - Corrected a dozen-plus stale `em move <ID> [FOLDER]` / `em flag <ID> # Alias for em star` references across `docs/help/QUICK-REFERENCE.md`, `docs/reference/MASTER-DISPATCHER-GUIDE.md`, `docs/reference/REFCARD-EMAIL-DISPATCHER.md` (which had both a stale and a correct `em move` row), `docs/guides/EMAIL-DISPATCHER-GUIDE.md`, `docs/guides/EMAIL-COOKBOOK.md`, and `man/man1/em.1` — all inherited the same wrong interface the code bug had.
+
+### Changed
+
+- **CI now runs 60 suites that had never executed on a runner** — `tests/run-all.sh` takes an
+  explicit list rather than a glob, so 118 `test-*.zsh` files were wired into nothing. Audited:
+  74 pass locally, of which 60 also pass on `ubuntu-latest`; those 60 run in a new non-blocking
+  `Extended Suite` soak job (`tests/run-extended.sh`). The 14 that need brew/atlas/keychain are
+  excluded and named in that file, with the fix noted (exit `77`, the clean-skip code).
+- **`CHANGELOG.md` and `docs/CHANGELOG.md` parity is now gated** on the `[Unreleased]` section
+  (`tests/test-changelog-parity.zsh`), so an entry can no longer land in one file only. The two
+  files have pre-existing bidirectional drift in their historical sections — 23 versions only in
+  root, 41 only in `docs/`, and of 33 shared only 12 have identical bodies — which needs a human
+  and is deliberately not auto-reconciled.
+- **Docs build is gated.** `mkdocs.yml` gains `strict: true`, so broken links fail the build
+  instead of deploying; `docs.yml` runs `gh-deploy --force` on push. `scripts/lint-docs.sh` now
+  runs in CI as advisory. Fixed a real bug there: `.markdownlintignore` is a markdownlint-cli **v1**
+  file while the script runs cli2, which never read it — the intent to skip `.archive/` was inert,
+  accounting for 49 of the reported errors.
+
 
 ## [7.16.0] — 2026-07-07 — agy em-ai backend + em ADHD-UX fixes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management. Zero dependencies. Standalone (works without Oh-My-Zsh or any plugin manager).
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Current Version:** v7.16.0
+- **Current Version:** v7.17.0
 - **Install:** Homebrew (recommended), or any plugin manager
 - **Source:** `source /opt/homebrew/opt/flow-cli/flow.plugin.zsh` (via Homebrew)
 - **Optional:** Atlas integration for enhanced state management
@@ -217,7 +217,7 @@ export FLOW_FORCE_DISPATCHER_OBS=1           # Force-keep one dispatcher (FLOW_F
 
 ## Current Status
 
-**Version:** v7.16.0 | **Tests:** 12000+ (75/75 suite, 1 skipped — tool absence) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.17.0 | **Tests:** 12000+ (75/75 suite, 1 skipped — tool absence) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ## [Unreleased]
 
+## [7.17.0] — 2026-08-23 — teach deploy safety + CI coverage
+
 ### Added
 
 - **`em undo`** — single-step undo of the last `em star`/`flag`/`unflag`/`move` action (1-hour window, no multi-level undo stack). Uses `lib/em-cache.zsh`'s existing cache API.
@@ -44,6 +46,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 - **`em move` was broken in production** — `_em_move` and its adapter `_em_hml_move` were each defined twice in the same file (zsh's last-definition-wins semantics), and the two live (later) definitions were incompatible with each other: the live `_em_move` called `_em_hml_move` with a numeric message ID in the source-folder position. Every `em move <ID> <folder>` call would attempt to move a message from a non-existent folder named after the ID. Removed the dead pair, kept the multi-ID interface (`em move <FOLDER> <ID>...`) that matches `em move --help`, `MASTER-DISPATCHER-GUIDE.md`, and the existing (previously unregistered) `tests/test-em-move-restore.zsh`. That test file — which would have caught this — was never wired into `tests/run-all.sh`; it is now.
 - Corrected a dozen-plus stale `em move <ID> [FOLDER]` / `em flag <ID> # Alias for em star` references across `docs/help/QUICK-REFERENCE.md`, `docs/reference/MASTER-DISPATCHER-GUIDE.md`, `docs/reference/REFCARD-EMAIL-DISPATCHER.md` (which had both a stale and a correct `em move` row), `docs/guides/EMAIL-DISPATCHER-GUIDE.md`, `docs/guides/EMAIL-COOKBOOK.md`, and `man/man1/em.1` — all inherited the same wrong interface the code bug had.
+
+### Changed
+
+- **CI now runs 60 suites that had never executed on a runner** — `tests/run-all.sh` takes an
+  explicit list rather than a glob, so 118 `test-*.zsh` files were wired into nothing. Audited:
+  74 pass locally, of which 60 also pass on `ubuntu-latest`; those 60 run in a new non-blocking
+  `Extended Suite` soak job (`tests/run-extended.sh`). The 14 that need brew/atlas/keychain are
+  excluded and named in that file, with the fix noted (exit `77`, the clean-skip code).
+- **`CHANGELOG.md` and `docs/CHANGELOG.md` parity is now gated** on the `[Unreleased]` section
+  (`tests/test-changelog-parity.zsh`), so an entry can no longer land in one file only. The two
+  files have pre-existing bidirectional drift in their historical sections — 23 versions only in
+  root, 41 only in `docs/`, and of 33 shared only 12 have identical bodies — which needs a human
+  and is deliberately not auto-reconciled.
+- **Docs build is gated.** `mkdocs.yml` gains `strict: true`, so broken links fail the build
+  instead of deploying; `docs.yml` runs `gh-deploy --force` on push. `scripts/lint-docs.sh` now
+  runs in CI as advisory. Fixed a real bug there: `.markdownlintignore` is a markdownlint-cli **v1**
+  file while the script runs cli2, which never read it — the intent to skip `.archive/` was inert,
+  accounting for 49 of the reported errors.
+
 
 ## [7.16.0] — 2026-07-07 — agy em-ai backend + em ADHD-UX fixes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,10 +29,10 @@ tags:
     **New here?** `setup` walks you through configuration interactively, or run `tutorial` for
     12 hands-on lessons at your own pace — both are guided, no docs required to start.
 
-!!! success "🎉 What's New in v7.16.0"
-    **`agy` (Antigravity CLI) added as an em-ai backend** — ahead of `gemini` (now legacy) in the fallback chain, with automatic output cleaning and validation.
-    **`em flag`/`em star` bug fixed** — a dead-code dispatch bug silently made `em flag` behave differently than intended; `em star` now also supports multiple IDs.
-    **`em help <topic>`** — filter help to one section instead of scanning the full command reference.
+!!! success "🎉 What's New in v7.17.0"
+    **`teach deploy --dry-run` is genuinely read-only** — it no longer aborts in CI mode, no longer prompts to commit (a pty wrapper used to auto-accept that and create a real commit), and it now names the uncommitted files its plan excludes.
+    **`teach deploy --direct` merges with `--no-ff`** — every deploy is one revertable commit again, so `teach deploy --rollback` can undo a multi-commit deploy as a unit.
+    **`em undo`** — single-step undo of the last `em star`/`flag`/`unflag`/`move`, plus `em move --recent` for quick folder re-picks.
     Full details → [Changelog](CHANGELOG.md).
 
 ---
@@ -326,4 +326,4 @@ ref               # Quick-reference card (forgot the syntax? this is faster than
 
 ---
 
-**v7.16.0** · Pure ZSH · Zero Dependencies · MIT License
+**v7.17.0** · Pure ZSH · Zero Dependencies · MIT License

--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -187,7 +187,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="7.16.0"
+export FLOW_VERSION="7.17.0"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup

--- a/man/man1/agenda.1
+++ b/man/man1/agenda.1
@@ -1,6 +1,6 @@
 .\" Man page for the agenda command (forward-looking schedule view)
 .\" Updated: June 2026
-.TH AGENDA 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH AGENDA 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 agenda \- forward-looking schedule across all projects
 .SH SYNOPSIS

--- a/man/man1/at.1
+++ b/man/man1/at.1
@@ -1,6 +1,6 @@
 .\" Man page for at dispatcher (Atlas bridge)
 .\" Generated: June 2026
-.TH AT 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH AT 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 at \- Atlas project intelligence bridge (optional integration)
 .SH SYNOPSIS

--- a/man/man1/cc.1
+++ b/man/man1/cc.1
@@ -1,6 +1,6 @@
 .\" Man page for cc dispatcher (Claude Code launcher)
 .\" Generated: June 2026
-.TH CC 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH CC 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 cc \- Claude Code launcher and dispatcher
 .SH SYNOPSIS

--- a/man/man1/dash.1
+++ b/man/man1/dash.1
@@ -1,6 +1,6 @@
 .\" Man page for the dash command (project dashboard)
 .\" Updated: June 2026
-.TH DASH 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH DASH 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 dash \- ADHD-friendly project dashboard
 .SH SYNOPSIS

--- a/man/man1/dots.1
+++ b/man/man1/dots.1
@@ -1,6 +1,6 @@
 .\" Man page for dots dispatcher (Dotfile Management)
 .\" Generated: June 2026
-.TH DOTS 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH DOTS 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 dots \- Dotfile management dispatcher (chezmoi wrapper)
 .SH SYNOPSIS

--- a/man/man1/em.1
+++ b/man/man1/em.1
@@ -1,6 +1,6 @@
 .\" Man page for em dispatcher (Email / himalaya)
 .\" Generated: June 2026
-.TH EM 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH EM 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 em \- Email dispatcher (himalaya wrapper)
 .SH SYNOPSIS

--- a/man/man1/flow-claude.1
+++ b/man/man1/flow-claude.1
@@ -1,4 +1,4 @@
-.TH FLOW-CLAUDE 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH FLOW-CLAUDE 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 flow-claude \- Claude Code environment health checker
 .SH SYNOPSIS

--- a/man/man1/flow.1
+++ b/man/man1/flow.1
@@ -1,6 +1,6 @@
 .\" Man page for flow command
 .\" Updated: June 2026
-.TH FLOW 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH FLOW 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 flow \- ADHD-friendly workflow CLI for developers
 .SH SYNOPSIS

--- a/man/man1/g.1
+++ b/man/man1/g.1
@@ -1,6 +1,6 @@
 .\" Man page for g dispatcher (Git workflows)
 .\" Updated: June 2026
-.TH G 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH G 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 g \- Git commands dispatcher
 .SH SYNOPSIS

--- a/man/man1/mcp.1
+++ b/man/man1/mcp.1
@@ -1,6 +1,6 @@
 .\" Man page for mcp dispatcher (MCP server management)
 .\" Updated: June 2026
-.TH MCP 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH MCP 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 mcp \- MCP server management dispatcher
 .SH SYNOPSIS

--- a/man/man1/morning.1
+++ b/man/man1/morning.1
@@ -1,6 +1,6 @@
 .\" Man page for the morning command (daily startup routine)
 .\" Updated: June 2026
-.TH MORNING 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH MORNING 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 morning \- ADHD-friendly daily startup routine
 .SH SYNOPSIS

--- a/man/man1/prompt.1
+++ b/man/man1/prompt.1
@@ -1,6 +1,6 @@
 .\" Man page for prompt dispatcher (Prompt Engine Switcher)
 .\" Generated: June 2026
-.TH PROMPT 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH PROMPT 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 prompt \- Prompt engine switcher
 .SH SYNOPSIS

--- a/man/man1/qu.1
+++ b/man/man1/qu.1
@@ -1,6 +1,6 @@
 .\" Man page for qu dispatcher (Quarto publishing)
 .\" Updated: June 2026
-.TH QU 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH QU 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 qu \- Quarto publishing dispatcher
 .SH SYNOPSIS

--- a/man/man1/r.1
+++ b/man/man1/r.1
@@ -1,6 +1,6 @@
 .\" Man page for r dispatcher (R package development)
 .\" Updated: June 2026
-.TH R 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH R 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 r \- R package development dispatcher
 .SH SYNOPSIS

--- a/man/man1/sec.1
+++ b/man/man1/sec.1
@@ -1,6 +1,6 @@
 .\" Man page for sec dispatcher (Secret Management)
 .\" Generated: June 2026
-.TH SEC 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH SEC 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 sec \- Secret management dispatcher (Keychain and Bitwarden)
 .SH SYNOPSIS

--- a/man/man1/teach.1
+++ b/man/man1/teach.1
@@ -1,6 +1,6 @@
 .\" Man page for teach dispatcher (Teaching Workflow)
 .\" Generated: June 2026
-.TH TEACH 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH TEACH 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 teach \- Teaching workflow dispatcher (Scholar integration)
 .SH SYNOPSIS

--- a/man/man1/tm.1
+++ b/man/man1/tm.1
@@ -1,6 +1,6 @@
 .\" Man page for tm dispatcher (Terminal Manager)
 .\" Generated: June 2026
-.TH TM 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH TM 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 tm \- Terminal manager dispatcher
 .SH SYNOPSIS

--- a/man/man1/today.1
+++ b/man/man1/today.1
@@ -1,6 +1,6 @@
 .\" Man page for the today command (quick daily status)
 .\" Updated: June 2026
-.TH TODAY 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH TODAY 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 today \- quick daily status
 .SH SYNOPSIS

--- a/man/man1/tok.1
+++ b/man/man1/tok.1
@@ -1,6 +1,6 @@
 .\" Man page for tok dispatcher (Token Management)
 .\" Generated: June 2026
-.TH TOK 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH TOK 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 tok \- Token lifecycle management dispatcher
 .SH SYNOPSIS

--- a/man/man1/v.1
+++ b/man/man1/v.1
@@ -1,6 +1,6 @@
 .\" Man page for v dispatcher (Vibe / Workflow Automation)
 .\" Generated: June 2026
-.TH V 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH V 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 v \- Workflow automation dispatcher (vibe coding mode)
 .SH SYNOPSIS

--- a/man/man1/week.1
+++ b/man/man1/week.1
@@ -1,6 +1,6 @@
 .\" Man page for the week command (weekly review helper)
 .\" Updated: June 2026
-.TH WEEK 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH WEEK 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 week \- weekly review helper
 .SH SYNOPSIS

--- a/man/man1/wt.1
+++ b/man/man1/wt.1
@@ -1,6 +1,6 @@
 .\" Man page for wt dispatcher (Git Worktree Management)
 .\" Generated: June 2026
-.TH WT 1 "June 2026" "flow-cli 7.16.0" "User Commands"
+.TH WT 1 "June 2026" "flow-cli 7.17.0" "User Commands"
 .SH NAME
 wt \- Git worktree management dispatcher
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "7.16.0",
+  "version": "7.17.0",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Version bump for v7.17.0. Minor: 2 `feat`, 3 `fix`, no breaking changes since v7.16.0.

## What ships

**teach deploy safety** (the substance of this release)

- `--dry-run` is genuinely read-only — no longer aborts in CI mode (which every non-TTY caller
  gets), no longer prompts to commit, and names the uncommitted files its plan excludes. The
  prompt mattered: a pty wrapper auto-accepted it and created a real commit in a live course repo.
- `--direct` merges with `--no-ff`, so a deploy is one revertable commit again and `--rollback`
  can undo a multi-commit deploy as a unit.

Plus `em undo` / `em move --recent`, and the CI coverage work from #506.

## Mechanics

- `scripts/release.sh 7.17.0` → `package.json`, `CLAUDE.md`, `flow.plugin.zsh`, README badge, 20 man pages
- Both changelogs cut `[7.17.0]` with identical bodies; `test-changelog-parity.zsh` confirms `[Unreleased]` parity
- **`docs/index.md` updated by hand** — `release.sh` does not touch it, so its "What's New" banner and
  footer still advertised v7.16.0. Worth folding into `release.sh` so the next release doesn't repeat it.

## Verification

```
grep 7.16.0 (excl. changelogs/release archives)  → no matches
tests/test-manpage-version-sync.zsh              → 12/12 passed
mkdocs build --strict                            → exit 0
tests/run-all.sh                                 → 82 passed, 2 failed
```

Both failures (`e2e-em-dispatcher`, `test-atlas-contract`) reproduce on unmodified `dev` and are
green in CI — local environment, not this branch.

## Note

Running the suite locally mutates tracked files (`.STATUS` gains fake "wins" entries,
`tests/fixtures/demo-course/.teach/concepts.json` changes). Caught at staging and restored, so
they are not in this diff — but it's a hygiene bug someone will commit by accident eventually.