### PR TITLE
chore(ci): scope the tap App token to contents + pull-requests

### DIFF
--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -73,6 +73,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: Data-Wise
           repositories: homebrew-tap
+          # Least privilege: without these the minted token inherits EVERY
+          # permission the App installation holds on homebrew-tap, for the whole
+          # job. This step needs exactly two things — commit/push the formula
+          # edit, and open then auto-merge the bump PR.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout homebrew-tap
         uses: actions/checkout@v7


### PR DESCRIPTION
## What

`homebrew-release.yml` mints its tap credential with no `permission-*` inputs:

```yaml
uses: actions/create-github-app-token@v3
with:
  app-id: ${{ secrets.APP_ID }}
  private-key: ${{ secrets.APP_PRIVATE_KEY }}
  owner: Data-Wise
  repositories: homebrew-tap
```

Omitting them means the minted token inherits **every** permission the `data-wise-homebrew-automation` installation holds on `homebrew-tap`, for the whole job — a job that runs `sed`, `git` and `gh` against a live credential. This declares the two it actually uses.

| Permission | Why |
|---|---|
| `contents: write` | commit + push the formula edit |
| `pull-requests: write` | open and auto-merge the bump PR (added by #499) |

## Both are known-granted, not guessed

The App has authored **7 PRs** on the tap (#215, #214, #213, #212, #210, #209, #207) and merged its own — #212 and #210 both show `mergedBy = app/data-wise-homebrew-automation`, which requires `pull-requests: write`. The formula pushes prove `contents: write`.

## Risk

No behavior change intended. `create-github-app-token` validates requested permissions against the installation and **fails at mint time** if one is not granted, so a mismatch surfaces immediately and loudly rather than silently degrading.

Worth stating plainly: this ships *before* the next release, so that release is its first live exercise — same as #499. If the mint fails, the fix is to drop these two lines.

## Verification

- `actionlint` — **2 SC2086 infos before, 2 after**: identical, pre-existing, and in a different step (line 32). Nothing introduced.
- YAML parses; both keys land in the app-token step's `with:` block:

```
step: Mint GitHub App token (for cross-repo push to homebrew-tap)
  owner = Data-Wise
  repositories = homebrew-tap
  permission-contents = write
  permission-pull-requests = write
```

Workflow-only change; no runtime code touched.