### PR TITLE
Release: v7.17.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,21 @@
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '09:00'
-    open-pull-requests-limit: 5
-    reviewers:
-      - 'dt'
-    commit-message:
-      prefix: 'chore(deps)'
-      include: 'scope'
-    labels:
-      - 'dependencies'
-      - 'automated'
-
   # GitHub Actions updates
+  #
+  # npm version updates were removed here (2026-09-04): package.json has no
+  # runtime `dependencies`, only 3 devDependencies (husky, lint-staged,
+  # prettier) that never reach a user — flow-cli ships as zsh through
+  # Homebrew. Of the last 16 npm dependabot PRs, 9 were closed unmerged and
+  # only 6 merged, each costing a full CI run (ZSH Plugin Tests alone ~7min).
+  # github-actions updates merged 3/3 and cover real security surface (e.g.
+  # #444 bumped actions/create-github-app-token, the action #514 later
+  # hardened) — kept.
   - package-ecosystem: 'github-actions'
     directory: '/'
+    # Open PRs against the integration branch. Without this, dependabot derives
+    # the base from the repo default (main) and RESETS it on every rebase, so a
+    # manual retarget to dev can never stick (observed on #503 and #512).
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       day: 'monday'

--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -73,6 +73,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: Data-Wise
           repositories: homebrew-tap
+          # Least privilege: without these the minted token inherits EVERY
+          # permission the App installation holds on homebrew-tap, for the whole
+          # job. This step needs exactly two things — commit/push the formula
+          # edit, and open then auto-merge the bump PR.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout homebrew-tap
         uses: actions/checkout@v7

--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -120,6 +120,11 @@ jobs:
             echo "No changes to commit (formula already at v${VERSION})"
             exit 0
           fi
+          # Tap main is branch-protected (PR-only + required status checks), so
+          # a direct push is rejected with GH006. Push a bot branch, open a PR,
+          # and enable auto-merge so it lands once the required checks pass.
+          BRANCH="bot/flow-cli-${VERSION}"
+          git checkout -b "$BRANCH"
           git commit -m "flow-cli: update to v${VERSION}"
 
           # Auth via URL-embedded App token; clear GITHUB_TOKEN so the
@@ -127,15 +132,19 @@ jobs:
           PUSH_URL="https://x-access-token:${TAP_TOKEN}@github.com/Data-Wise/homebrew-tap.git"
           git remote set-url origin "$PUSH_URL"
           unset GITHUB_TOKEN
+          # Force-push is safe: bot/flow-cli-* is a bot-owned, per-version
+          # branch; overwriting it just makes re-runs idempotent.
+          git push --force -u origin "$BRANCH"
 
-          for attempt in 1 2 3; do
-            if git push origin HEAD:main; then
-              echo "Pushed to main (attempt $attempt)"
-              exit 0
-            fi
-            echo "Push failed (attempt $attempt/3), rebasing..."
-            git pull --rebase origin main
-          done
+          export GH_TOKEN="$TAP_TOKEN"
+          if ! gh pr view "$BRANCH" --repo Data-Wise/homebrew-tap --json state -q .state 2>/dev/null | grep -q OPEN; then
+            gh pr create --repo Data-Wise/homebrew-tap \
+              --base main --head "$BRANCH" \
+              --title "flow-cli: update to v${VERSION}" \
+              --body "Automated formula bump from flow-cli homebrew-release.yml."
+          fi
 
