### PR TITLE
chore(ci): pin dependabot to dev, drop npm updates, bump prettier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,21 @@
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '09:00'
-    open-pull-requests-limit: 5
-    reviewers:
-      - 'dt'
-    commit-message:
-      prefix: 'chore(deps)'
-      include: 'scope'
-    labels:
-      - 'dependencies'
-      - 'automated'
-
   # GitHub Actions updates
+  #
+  # npm version updates were removed here (2026-09-04): package.json has no
+  # runtime `dependencies`, only 3 devDependencies (husky, lint-staged,
+  # prettier) that never reach a user — flow-cli ships as zsh through
+  # Homebrew. Of the last 16 npm dependabot PRs, 9 were closed unmerged and
+  # only 6 merged, each costing a full CI run (ZSH Plugin Tests alone ~7min).
+  # github-actions updates merged 3/3 and cover real security surface (e.g.
+  # #444 bumped actions/create-github-app-token, the action #514 later
+  # hardened) — kept.
   - package-ecosystem: 'github-actions'
     directory: '/'
+    # Open PRs against the integration branch. Without this, dependabot derives
+    # the base from the repo default (main) and RESETS it on every rebase, so a
+    # manual retarget to dev can never stick (observed on #503 and #512).
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       day: 'monday'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "husky": "^9.1.7",
         "lint-staged": "^17.4.1",
-        "prettier": "^3.9.4"
+        "prettier": "^3.9.6"
       }
     },
     "node_modules/husky": {
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^17.4.1",
-    "prettier": "^3.9.4"
+    "prettier": "^3.9.6"
   },
   "lint-staged": {
     "*.{json,md,yml,yaml}": [


### PR DESCRIPTION
## What
- Add `target-branch: dev` to the github-actions dependabot block.
- Drop the npm package-ecosystem block entirely.
- Bump prettier 3.9.4 → 3.9.6 by hand (same bump #503 proposed).

## Why
Dependabot derives its PR base from the repo default (`main`) whenever no
`target-branch` is set, and **resets it back to `main` on every rebase** —
confirmed live on #503: retargeted to `dev`, requested a rebase, base
reset to `main` again with a new head commit. A manual per-PR retarget
can never stick against this.

npm updates are dropped rather than just retargeted: `package.json` has
no runtime `dependencies`, only 3 devDependencies (husky, lint-staged,
prettier) that never reach a user — flow-cli ships as zsh through
Homebrew. Of the last 16 npm dependabot PRs, 9 were closed unmerged and
only 6 merged, each costing a full CI run (ZSH Plugin Tests alone ~7min).
github-actions updates merged 3/3 and cover real security surface (e.g.
#444 bumped `actions/create-github-app-token`, later hardened by #514) —
kept, now correctly targeting `dev`.

## Supersedes
Closes #503 (prettier 3.9.4→3.9.6) — same version landed here by hand.

## Test plan
- `.github/dependabot.yml` validated with `yq` (both ecosystem blocks
  parse, `target-branch: dev` present).
- `npx prettier@3.9.6 --check` run against this branch and against
  `origin/dev` (old prettier 3.9.4) — identical set of pre-existing
  warnings/errors (archive docs, test fixtures with an invalid YAML
  escape); nothing newly introduced by the bump.
- Config/docs-only change shape — no new runtime logic, so no new test
  coverage required per the repo's pre-PR testing tier table.
