### PR TITLE
fix(zsh): add ~/.local/bin to PATH in .zshenv for uv tool shims

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -23,6 +23,13 @@
 # ENVIRONMENT VARIABLES (from .zshrc)
 # ============================================
 
+# PATH
+# uv installs tool shims here (radian, arxiv_latex_cleaner, ...). Set in
+# .zshenv, not .zshrc, so non-interactive shells (scripts, Claude Code) can
+# reach them too. Guarded: .zshenv is sourced for every zsh invocation, so an
+# unconditional prepend would grow PATH once per nested shell.
+[[ ":$PATH:" == *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"
+
 # R Package Development
 export R_PACKAGES_DIR="$HOME/R-packages"
 export QUARTO_DIR="$HOME/quarto-projects"


### PR DESCRIPTION
## Problem

`uv` installs tool shims into `~/.local/bin` (currently `radian` and `arxiv_latex_cleaner`), but nothing in the zsh config put that directory on `PATH`. The tools were installed yet unreachable by name — `uv` itself warns about this on every install.

Surfaced while restoring a new Mac: `radian` (the R console) is listed in the captured machine state and is load-bearing, but would not resolve.

## Change

One guarded line in `zsh/.zshenv`.

- **`.zshenv`, not `.zshrc`** — so non-interactive shells (scripts, Claude Code) resolve the tools too. This matches the file's own stated purpose: "Use this for: Essential PATH modifications".
- **Guarded with a substring test** — `.zshenv` is sourced for *every* zsh invocation, so an unconditional prepend would grow `PATH` once per nested shell.

## Verification

- `zsh -n zsh/.zshenv` parses
- Fresh shell: `~/.local/bin` present on `PATH`
- Sourced 3x in one shell: exactly **1** occurrence (guard works)
- `command -v radian` and `command -v arxiv_latex_cleaner` both resolve

## Test suite

`zsh/tests/run-all-tests.zsh` — 2 passed, 1 failed.

The failure is **pre-existing and unrelated**: the duplicate-function check flags `_log_error()` defined in both `lib/hooks/pre-commit-template.zsh:39` and `lib/hooks/pre-push-template.zsh:37`. Confirmed by stashing this change and re-running — identical failure on a clean tree. Not addressed here; worth its own issue.