-          echo "::error::Failed to push after 3 attempts"
-          exit 1
+          # Auto-merge waits for the tap's required checks; if they already
+          # completed, fall back to an immediate merge.
+          gh pr merge "$BRANCH" --repo Data-Wise/homebrew-tap --squash --auto \
+            || gh pr merge "$BRANCH" --repo Data-Wise/homebrew-tap --squash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.17.2] — 2026-09-05 — CI hardening + PATH fix
+
+### Fixed
+
+- **`uv` tool shims (radian, arxiv_latex_cleaner) were installed but unreachable.** `~/.local/bin` is
+  where `uv` installs them, but nothing in the zsh config put that directory on `PATH`. Added to
+  `.zshenv` (not `.zshrc`) so non-interactive shells — scripts, Claude Code — resolve them too,
+  guarded against unbounded growth across nested shells. (#513)
+- **The Homebrew tap release workflow's direct push to `main` started failing (GH006)** once
+  `Data-Wise/homebrew-tap` enabled branch protection. The workflow now pushes a
+  `bot/flow-cli-<version>` branch, opens a PR, and enables auto-merge so it lands once the tap's
+  required checks pass. (#499)
+
+### Changed
+
+- **The tap release App token is now scoped to `contents: write` + `pull-requests: write`**
+  instead of inheriting every permission the App's installation holds on `homebrew-tap` — the
+  two permissions the job actually uses (formula push, PR open/auto-merge). (#514)
+- **Dependabot's `github-actions` updates now target `dev` explicitly.** Without a
+  `target-branch`, dependabot re-derives the base from the repo default (`main`) and resets it on
+  every rebase, so a manual PR retarget could never stick. (#515)
+- **Dropped the npm dependabot ecosystem.** `package.json` has no runtime dependencies — only 3
+  devDependencies that never reach a user, since flow-cli ships as zsh through Homebrew. Of the
+  last 16 npm dependabot PRs, 9 were closed unmerged; the 3 github-actions updates in the same
+  window all merged and covered real security surface. (#515)
+- Bumped `prettier` 3.9.4 → 3.9.6 and `lint-staged` 17.0.8 → 17.4.1 (devDependencies only). (#512, #515)
+
 ## [7.17.1] — 2026-08-23 — alias-proof shipped pipelines
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **flow-cli** - Pure ZSH plugin for ADHD-optimized workflow management. Zero dependencies. Standalone (works without Oh-My-Zsh or any plugin manager).
 
 - **Architecture:** Pure ZSH plugin (no Node.js runtime required)
-- **Current Version:** v7.17.1
+- **Current Version:** v7.17.2
 - **Install:** Homebrew (recommended), or any plugin manager
 - **Source:** `source /opt/homebrew/opt/flow-cli/flow.plugin.zsh` (via Homebrew)
 - **Optional:** Atlas integration for enhanced state management
@@ -217,7 +217,7 @@ export FLOW_FORCE_DISPATCHER_OBS=1           # Force-keep one dispatcher (FLOW_F
 
 ## Current Status
 
-**Version:** v7.17.1 | **Tests:** 12000+ (75/75 suite, 1 skipped — tool absence) | **Docs:** https://Data-Wise.github.io/flow-cli/
+**Version:** v7.17.2 | **Tests:** 12000+ (75/75 suite, 1 skipped — tool absence) | **Docs:** https://Data-Wise.github.io/flow-cli/
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,33 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and this pro
 
 ## [Unreleased]
 
+## [7.17.2] — 2026-09-05 — CI hardening + PATH fix
+
+### Fixed
+
+- **`uv` tool shims (radian, arxiv_latex_cleaner) were installed but unreachable.** `~/.local/bin` is
+  where `uv` installs them, but nothing in the zsh config put that directory on `PATH`. Added to
+  `.zshenv` (not `.zshrc`) so non-interactive shells — scripts, Claude Code — resolve them too,
+  guarded against unbounded growth across nested shells. (#513)
+- **The Homebrew tap release workflow's direct push to `main` started failing (GH006)** once
+  `Data-Wise/homebrew-tap` enabled branch protection. The workflow now pushes a
+  `bot/flow-cli-<version>` branch, opens a PR, and enables auto-merge so it lands once the tap's
+  required checks pass. (#499)
+
+### Changed
+
+- **The tap release App token is now scoped to `contents: write` + `pull-requests: write`**
+  instead of inheriting every permission the App's installation holds on `homebrew-tap` — the
+  two permissions the job actually uses (formula push, PR open/auto-merge). (#514)
+- **Dependabot's `github-actions` updates now target `dev` explicitly.** Without a
+  `target-branch`, dependabot re-derives the base from the repo default (`main`) and resets it on
+  every rebase, so a manual PR retarget could never stick. (#515)
+- **Dropped the npm dependabot ecosystem.** `package.json` has no runtime dependencies — only 3
+  devDependencies that never reach a user, since flow-cli ships as zsh through Homebrew. Of the
+  last 16 npm dependabot PRs, 9 were closed unmerged; the 3 github-actions updates in the same
+  window all merged and covered real security surface. (#515)
+- Bumped `prettier` 3.9.4 → 3.9.6 and `lint-staged` 17.0.8 → 17.4.1 (devDependencies only). (#512, #515)
+
 ## [7.17.1] — 2026-08-23 — alias-proof shipped pipelines
 
 ### Fixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -327,4 +327,4 @@ ref               # Quick-reference card (forgot the syntax? this is faster than
 
 ---
 
-**v7.17.1** · Pure ZSH · Zero Dependencies · MIT License
+**v7.17.2** · Pure ZSH · Zero Dependencies · MIT License

--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -187,7 +187,7 @@ _flow_plugin_init
 
 # Export loaded marker
 export FLOW_PLUGIN_LOADED=1
-export FLOW_VERSION="7.17.1"
+export FLOW_VERSION="7.17.2"
 
 # Register exit hook for plugin cleanup
 add-zsh-hook zshexit _flow_plugin_cleanup

--- a/man/man1/agenda.1
+++ b/man/man1/agenda.1
@@ -1,6 +1,6 @@
 .\" Man page for the agenda command (forward-looking schedule view)
 .\" Updated: June 2026
-.TH AGENDA 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH AGENDA 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 agenda \- forward-looking schedule across all projects
 .SH SYNOPSIS

--- a/man/man1/at.1
+++ b/man/man1/at.1
@@ -1,6 +1,6 @@
 .\" Man page for at dispatcher (Atlas bridge)
 .\" Generated: June 2026
-.TH AT 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH AT 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 at \- Atlas project intelligence bridge (optional integration)
 .SH SYNOPSIS

--- a/man/man1/cc.1
+++ b/man/man1/cc.1
@@ -1,6 +1,6 @@
 .\" Man page for cc dispatcher (Claude Code launcher)
 .\" Generated: June 2026
-.TH CC 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH CC 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 cc \- Claude Code launcher and dispatcher
 .SH SYNOPSIS

--- a/man/man1/dash.1
+++ b/man/man1/dash.1
@@ -1,6 +1,6 @@
 .\" Man page for the dash command (project dashboard)
 .\" Updated: June 2026
-.TH DASH 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH DASH 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 dash \- ADHD-friendly project dashboard
 .SH SYNOPSIS

--- a/man/man1/dots.1
+++ b/man/man1/dots.1
@@ -1,6 +1,6 @@
 .\" Man page for dots dispatcher (Dotfile Management)
 .\" Generated: June 2026
-.TH DOTS 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH DOTS 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 dots \- Dotfile management dispatcher (chezmoi wrapper)
 .SH SYNOPSIS

--- a/man/man1/em.1
+++ b/man/man1/em.1
@@ -1,6 +1,6 @@
 .\" Man page for em dispatcher (Email / himalaya)
 .\" Generated: June 2026
-.TH EM 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH EM 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 em \- Email dispatcher (himalaya wrapper)
 .SH SYNOPSIS

--- a/man/man1/flow-claude.1
+++ b/man/man1/flow-claude.1
@@ -1,4 +1,4 @@
-.TH FLOW-CLAUDE 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH FLOW-CLAUDE 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 flow-claude \- Claude Code environment health checker
 .SH SYNOPSIS

--- a/man/man1/flow.1
+++ b/man/man1/flow.1
@@ -1,6 +1,6 @@
 .\" Man page for flow command
 .\" Updated: June 2026
-.TH FLOW 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH FLOW 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 flow \- ADHD-friendly workflow CLI for developers
 .SH SYNOPSIS

--- a/man/man1/g.1
+++ b/man/man1/g.1
@@ -1,6 +1,6 @@
 .\" Man page for g dispatcher (Git workflows)
 .\" Updated: June 2026
-.TH G 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH G 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 g \- Git commands dispatcher
 .SH SYNOPSIS

--- a/man/man1/mcp.1
+++ b/man/man1/mcp.1
@@ -1,6 +1,6 @@
 .\" Man page for mcp dispatcher (MCP server management)
 .\" Updated: June 2026
-.TH MCP 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH MCP 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 mcp \- MCP server management dispatcher
 .SH SYNOPSIS

--- a/man/man1/morning.1
+++ b/man/man1/morning.1
@@ -1,6 +1,6 @@
 .\" Man page for the morning command (daily startup routine)
 .\" Updated: June 2026
-.TH MORNING 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH MORNING 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 morning \- ADHD-friendly daily startup routine
 .SH SYNOPSIS

--- a/man/man1/prompt.1
+++ b/man/man1/prompt.1
@@ -1,6 +1,6 @@
 .\" Man page for prompt dispatcher (Prompt Engine Switcher)
 .\" Generated: June 2026
-.TH PROMPT 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH PROMPT 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 prompt \- Prompt engine switcher
 .SH SYNOPSIS

--- a/man/man1/qu.1
+++ b/man/man1/qu.1
@@ -1,6 +1,6 @@
 .\" Man page for qu dispatcher (Quarto publishing)
 .\" Updated: June 2026
-.TH QU 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH QU 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 qu \- Quarto publishing dispatcher
 .SH SYNOPSIS

--- a/man/man1/r.1
+++ b/man/man1/r.1
@@ -1,6 +1,6 @@
 .\" Man page for r dispatcher (R package development)
 .\" Updated: June 2026
-.TH R 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH R 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 r \- R package development dispatcher
 .SH SYNOPSIS

--- a/man/man1/sec.1
+++ b/man/man1/sec.1
@@ -1,6 +1,6 @@
 .\" Man page for sec dispatcher (Secret Management)
 .\" Generated: June 2026
-.TH SEC 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH SEC 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 sec \- Secret management dispatcher (Keychain and Bitwarden)
 .SH SYNOPSIS

--- a/man/man1/teach.1
+++ b/man/man1/teach.1
@@ -1,6 +1,6 @@
 .\" Man page for teach dispatcher (Teaching Workflow)
 .\" Generated: June 2026
-.TH TEACH 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH TEACH 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 teach \- Teaching workflow dispatcher (Scholar integration)
 .SH SYNOPSIS

--- a/man/man1/tm.1
+++ b/man/man1/tm.1
@@ -1,6 +1,6 @@
 .\" Man page for tm dispatcher (Terminal Manager)
 .\" Generated: June 2026
-.TH TM 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH TM 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 tm \- Terminal manager dispatcher
 .SH SYNOPSIS

--- a/man/man1/today.1
+++ b/man/man1/today.1
@@ -1,6 +1,6 @@
 .\" Man page for the today command (quick daily status)
 .\" Updated: June 2026
-.TH TODAY 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH TODAY 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 today \- quick daily status
 .SH SYNOPSIS

--- a/man/man1/tok.1
+++ b/man/man1/tok.1
@@ -1,6 +1,6 @@
 .\" Man page for tok dispatcher (Token Management)
 .\" Generated: June 2026
-.TH TOK 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH TOK 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 tok \- Token lifecycle management dispatcher
 .SH SYNOPSIS

--- a/man/man1/v.1
+++ b/man/man1/v.1
@@ -1,6 +1,6 @@
 .\" Man page for v dispatcher (Vibe / Workflow Automation)
 .\" Generated: June 2026
-.TH V 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH V 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 v \- Workflow automation dispatcher (vibe coding mode)
 .SH SYNOPSIS

--- a/man/man1/week.1
+++ b/man/man1/week.1
@@ -1,6 +1,6 @@
 .\" Man page for the week command (weekly review helper)
 .\" Updated: June 2026
-.TH WEEK 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH WEEK 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 week \- weekly review helper
 .SH SYNOPSIS

--- a/man/man1/wt.1
+++ b/man/man1/wt.1
@@ -1,6 +1,6 @@
 .\" Man page for wt dispatcher (Git Worktree Management)
 .\" Generated: June 2026
-.TH WT 1 "June 2026" "flow-cli 7.17.1" "User Commands"
+.TH WT 1 "June 2026" "flow-cli 7.17.2" "User Commands"
 .SH NAME
 wt \- Git worktree management dispatcher
 .SH SYNOPSIS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flow-cli",
-  "version": "7.17.1",
+  "version": "7.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flow-cli",
-      "version": "7.17.1",
+      "version": "7.17.2",
       "license": "MIT",
       "devDependencies": {
         "husky": "^9.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "husky": "^9.1.7",
         "lint-staged": "^17.4.1",
-        "prettier": "^3.9.4"
+        "prettier": "^3.9.6"
       }
     },
     "node_modules/husky": {
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,119 +1,17 @@
 {
   "name": "flow-cli",
-  "version": "7.15.0",
+  "version": "7.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flow-cli",
-      "version": "7.15.0",
+      "version": "7.17.1",
       "license": "MIT",
       "devDependencies": {
         "husky": "^9.1.7",
-        "lint-staged": "^17.0.8",
+        "lint-staged": "^17.4.1",
         "prettier": "^3.9.4"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
-      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
-      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^8.0.0",
-        "string-width": "^8.2.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/environment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/husky": {
@@ -132,33 +30,16 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lint-staged": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
-      "integrity": "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
+      "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "listr2": "^10.2.1",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.7",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.2.4"
+        "tinyexec": "^1.3.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -173,142 +54,10 @@
         "yaml": "^2.9.0"
       }
     },
-    "node_modules/listr2": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
-      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cli-truncate": "^5.2.0",
-        "eventemitter3": "^5.0.4",
-        "log-update": "^6.1.0",
-        "rfdc": "^1.4.1",
-        "wrap-ansi": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=22.13.0"
-      }
-    },
-    "node_modules/log-update": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^7.0.0",
-        "cli-cursor": "^5.0.0",
-        "slice-ansi": "^7.1.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -334,73 +83,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
-      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "is-fullwidth-code-point": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -411,78 +93,14 @@
         "node": ">=0.6.19"
       }
     },
-    "node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
-      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "string-width": "^8.2.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^17.4.1",
-    "prettier": "^3.9.4"
+    "prettier": "^3.9.6"
   },
   "lint-staged": {
     "*.{json,md,yml,yaml}": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cli",
-  "version": "7.17.1",
+  "version": "7.17.2",
   "description": "ADHD-optimized ZSH workflow plugin",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "husky": "^9.1.7",
-    "lint-staged": "^17.0.8",
+    "lint-staged": "^17.4.1",
     "prettier": "^3.9.4"
   },
   "lint-staged": {

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -23,6 +23,13 @@
 # ENVIRONMENT VARIABLES (from .zshrc)
 # ============================================
 
+# PATH
+# uv installs tool shims here (radian, arxiv_latex_cleaner, ...). Set in
+# .zshenv, not .zshrc, so non-interactive shells (scripts, Claude Code) can
+# reach them too. Guarded: .zshenv is sourced for every zsh invocation, so an
+# unconditional prepend would grow PATH once per nested shell.
+[[ ":$PATH:" == *":$HOME/.local/bin:"* ]] || export PATH="$HOME/.local/bin:$PATH"
+
 # R Package Development
 export R_PACKAGES_DIR="$HOME/R-packages"
 export QUARTO_DIR="$HOME/quarto-projects"


### PR DESCRIPTION
## Release v7.17.2

Patch release — 2 fixes, 3 CI/deps hardening changes, no new features.

### Fixed
- **uv tool shims unreachable** — `~/.local/bin` added to `.zshenv` PATH. (#513)
- **Homebrew tap release push failing (GH006)** — now opens a PR + auto-merge instead of a direct push to a now-protected `main`. (#499)

### Changed
- Tap release App token scoped to `contents: write` + `pull-requests: write` only (was: full installation permissions). (#514)
- Dependabot `github-actions` updates now target `dev` explicitly — fixes a base-reset bug that made manual PR retargets unable to stick. (#515)
- Dropped the npm dependabot ecosystem (9/16 recent npm PRs closed unmerged; 0 runtime deps affected). (#515)
- `prettier` 3.9.4→3.9.6, `lint-staged` 17.0.8→17.4.1 (devDependencies only). (#512, #515)

### Test plan
- `./tests/run-all.sh`: 78 passed / 6 failed / 1 skipped. All 6 failures reproduce identically
  on `origin/main` pre-release (test-pick-smart-defaults, the teach-deploy-v2 cluster x4,
  test-atlas-contract) — confirmed via a throwaway worktree, local-environment-sensitive,
  pre-existing, unrelated to this release's diff.
- `prettier --check` parity verified between old (3.9.4) and new (3.9.6) across the full repo
  in #515 — identical pre-existing warnings, nothing newly introduced.
- Version grep swept post-bump: 3 remaining `7.17.1` hits, all intentional (two CHANGELOG
  section headers + one docs/index.md banner describing 7.17.1-specific features that
  7.17.2 has no replacement content for).

This is the first live exercise of #499's auto-merge tap-release flow and #514's scoped token.
