### PR TITLE
chore(release): v7.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.17.1] — 2026-08-23 — alias-proof shipped pipelines
+
+### Fixed
+
+- **A user alias on a coreutil could hijack shipped pipelines.** Dispatchers run in the user's
+  *interactive* shell, where aliases are live and expand at parse time. On a machine with
+  `tr='track-activity report'`, every `... | tr -d ' '` in `lib/` ran that command instead, and its
+  output landed in the variable where a count belonged — `teach deploy --dry-run` printed
+  `Would deploy Monthly Terminal Report (2026-08):` instead of `Would deploy 675 files:`. All 101
+  pipeline sites across 34 files now use `command tr`, which bypasses aliases and functions.
+  Guarded by `tests/test-alias-shadowing.zsh`, including a negative control so the test cannot pass
+  vacuously if the environment stops reproducing the hijack.
+
 ## [7.17.0] — 2026-08-23 — teach deploy safety + CI coverage
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management. Zero dependencies. Standalone (works without Oh-My-Zsh or any plugin manager).
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Current Version:** v7.17.0
+- **Current Version:** v7.17.1
 - **Install:** Homebrew (recommended), or any plugin manager
 - **Source:** `source /opt/homebrew/opt/flow-cli/flow.plugin.zsh` (via Homebrew)
 - **Optional:** Atlas integration for enhanced state management
@@ -217,7 +217,7 @@ export FLOW_FORCE_DISPATCHER_OBS=1           # Force-keep one dispatcher (FLOW_F
 
 ## Current Status
 
-**Version:** v7.17.0 | **Tests:** 12000+ (75/75 suite, 1 skipped — tool absence) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.17.1 | **Tests:** 12000+ (75/75 suite, 1 skipped — tool absence) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ## [Unreleased]
 
+## [7.17.1] — 2026-08-23 — alias-proof shipped pipelines
+
+### Fixed
+
+- **A user alias on a coreutil could hijack shipped pipelines.** Dispatchers run in the user's
+  *interactive* shell, where aliases are live and expand at parse time. On a machine with
+  `tr='track-activity report'`, every `... | tr -d ' '` in `lib/` ran that command instead, and its
+  output landed in the variable where a count belonged — `teach deploy --dry-run` printed
+  `Would deploy Monthly Terminal Report (2026-08):` instead of `Would deploy 675 files:`. All 101
+  pipeline sites across 34 files now use `command tr`, which bypasses aliases and functions.
+  Guarded by `tests/test-alias-shadowing.zsh`, including a negative control so the test cannot pass
+  vacuously if the environment stops reproducing the hijack.
+
 ## [7.17.0] — 2026-08-23 — teach deploy safety + CI coverage
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,10 +29,11 @@ tags:
     **New here?** `setup` walks you through configuration interactively, or run `tutorial` for
     12 hands-on lessons at your own pace — both are guided, no docs required to start.
 
-!!! success "🎉 What's New in v7.17.0"
+!!! success "🎉 What's New in v7.17.1"
     **`teach deploy --dry-run` is genuinely read-only** — it no longer aborts in CI mode, no longer prompts to commit (a pty wrapper used to auto-accept that and create a real commit), and it now names the uncommitted files its plan excludes.
     **`teach deploy --direct` merges with `--no-ff`** — every deploy is one revertable commit again, so `teach deploy --rollback` can undo a multi-commit deploy as a unit.
     **`em undo`** — single-step undo of the last `em star`/`flag`/`unflag`/`move`, plus `em move --recent` for quick folder re-picks.
+    **Shipped pipelines are alias-proof** — a user alias on a coreutil (e.g. `tr`) could hijack internal pipelines and replace counts with unrelated output; all 101 sites now use `command tr`.
     Full details → [Changelog](CHANGELOG.md).
 
 ---
@@ -326,4 +327,4 @@ ref               # Quick-reference card (forgot the syntax? this is faster than
 
 ---
 
-**v7.17.0** · Pure ZSH · Zero Dependencies · MIT License
+**v7.17.1** · Pure ZSH · Zero Dependencies · MIT License

--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -187,7 +187,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="7.17.0"
+export FLOW_VERSION="7.17.1"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup

--- a/man/man1/agenda.1
+++ b/man/man1/agenda.1
@@ -1,6 +1,6 @@
 .\" Man page for the agenda command (forward-looking schedule view)
 .\" Updated: June 2026
-.TH AGENDA 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH AGENDA 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 agenda \- forward-looking schedule across all projects
 .SH SYNOPSIS

--- a/man/man1/at.1
+++ b/man/man1/at.1
@@ -1,6 +1,6 @@
 .\" Man page for at dispatcher (Atlas bridge)
 .\" Generated: June 2026
-.TH AT 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH AT 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 at \- Atlas project intelligence bridge (optional integration)
 .SH SYNOPSIS

--- a/man/man1/cc.1
+++ b/man/man1/cc.1
@@ -1,6 +1,6 @@
 .\" Man page for cc dispatcher (Claude Code launcher)
 .\" Generated: June 2026
-.TH CC 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH CC 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 cc \- Claude Code launcher and dispatcher
 .SH SYNOPSIS

--- a/man/man1/dash.1
+++ b/man/man1/dash.1
@@ -1,6 +1,6 @@
 .\" Man page for the dash command (project dashboard)
 .\" Updated: June 2026
-.TH DASH 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH DASH 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 dash \- ADHD-friendly project dashboard
 .SH SYNOPSIS

--- a/man/man1/dots.1
+++ b/man/man1/dots.1
@@ -1,6 +1,6 @@
 .\" Man page for dots dispatcher (Dotfile Management)
 .\" Generated: June 2026
-.TH DOTS 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH DOTS 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 dots \- Dotfile management dispatcher (chezmoi wrapper)
 .SH SYNOPSIS

--- a/man/man1/em.1
+++ b/man/man1/em.1
@@ -1,6 +1,6 @@
 .\" Man page for em dispatcher (Email / himalaya)
 .\" Generated: June 2026
-.TH EM 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH EM 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 em \- Email dispatcher (himalaya wrapper)
 .SH SYNOPSIS

--- a/man/man1/flow-claude.1
+++ b/man/man1/flow-claude.1
@@ -1,4 +1,4 @@
-.TH FLOW-CLAUDE 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH FLOW-CLAUDE 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 flow-claude \- Claude Code environment health checker
 .SH SYNOPSIS

--- a/man/man1/flow.1
+++ b/man/man1/flow.1
@@ -1,6 +1,6 @@
 .\" Man page for flow command
 .\" Updated: June 2026
-.TH FLOW 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH FLOW 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 flow \- ADHD-friendly workflow CLI for developers
 .SH SYNOPSIS

--- a/man/man1/g.1
+++ b/man/man1/g.1
@@ -1,6 +1,6 @@
 .\" Man page for g dispatcher (Git workflows)
 .\" Updated: June 2026
-.TH G 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH G 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 g \- Git commands dispatcher
 .SH SYNOPSIS

--- a/man/man1/mcp.1
+++ b/man/man1/mcp.1
@@ -1,6 +1,6 @@
 .\" Man page for mcp dispatcher (MCP server management)
 .\" Updated: June 2026
-.TH MCP 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH MCP 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 mcp \- MCP server management dispatcher
 .SH SYNOPSIS

--- a/man/man1/morning.1
+++ b/man/man1/morning.1
@@ -1,6 +1,6 @@
 .\" Man page for the morning command (daily startup routine)
 .\" Updated: June 2026
-.TH MORNING 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH MORNING 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 morning \- ADHD-friendly daily startup routine
 .SH SYNOPSIS

--- a/man/man1/prompt.1
+++ b/man/man1/prompt.1
@@ -1,6 +1,6 @@
 .\" Man page for prompt dispatcher (Prompt Engine Switcher)
 .\" Generated: June 2026
-.TH PROMPT 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH PROMPT 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 prompt \- Prompt engine switcher
 .SH SYNOPSIS

--- a/man/man1/qu.1
+++ b/man/man1/qu.1
@@ -1,6 +1,6 @@
 .\" Man page for qu dispatcher (Quarto publishing)
 .\" Updated: June 2026
-.TH QU 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH QU 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 qu \- Quarto publishing dispatcher
 .SH SYNOPSIS

--- a/man/man1/r.1
+++ b/man/man1/r.1
@@ -1,6 +1,6 @@
 .\" Man page for r dispatcher (R package development)
 .\" Updated: June 2026
-.TH R 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH R 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 r \- R package development dispatcher
 .SH SYNOPSIS

--- a/man/man1/sec.1
+++ b/man/man1/sec.1
@@ -1,6 +1,6 @@
 .\" Man page for sec dispatcher (Secret Management)
 .\" Generated: June 2026
-.TH SEC 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH SEC 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 sec \- Secret management dispatcher (Keychain and Bitwarden)
 .SH SYNOPSIS

--- a/man/man1/teach.1
+++ b/man/man1/teach.1
@@ -1,6 +1,6 @@
 .\" Man page for teach dispatcher (Teaching Workflow)
 .\" Generated: June 2026
-.TH TEACH 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH TEACH 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 teach \- Teaching workflow dispatcher (Scholar integration)
 .SH SYNOPSIS

--- a/man/man1/tm.1
+++ b/man/man1/tm.1
@@ -1,6 +1,6 @@
 .\" Man page for tm dispatcher (Terminal Manager)
 .\" Generated: June 2026
-.TH TM 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH TM 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 tm \- Terminal manager dispatcher
 .SH SYNOPSIS

--- a/man/man1/today.1
+++ b/man/man1/today.1
@@ -1,6 +1,6 @@
 .\" Man page for the today command (quick daily status)
 .\" Updated: June 2026
-.TH TODAY 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH TODAY 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 today \- quick daily status
 .SH SYNOPSIS

--- a/man/man1/tok.1
+++ b/man/man1/tok.1
@@ -1,6 +1,6 @@
 .\" Man page for tok dispatcher (Token Management)
 .\" Generated: June 2026
-.TH TOK 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH TOK 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 tok \- Token lifecycle management dispatcher
 .SH SYNOPSIS

--- a/man/man1/v.1
+++ b/man/man1/v.1
@@ -1,6 +1,6 @@
 .\" Man page for v dispatcher (Vibe / Workflow Automation)
 .\" Generated: June 2026
-.TH V 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH V 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 v \- Workflow automation dispatcher (vibe coding mode)
 .SH SYNOPSIS

--- a/man/man1/week.1
+++ b/man/man1/week.1
@@ -1,6 +1,6 @@
 .\" Man page for the week command (weekly review helper)
 .\" Updated: June 2026
-.TH WEEK 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH WEEK 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 week \- weekly review helper
 .SH SYNOPSIS

--- a/man/man1/wt.1
+++ b/man/man1/wt.1
@@ -1,6 +1,6 @@
 .\" Man page for wt dispatcher (Git Worktree Management)
 .\" Generated: June 2026
-.TH WT 1 "June 2026" "flow-cli 7.17.0" "User Commands"
+.TH WT 1 "June 2026" "flow-cli 7.17.1" "User Commands"
 .SH NAME
 wt \- Git worktree management dispatcher
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "7.17.0",
+  "version": "7.17.1",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Patch release shipping the `tr`-alias-shadowing fix (#509, merged to dev as `bc2b366bb`) to the installed binary. v7.17.0 (already `brew upgrade`d) does NOT contain this fix — every `| tr ` pipeline in shipped `lib/*.zsh` silently ran the user's interactive `tr` alias instead of coreutils `tr`, corrupting output in commands like `teach deploy --dry-run`.

## Changes

- `CHANGELOG.md` / `docs/CHANGELOG.md`: cut `[7.17.1]` sections, parity-verified via `tests/test-changelog-parity.zsh`
- Version bump via `scripts/release.sh 7.17.1`: `package.json`, `CLAUDE.md`, `flow.plugin.zsh`, README badge, 20 man pages
- `docs/index.md`: hand-updated banner + footer version (release.sh doesn't touch this file — missed on v7.17.0, fixed proactively this time)

## Verification

- `tests/test-manpage-version-sync.zsh`: 12/12 passed
- `mkdocs build --strict`: exit 0
- Zero stale `7.17.0` references outside changelogs
- `timeout 580 bash tests/run-all.sh`: 81 passed / 1 failed / 3 timeout — same known local-environment-only failures seen throughout this release cycle, not caused by this change
- Test-mutated tracked files (`.STATUS`, fixtures, `.flow/teach-config.yml`) restored via `git checkout --` before commit

## Test plan

- [x] Changelog parity test passes
- [x] Manpage version sync passes
- [x] Docs build strict passes
- [x] Full suite run, failures triaged against known baseline
- [ ] CI green on this PR